### PR TITLE
ENH: Use a common, backend-independent implementation of ColorColumn.

### DIFF
--- a/integrationtests/ui/table_editor_color_test.py
+++ b/integrationtests/ui/table_editor_color_test.py
@@ -21,7 +21,7 @@ from traits.api \
 from traitsui.api \
     import View, Item, TableEditor
 
-from traitsui.wx.color_column \
+from traitsui.color_column \
     import ColorColumn
 
 from enable.api \

--- a/traitsui/color_column.py
+++ b/traitsui/color_column.py
@@ -1,0 +1,65 @@
+#------------------------------------------------------------------------------
+#
+#  Copyright (c) 2005, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+#  Author: David C. Morrill
+#
+#------------------------------------------------------------------------------
+
+""" Table column object for Color traits.
+"""
+
+#-------------------------------------------------------------------------------
+#  Imports:
+#-------------------------------------------------------------------------------
+
+from traitsui.table_column \
+    import ObjectColumn
+
+#-------------------------------------------------------------------------------
+#  'ColorColumn' class:
+#-------------------------------------------------------------------------------
+
+class ColorColumn ( ObjectColumn ):
+    """ Table column object for Color traits. """
+
+#-- ObjectColumn Overrides -----------------------------------------------------
+
+    def get_cell_color ( self, object ):
+        """ Returns the cell background color for the column for a specified
+            object.
+        """
+        color_values = getattr( object, self.name + '_' )
+        if type( color_values ) is tuple:
+            tk_color = self._as_int_rgb_tuple( color_values )
+        else:
+            tk_color = super( ColorColumn, self ).get_cell_color( object )
+        return tk_color
+
+    def get_value ( self, object ):
+        """ Gets the value of the column for a specified object.
+        """
+        value = getattr( self.get_object( object ), self.name )
+        if type( value ) is tuple:
+            value = "(%3d, %3d, %3d)" % self._as_int_rgb_tuple( value[:-1] )
+        elif type( value ) is not str:
+            value = str( value )
+
+        return value
+
+#-- Private Methods ------------------------------------------------------------
+
+    def _as_int_rgb_tuple ( self, color_values ):
+        """ Returns object color as RGB integers. """
+        return ( int( 255 * color_values[0] ),
+                 int( 255 * color_values[1] ),
+                 int( 255 * color_values[2] ) )
+

--- a/traitsui/wx/color_column.py
+++ b/traitsui/wx/color_column.py
@@ -17,52 +17,9 @@
 """ Table column object for Color traits.
 """
 
-#-------------------------------------------------------------------------------
-#  Imports:
-#-------------------------------------------------------------------------------
+import warnings
+warnings.warn("traitsui.wx.color_column is deprecated. Use the "
+    "backend-independent implementation in traitsui.color_column")
 
-from wx \
-    import Colour as WxColour
-
-from traitsui.table_column \
-    import ObjectColumn
-
-#-------------------------------------------------------------------------------
-#  'ColorColumn' class:
-#-------------------------------------------------------------------------------
-
-class ColorColumn ( ObjectColumn ):
-    """ Table column object for Color traits. """
-
-#-- ObjectColumn Overrides -----------------------------------------------------
-
-    def get_cell_color ( self, object ):
-        """ Returns the cell background color for the column for a specified
-            object.
-        """
-        color_values = getattr( object, self.name + '_' )
-        if type( color_values ) is tuple:
-            wxcolor = WxColour( *self._as_int_rgb_tuple( color_values ) )
-        else:
-            wxcolor = super( ColorColumn, self ).get_cell_color( object )
-        return wxcolor
-
-    def get_value ( self, object ):
-        """ Gets the value of the column for a specified object.
-        """
-        value = getattr( self.get_object( object ), self.name )
-        if type( value ) is tuple:
-            value = "(%3d, %3d, %3d)" % self._as_int_rgb_tuple( value[:-1] )
-        elif type( value ) is not str:
-            value = str( value )
-
-        return value
-
-#-- Private Methods ------------------------------------------------------------
-
-    def _as_int_rgb_tuple ( self, color_values ):
-        """ Returns object color as RGB integers. """
-        return ( int( 255 * color_values[0] ),
-                 int( 255 * color_values[1] ),
-                 int( 255 * color_values[2] ) )
+from traitsui.color_column import ColorColumn
 


### PR DESCRIPTION
The backend implementations of the `TableEditor` both accept a 3-tuple of 0..255 ints for the output of `get_cell_color()`. We don't need a wx-only implementation that returns a `wx.Colour` object.
