### PR TITLE
Exposes PyMimeData to outside traitsui

### DIFF
--- a/traitsui/api.py
+++ b/traitsui/api.py
@@ -96,8 +96,6 @@ from .view_element import ViewElement, ViewSubElement
 
 from . import view_elements
 
-from .mimedata import PyMimeData
-
 _constants  = toolkit().constants()
 WindowColor = _constants.get( 'WindowColor', 0xFFFFFF )
 

--- a/traitsui/mimedata.py
+++ b/traitsui/mimedata.py
@@ -1,3 +1,6 @@
 # Import the toolkit specific version.
 from traitsui.toolkit import toolkit_object
+
+# WIP: Currently only supports qt4 backend. API might change without
+# prior notification
 PyMimeData = toolkit_object('clipboard:PyMimeData')


### PR DESCRIPTION
This PR exposes the PyMimeData class to outside traitsui, which is quite useful for writing mime data for generic python instances. Note that, however, only qt4 version is supported yet.
