### PR TITLE
FileEditor.dclick: set the event to the double clicked path instead of True

### DIFF
--- a/traitsui/editors/file_editor.py
+++ b/traitsui/editors/file_editor.py
@@ -87,7 +87,7 @@ class ToolkitEditorFactory ( EditorFactory ):
     reload_name = Str
 
     # Optional extended trait name used to notify when the user double-clicks
-    # an entry in the file tree view:
+    # an entry in the file tree view. The associated path is assigned it:
     dclick_name = Str
 
     # The style of file dialog to use when the 'Browse...' button is clicked

--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -268,7 +268,7 @@ class CustomEditor ( SimpleTextEditor ):
     def _on_dclick ( self, idx ):
         """ Handles the user double-clicking on a file name.
         """
-        self.dclick = True
+        self.dclick = unicode(self._model.filePath(idx))
 
     #---------------------------------------------------------------------------
     #  Handles the 'reload' trait being changed:

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -406,7 +406,7 @@ class CustomEditor ( SimpleTextEditor ):
     def _on_dclick ( self, event ):
         """ Handles the user double-clicking on a file name.
         """
-        self.dclick = True
+        self.dclick = self.control.GetPath()
 
     #---------------------------------------------------------------------------
     #  Handles the 'reload' trait being changed:


### PR DESCRIPTION
FileEditor.dclick: set the event to the double clicked path instead of True
This is needed to get the double clicked (activated) path since the
selected path is not yet set to the double clicked path (observed on qt backend)
and there seems to be no other way to get the dclicked path
Also this makes it follow the same convention as the click and dclick traits of TreeEditor
