### PR TITLE
FIX: key_event_name: provides an empty string key if no key is found

### DIFF
--- a/traitsui/qt4/key_event_to_name.py
+++ b/traitsui/qt4/key_event_to_name.py
@@ -148,7 +148,7 @@ def key_event_to_name(event):
     else:
         key = None
     if key is None:
-        key = key_map.get(key_code)
+        key = key_map.get(key_code, 'Unknown-Key')
 
     name = ''
     if modifiers & QtCore.Qt.ControlModifier:


### PR DESCRIPTION
in the keymap.

This used to throw an error earlier.
