### PR TITLE
wx 2.9 requires that all pushed EvtHandlers be popped before a window is...

### DIFF
--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -471,6 +471,13 @@ class GUIToolkit ( Toolkit ):
         """ Destroys all of the child controls of a specified GUI toolkit
             control.
         """
+        def _popAllEvtHandlers(win):
+            while win.GetEventHandler() is not win:
+                win.PopEventHandler(True)
+            for child in win.GetChildren():
+                _popAllEvtHandlers(child)
+
+        _popAllEvtHandlers(control)
         control.DestroyChildren()
 
     #---------------------------------------------------------------------------


### PR DESCRIPTION
... destroyed.
