### PR TITLE
ENH: Add a tool-tip to items in the TreeView of file editor.

### DIFF
--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -296,6 +296,19 @@ class _TreeView(QtGui.QTreeView):
         super(_TreeView, self).__init__()
         self.doubleClicked.connect(editor._on_dclick)
         self._editor = editor
+        
+    def event(self, event): 
+        if event.type() == QtCore.QEvent.ToolTip:
+            index = self.indexAt(event.pos())
+            if index and index.isValid():
+                QtGui.QToolTip.showText(event.globalPos(), index.data(), self)
+            else:
+                QtGui.QToolTip.hideText()
+                event.ignore()
+                                
+            return True
+            
+        return super(_TreeView, self).event(event)
 
     def currentChanged(self, current, previous):
         """ Reimplemented to tell the editor when the current index has changed.

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -325,8 +325,9 @@ class CustomEditor ( SimpleTextEditor ):
         self.control = wx.GenericDirCtrl( parent, style = style )
         self._tree   = tree = self.control.GetTreeCtrl()
         id           = tree.GetId()
-        wx.EVT_TREE_SEL_CHANGED(    tree, id, self.update_object )
-        wx.EVT_TREE_ITEM_ACTIVATED( tree, id, self._on_dclick )
+        wx.EVT_TREE_SEL_CHANGED(     tree, id, self.update_object )
+        wx.EVT_TREE_ITEM_ACTIVATED(  tree, id, self._on_dclick )
+        wx.EVT_TREE_ITEM_GETTOOLTIP( tree, id, self._on_tooltip )
 
         self.filter = factory.filter
         self.sync_value( factory.filter_name, 'filter', 'from', is_list = True )
@@ -407,6 +408,16 @@ class CustomEditor ( SimpleTextEditor ):
         """ Handles the user double-clicking on a file name.
         """
         self.dclick = self.control.GetPath()
+
+    #---------------------------------------------------------------------------
+    #  Handles the user hovering on a file name for a tooltip:
+    #---------------------------------------------------------------------------
+
+    def _on_tooltip ( self, event ):
+        """ Handles the user hovering on a file name for a tooltip.
+        """
+        text = self._tree.GetItemText(event.GetItem())
+        event.SetToolTip(text)
 
     #---------------------------------------------------------------------------
     #  Handles the 'reload' trait being changed:


### PR DESCRIPTION
The wx implementation doesn't work exactly as expected.  

Once the mouse is hovered over one item of the list and a tooltip is shown, moving the mouse to other items, shows the tooltip of the other items also at the old position.  This seems to be because the position of the event doesn't seem to be returned correctly.  Can someone help fix this?  

Thanks!
