### PR TITLE
Fix editor factory mode for LogRangeSliderEditor under qt4: style = 'logslider' should now work

### DIFF
--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -822,7 +822,7 @@ SimpleEditorMap = {
     'spinner': SimpleSpinEditor,
     'enum':    SimpleEnumEditor,
     'text':    RangeTextEditor,
-    'low':     LogRangeSliderEditor
+    'logslider':     LogRangeSliderEditor
 }
 # Mapping between editor factory modes and custom editor classes
 CustomEditorMap = {
@@ -831,5 +831,5 @@ CustomEditorMap = {
     'spinner': SimpleSpinEditor,
     'enum':    CustomEnumEditor,
     'text':    RangeTextEditor,
-    'low':     LogRangeSliderEditor
+    'logslider':     LogRangeSliderEditor
 }


### PR DESCRIPTION
This patch changes the style name for the qt4 LogRangeSliderEditor from "low" (which was probably not intended) to "logslider". This makes the qt4 backend compatible with the wx backend.
