### PR TITLE
BUG: Allow unicode page names for the NotebookEditor

### DIFF
--- a/traitsui/wx/list_editor.py
+++ b/traitsui/wx/list_editor.py
@@ -737,8 +737,8 @@ class NotebookEditor ( Editor ):
                     name = handler( self.ui.info, user_object )
 
                 if name is None:
-                    name = str( xgetattr( view_object,
-                                          self.factory.page_name[1:], '???' ) )
+                    name = unicode( xgetattr( view_object,
+                                          self.factory.page_name[1:], u'???' ) )
 
                 changed |= (dock_control.name != name)
                 dock_control.name = name
@@ -780,7 +780,7 @@ class NotebookEditor ( Editor ):
                 if handler_name is not None:
                     name = handler_name
                 else:
-                    name = str( name ) or '???'
+                    name = unicode( name ) or u'???'
                 view_object.on_trait_change( self.update_page_name,
                                              page_name[1:], dispatch = 'ui' )
             else:


### PR DESCRIPTION
As reported on enthought-dev, the casting to `str` does not allow non-ASCII Unicode names.
