### PR TITLE
FIX: Adds a `localPaths` property/method to PyMimeData

### DIFF
--- a/traitsui/qt4/clipboard.py
+++ b/traitsui/qt4/clipboard.py
@@ -108,7 +108,6 @@ class PyMimeData(QtCore.QMimeData):
 
         return None
 
-    @property
     def localPaths(self):
         """ The list of local paths from url list, if any.
         """


### PR DESCRIPTION
This method/property returns the list of local filenames available in the urls of the mimedata.
