### PR TITLE
ENH: TreeEditor: Added on_activated trait to TreeNode.

### DIFF
--- a/traitsui/editors/tree_editor.py
+++ b/traitsui/editors/tree_editor.py
@@ -101,6 +101,9 @@ class ToolkitEditorFactory ( EditorFactory ):
     # Called when a node is double-clicked
     on_dclick = Any
 
+    # Called when a node is activated
+    on_activated = Any
+
     # Call when the mouse hovers over a node
     on_hover = Any
 

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1001,6 +1001,13 @@ class SimpleEditor ( Editor ):
         """
         _, node, object = self._get_node_data(nid)
 
+        if node.activated(object) is True:
+            if self.factory.on_activated is not None:
+                self.ui.evaluate(self.factory.on_activated, object)
+                self._veto = True
+        else:
+            self._veto = True
+
         # Fire the 'activated' event with the clicked on object as value:
         self.activated = object
 

--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -119,6 +119,10 @@ class TreeNode ( HasPrivateTraits ):
     # Function for handling double-clicking an object
     on_dclick = Callable
 
+    # Function for handling activation of an object
+    # (double-click or Enter key press when node is in focus)
+    on_activated = Callable
+
     # View to use for editing the object
     view = AView
 
@@ -623,6 +627,19 @@ class TreeNode ( HasPrivateTraits ):
         return True
 
     #---------------------------------------------------------------------------
+    #  Handles an object being activated:
+    #---------------------------------------------------------------------------
+
+    def activated ( self, object ):
+        """ Handles an object being activated.
+        """
+        if self.on_activated is not None:
+            self.on_activated( object )
+            return None
+
+        return True
+
+    #---------------------------------------------------------------------------
     #  Returns whether or not a specified object class can be added to the node:
     #---------------------------------------------------------------------------
 
@@ -818,6 +835,10 @@ class ITreeNode ( Interface ):
 
     def dclick ( self ):
         """ Handles an object being double-clicked.
+        """
+
+    def activated ( self ):
+        """ Handles an object being activated.
         """
 
 #-------------------------------------------------------------------------------
@@ -1054,6 +1075,11 @@ class ITreeNodeAdapter ( Adapter ):
         """
         pass
 
+    def activated ( self ):
+        """ Handles an object being activated.
+        """
+        pass
+
 #-------------------------------------------------------------------------------
 #  'ITreeNodeAdapterBridge' class
 #-------------------------------------------------------------------------------
@@ -1278,6 +1304,11 @@ class ITreeNodeAdapterBridge ( HasPrivateTraits ):
         """ Handles an object being double-clicked.
         """
         return self.adapter.dclick()
+
+    def activated ( self, object ):
+        """ Handles an object being activated.
+        """
+        return self.adapter.activated()
 
 
 # FIXME RTK: add the column_labels API to the following TreeNodes, too.
@@ -1629,6 +1660,15 @@ class ObjectTreeNode ( TreeNode ):
         """ Handles an object being double-clicked.
         """
         return object.tno_dclick( self )
+
+    #---------------------------------------------------------------------------
+    #  Handles an object being activated:
+    #---------------------------------------------------------------------------
+
+    def activated ( self, object ):
+        """ Handles an object being activated.
+        """
+        return object.tno_activated( self )
 
 #-------------------------------------------------------------------------------
 #  'TreeNodeObject' class:
@@ -2042,6 +2082,19 @@ class TreeNodeObject ( HasPrivateTraits ):
 
         return True
 
+    #---------------------------------------------------------------------------
+    #  Handles an object being activated:
+    #---------------------------------------------------------------------------
+
+    def tno_activated ( self, node ):
+        """ Handles an object being activated.
+        """
+        if node.on_activated is not None:
+            node.on_activated( self )
+            return None
+
+        return True
+
 #-------------------------------------------------------------------------------
 #  'MultiTreeNode' object:
 #-------------------------------------------------------------------------------
@@ -2333,4 +2386,13 @@ class MultiTreeNode ( TreeNode ):
         """ Handles an object being double-clicked.
         """
         return self.root_node.dclick( object )
+
+    #---------------------------------------------------------------------------
+    #  Handles an object being activated:
+    #---------------------------------------------------------------------------
+
+    def activated ( self, object ):
+        """ Handles an object being activated.
+        """
+        return self.root_node.activated( object )
 

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -1277,6 +1277,13 @@ class SimpleEditor ( Editor ):
         """
         expanded, node, object = self._get_node_data( event.GetItem() )
 
+        if node.activated( object ) is True:
+            if self.factory.on_activated is not None:
+                self.ui.evaluate( self.factory.on_activated, object )
+                self._veto = True
+        else:
+            self._veto = True
+
         # Fire the 'activated' event with the clicked on object as value:
         self.activated = object
 
@@ -1371,9 +1378,12 @@ class SimpleEditor ( Editor ):
 
         # If the mouse is over a node, then process the click:
         if node is not None:
-            if ((node.dclick( object ) is True) and
-                (self.factory.on_dclick is not None)):
-                self.ui.evaluate( self.factory.on_dclick, object )
+            if node.dclick( object ) is True:
+                if self.factory.on_dclick is not None:
+                    self.ui.evaluate( self.factory.on_dclick, object )
+                    self._veto = True
+            else:
+                self._veto = True
 
             # Fire the 'dclick' event with the object as its value:
             # FIXME: This is instead done in _on_item_activated for backward


### PR DESCRIPTION
This complements the activated trait of TreeEditor, and allows
TreeNodes and related classes (TreeNodeObject etc.) to implement
functionality when a TreeEditor's node is activated
(double clicked or Enter key is pressed when the node has focus).
Also fixed a bug in vetoing to double click events on wx backend.
