### PR TITLE
ENH: Change "Browse..." text for file editor to an icon.

### DIFF
--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -26,6 +26,7 @@ from traits.api import List, Event, File, Unicode, TraitError
 # traitsui.editors.file_editor file.
 from traitsui.editors.file_editor import ToolkitEditorFactory
 from text_editor import SimpleEditor as SimpleTextEditor
+from helper import IconButton
 
 #-------------------------------------------------------------------------------
 #  Trait definitions:
@@ -67,11 +68,8 @@ class SimpleEditor ( SimpleTextEditor ):
             signal = QtCore.SIGNAL('editingFinished()')
         QtCore.QObject.connect(control, signal, self.update_object)
 
-        button = QtGui.QPushButton("Browse...")
+        button = IconButton(QtGui.QStyle.SP_DirIcon, self.show_file_dialog)
         layout.addWidget(button)
-
-        QtCore.QObject.connect(button, QtCore.SIGNAL('clicked()'),
-                               self.show_file_dialog)
 
         self.set_tooltip(control)
 

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -100,7 +100,10 @@ class SimpleEditor ( SimpleTextEditor ):
             if factory.auto_set:
                 wx.EVT_TEXT( panel, control.GetId(), self.update_object )
 
-            button = wx.Button( panel, -1, 'Browse...' )
+            bmp    = wx.ArtProvider.GetBitmap( wx.ART_FOLDER_OPEN,
+                                               size = ( 15, 15 ) )
+            button = wx.BitmapButton( panel, -1, bitmap = bmp )
+            
             pad    = 8
 
         self._file_name = control


### PR DESCRIPTION
Changes the button for browsing files for a file editor into a Button with icon, instead of a text button. 
