### PR TITLE
FIX TreeEditor should release listeners to root node object

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -448,6 +448,7 @@ class SimpleEditor ( Editor ):
         """ Inserts a new node before a specified index into the children of the
             specified node.
         """
+
         cnid = self._create_item(nid, node, object, index)
 
         has_children = self._has_children(node, object)
@@ -477,11 +478,9 @@ class SimpleEditor ( Editor ):
     def _delete_node ( self, nid ):
         """ Deletes a specified tree node and all its children.
         """
+
         for cnid in self._nodes_for( nid ):
             self._delete_node( cnid )
-
-        if nid is self._tree.invisibleRootItem():
-            return
 
         # See if it is a dummy.
         pnid = nid.parent()
@@ -619,6 +618,7 @@ class SimpleEditor ( Editor ):
     def _add_listeners ( self, node, object ):
         """ Adds the event listeners for a specified object.
         """
+
         if node.allows_children( object ):
             node.when_children_replaced( object, self._children_replaced, False)
             node.when_children_changed(  object, self._children_updated,  False)
@@ -633,6 +633,7 @@ class SimpleEditor ( Editor ):
     def _remove_listeners ( self, node, object ):
         """ Removes any event listeners from a specified object.
         """
+
         if node.allows_children( object ):
             node.when_children_replaced( object, self._children_replaced, True )
             node.when_children_changed(  object, self._children_updated,  True )

--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -1,0 +1,79 @@
+#------------------------------------------------------------------------------
+#
+#  Copyright (c) 2012, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Author: Pietro Berkes
+#  Date:   Dec 2012
+#
+#------------------------------------------------------------------------------
+
+
+from traits.api import Bool, HasTraits, Instance, Int, List
+from traitsui.api import Item, TreeEditor, TreeNode, View
+
+from traitsui.tests._tools import *
+
+
+class Bogus(HasTraits):
+    """ A bogus class representing a bogus tree. """
+
+    bogus_list = List
+
+
+class BogusTreeView(HasTraits):
+    """ A traitsui view visualizing Bogus objects as trees. """
+
+    bogus = Instance(Bogus)
+
+    hide_root = Bool
+
+    def default_traits_view(self):
+        nodes = [
+            TreeNode(node_for=[Bogus], children='bogus_list', label='=Bogus'),
+        ]
+
+        tree_editor = TreeEditor(
+            nodes=nodes, hide_root=self.hide_root, editable=False
+        )
+
+        traits_view = View(
+            Item(name='bogus', id='engine', editor=tree_editor),
+            buttons = ['OK'],
+        )
+
+        return traits_view
+
+
+def _test_tree_editor_releases_listeners(hide_root):
+    """ The TreeEditor should release the listener to the root node's children
+    when it's disposed of.
+    """
+
+    with store_exceptions_on_all_threads():
+        bogus = Bogus(bogus_list=[Bogus()])
+        tree_editor_view = BogusTreeView(bogus=bogus, hide_root=hide_root)
+        ui = tree_editor_view.edit_traits()
+
+        # The TreeEditor sets a listener on the bogus object's children list
+        notifiers_list = bogus.trait('bogus_list')._notifiers(False)
+        nose.tools.assert_equal(1, len(notifiers_list))
+
+        # Manually close the UI
+        press_ok_button(ui)
+
+        # The listener should be removed after the UI has been closed
+        notifiers_list = bogus.trait('bogus_list')._notifiers(False)
+        nose.tools.assert_equal(0, len(notifiers_list))
+
+
+def test_tree_editor_listeners_with_shown_root():
+    _test_tree_editor_releases_listeners(hide_root=False)
+
+def test_tree_editor_listeners_with_hidden_root():
+    _test_tree_editor_releases_listeners(hide_root=True)


### PR DESCRIPTION
With Qt, when hide_root==True, the root node is assigned to
the tree's "invisibleRootItem", and listeners are added
as usual on the root node object.

However, when disposing the TreeEditor, the listener was
not released. This commit fixes that. This issue caused
a traceback when using Mayavi's "engine view", then closing
the "engine view" before exiting the application.
