### PR TITLE
BUG: Using 'visible_when' with Groups can leave ugly blank space.

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -552,9 +552,16 @@ class _GroupPanel(object):
         else:
             # See if we need to control the visual appearance of the group.
             if group.visible_when != '' or group.enabled_when != '':
-                # Make sure that outer is a widget or a layout.
+                # Make sure that outer is a widget and inner is a layout.
+                # Hiding a layout is not properly supported by Qt (the
+                # workaround in ``traitsui.qt4.editor._visible_changed_helper``
+                # often leaves undesirable blank space).
                 if outer is None:
                     outer = inner = QtGui.QBoxLayout(self.direction)
+                if isinstance(outer, QtGui.QLayout):
+                    widget = QtGui.QWidget()
+                    widget.setLayout(outer)
+                    outer = widget
 
                 # Create an editor.
                 self._setup_editor(group, GroupEditor(control=outer))


### PR DESCRIPTION
See the comment in the diff for more information.

The referenced problematic code is:

https://github.com/enthought/traitsui/blob/master/traitsui/qt4/editor.py#L197
