### PR TITLE
BUG: ListStrEditor (on qt) shows double context menus.

### DIFF
--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -139,9 +139,6 @@ class _ListStrEditor(Editor):
         signal = QtCore.SIGNAL('activated(QModelIndex)')
         QtCore.QObject.connect(self.list_view, signal, self._on_activate)
 
-        signal = QtCore.SIGNAL('customContextMenuRequested(QPoint)')
-        QtCore.QObject.connect(self.list_view, signal, self._on_context_menu)
-
         # Initialize the editor title:
         self.title = factory.title
         self.sync_value(factory.title_name, 'title', 'from')


### PR DESCRIPTION
Both `_ListStrEditor` and `_ListView` were connecting to
`customContextMenuRequested` signal, producing double menus.
