### PR TITLE
FIX: Show only directories in the DirectoryEditor for qt backend.

### DIFF
--- a/traitsui/qt4/directory_editor.py
+++ b/traitsui/qt4/directory_editor.py
@@ -47,6 +47,7 @@ class SimpleEditor ( SimpleFileEditor ):
         dlg = QtGui.QFileDialog(self.control)
         dlg.selectFile(self._file_name.text())
         dlg.setFileMode(QtGui.QFileDialog.Directory)
+        dlg.setOptions(QtGui.QFileDialog.ShowDirsOnly)
 
         return dlg
 


### PR DESCRIPTION
The directory editor should show only directories, since only they can be chosen. 
