### PR TITLE
Don't use wx.InitAllImageHandlers or wx.PySimpleApp

### DIFF
--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -32,7 +32,7 @@ import wx
 # Make sure a wx.App object is created early:
 _app = wx.GetApp()
 if _app is None:
-    _app = wx.PySimpleApp()
+    _app = wx.App(redirect=False)
 
 from traits.api \
     import HasPrivateTraits, Instance, Property, Category, cached_property

--- a/traitsui/wx/view_application.py
+++ b/traitsui/wx/view_application.py
@@ -90,7 +90,7 @@ def view_application ( context, view, kind, handler, id, scrollable, args ):
 #  'ViewApplication' class:
 #-------------------------------------------------------------------------------
 
-class ViewApplication ( wx.PySimpleApp ):
+class ViewApplication ( wx.App ):
     """ Modal window that contains a stand-alone application.
     """
     #---------------------------------------------------------------------------
@@ -108,8 +108,6 @@ class ViewApplication ( wx.PySimpleApp ):
         self.scrollable = scrollable
         self.args       = args
 
-        wx.InitAllImageHandlers()
-
         if os.environ.get( 'ENABLE_FBI' ) is not None:
             try:
                 from etsdevtools.developer.helper.fbi import enable_fbi
@@ -120,7 +118,7 @@ class ViewApplication ( wx.PySimpleApp ):
         if redirect_filename.strip() != '':
             super( ViewApplication, self ).__init__( 1, redirect_filename )
         else:
-            super( ViewApplication, self ).__init__()
+            super( ViewApplication, self ).__init__(0)
 
         # Start the event loop in an IPython-conforming manner.
         start_event_loop_wx(self)


### PR DESCRIPTION
These changes are compatible with both wx 2.8 and 2.9

wx.InitAllImageHandlers has been a NOP for a long time, and is now deprecated.

wx.PySimpleApp is deprecated, wx.App(redirect=False) is exactly the same as wx.PySimpleApp.
