### PR TITLE
FIX: Fix TextEditor to respect the value of the 'invalid' trait at initialization time.

### DIFF
--- a/integrationtests/ui/text_editor_invalid.py
+++ b/integrationtests/ui/text_editor_invalid.py
@@ -1,0 +1,31 @@
+# Test for TextEditor 'invalid' trait.
+#
+# Look for:
+#
+#   background color should be correctly to the error indicating color
+#     whenever the name is invalid (all whitespace).  In particular:
+#
+#   background color should be set at initialization.
+
+from traits.api import Bool, HasTraits, Property, Str
+from traitsui.api import Item, View
+from traitsui.api import TextEditor
+
+
+class Person(HasTraits):
+    name = Str
+
+    invalid = Property(Bool, depends_on='name')
+
+    def _get_invalid(self):
+        # Name is valid iff it doesn't consist entirely of whitespace.
+        stripped_name = self.name.strip()
+        return stripped_name == ''
+
+    traits_view = View(
+        Item('name', editor=TextEditor(invalid='invalid')),
+    )
+
+
+if __name__ == '__main__':
+    Person().configure_traits()

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -219,6 +219,9 @@ class Editor ( UIEditor ):
             control = [ control ]
 
         for item in control:
+            if item is None:
+                continue
+
             pal = QtGui.QPalette(item.palette())
 
             if state:

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -98,6 +98,7 @@ class SimpleEditor ( Editor ):
                     self.update_object)
 
         self.control = control
+        self.set_error_state( False )
         self.set_tooltip()
 
     #---------------------------------------------------------------------------

--- a/traitsui/wx/text_editor.py
+++ b/traitsui/wx/text_editor.py
@@ -108,6 +108,7 @@ class SimpleEditor ( Editor ):
             wx.EVT_TEXT( parent, control.GetId(), self.update_object )
 
         self.control = control
+        self.set_error_state( False )
         self.set_tooltip()
 
     #---------------------------------------------------------------------------


### PR DESCRIPTION
Also adds a workaround for a Qt traceback from the set_error_state function in editor.py.
