### PR TITLE
BUGFIX: configure_traits() should return result of superclass configure_traits()

### DIFF
--- a/traitsui/handler.py
+++ b/traitsui/handler.py
@@ -454,7 +454,7 @@ class Handler ( HasPrivateTraits ):
                                  id       = '',   scrollable = None, **args ):
         """ Configures the object's traits.
         """
-        super( HasPrivateTraits, self ).configure_traits(
+        return super( HasPrivateTraits, self ).configure_traits(
                        filename, view, kind, edit, context, handler or self, id,
                        scrollable, **args )
 


### PR DESCRIPTION
The fact that it wasn't meant that if you did configure_traits() on a handler then you couldn't easily tell if the dialog was closed with 'OK' or 'Cancel'.  With this fix, it now returns True if the user selects OK and False if the user selects cancel, which conforms to the call of configure_traits() on a HasTraits object.

This fix should not break any code, since code which was checking the return value from a handler's configure_traits was already broken.
