### PR TITLE
BUG: qt FileEditor did not show horizontal scrollbar even when needed.

### DIFF
--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -210,6 +210,10 @@ class CustomEditor ( SimpleTextEditor ):
 
         self.set_tooltip()
 
+        # This is needed to enable horizontal scrollbar.
+        self.control.header().setResizeMode(0, QtGui.QHeaderView.ResizeToContents)
+        self.control.header().setStretchLastSection(False)
+
     #---------------------------------------------------------------------------
     #  Handles the user changing the contents of the edit control:
     #---------------------------------------------------------------------------


### PR DESCRIPTION
The change is a qt quirk needed to add horizontal scrollbar to a single
column tree.
