### PR TITLE
Rename wx.Color to wx.Colour.

### DIFF
--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -187,7 +187,7 @@ class Panel ( BaseDialog ):
                 # Groups with borders have a two-tone background, and the
                 # getter is picking the wrong color.  Set to transparent
                 # and hope that the parent has been painted.
-                bg_color = wx.Color(224, 224, 224, 0)
+                bg_color = wx.Colour(224, 224, 224, 0)
                 self.control = cpanel = TraitsUIPanel( parent, -1,
                                                        bg_color=bg_color )
             else:


### PR DESCRIPTION
Aliasing of Color names was removed from wxPython 2.9. See http://wxpython.org/MigrationGuide.html.

Closes issue #99.
