### PR TITLE
BUG: Deletion of items in tabular editor deletes wrong elements.

### DIFF
--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -197,11 +197,16 @@ class TabularModel(QtCore.QAbstractTableModel):
         """
         editor = self._editor
         adapter = editor.adapter
-
         self.beginRemoveRows(parent, row, row + count - 1)
         for i in xrange(count):
             editor.callx(adapter.delete, editor.object, editor.name, row)
         self.endRemoveRows()
+        n = self.rowCount(None)
+        if not editor.factory.multi_select:
+            editor.selected_row = row if row < n else row-1
+        else:
+            #FIXME: what should the selection be?
+            editor.multi_selected_rows = []
         return True
 
     def mimeTypes(self):

--- a/traitsui/wx/tabular_editor.py
+++ b/traitsui/wx/tabular_editor.py
@@ -1045,7 +1045,13 @@ class TabularEditor ( Editor ):
             for row in selected:
                 delete( self.object, self.name, row )
 
-            self.row = row
+            n = self.adapter.len( self.object, self.name )
+            if not self.factory.multi_select:
+                self.selected_row = self.row = n-1 if row>=n else row
+            else:
+                #FIXME: What should the selection be?
+                self.multi_selected = []
+                self.multi_selected_rows = []
 
     def _move_up_current ( self ):
         """ Moves the currently selected item up one line in the list control.


### PR DESCRIPTION
In a tabular editor -

   qt backend: deleting items consecutively from the top doesn't work
   correctly.

   wx backend: deleting items consecutively from the bottom doesn't
   work correctly.
