### PR TITLE
TextEditor for PySide (and probably PyQt) uses up all available space even when item.resizable=False and springy=False

### DIFF
--- a/traitsui/editors/progress_editor.py
+++ b/traitsui/editors/progress_editor.py
@@ -39,16 +39,25 @@ class ToolkitEditorFactory ( EditorFactory ):
     # The message to be displayed along side the progress guage
     message = Str
 
+    # The name of an [object.]trait that defines the message string
+    message_name = Str
+
     # The starting value
     min = Int
+
+    # The name of an [object.]trait that defines the starting value
+    min_name = Str
 
     # The ending value
     max = Int
 
-    # If the cancel button should be shown
+    # The name of an [object.]trait that defines the ending value
+    max_name = Str
+
+    # If the cancel button should be shown (not very sensible as an editor)
     can_cancel = Bool(False)
 
-    # If the estimated time should be shown
+    # If the estimated time should be shown (not very sensible as an editor)
     show_time = Bool(False)
 
     # if the percent complete should be shown

--- a/traitsui/qt4/progress_editor.py
+++ b/traitsui/qt4/progress_editor.py
@@ -1,8 +1,10 @@
-import wx
+import time
+
+from pyface.qt import QtGui, QtCore
 
 from traits.api import Instance, Int, Str
-from traitsui.wx.editor import Editor
-from pyface.ui.wx.progress_dialog import ProgressDialog
+from traitsui.qt4.editor import Editor
+from pyface.ui.qt4.progress_dialog import ProgressDialog
 
 class _ProgressDialog(ProgressDialog):
     def close(self):
@@ -10,13 +12,13 @@ class _ProgressDialog(ProgressDialog):
         """
         pass
 
+
 class SimpleEditor(Editor):
     """
     Show a progress bar with all the optional goodies
 
     """
-
-    progress = Instance(ProgressDialog)
+    progress = Instance(_ProgressDialog)
 
     # The message to be displayed along side the progress guage
     message = Str
@@ -41,6 +43,7 @@ class SimpleEditor(Editor):
         self.sync_value( factory.min_name,  'min',  'from' )
         self.sync_value( factory.max_name, 'max', 'from' )
         self.sync_value( factory.message_name, 'message', 'from' )
+        
         self.set_tooltip()
 
     def create_control (self, parent):
@@ -48,7 +51,7 @@ class SimpleEditor(Editor):
         Finishes initializing the editor by creating the underlying widget.
         """
 
-        self.progress = ProgressDialog( title=self.factory.title,
+        self.progress = _ProgressDialog( title=self.factory.title,
                                         message=self.factory.message,
                                         min=self.factory.min,
                                         max=self.factory.max,
@@ -56,27 +59,17 @@ class SimpleEditor(Editor):
                                         show_time=self.factory.show_time,
                                         show_percent=self.factory.show_percent)
 
-        panel = wx.Panel(parent, -1)
-
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        panel.SetSizer(sizer)
-        panel.SetAutoLayout(True)
-        panel.SetBackgroundColour(wx.NullColor)
-
-        self.progress.dialog_size = wx.Size()
+        control = QtGui.QWidget()
+        self.control = control
+        layout = QtGui.QVBoxLayout(self.control)
+        layout.setContentsMargins(0, 0, 0, 0)
 
         # The 'guts' of the dialog.
-        self.progress._create_message(panel, sizer)
-        self.progress._create_gauge(panel, sizer)
-        self.progress._create_percent(panel, sizer)
-        self.progress._create_timer(panel, sizer)
-        self.progress._create_buttons(panel, sizer)
-
-        panel.SetClientSize(self.progress.dialog_size)
-
-        panel.CentreOnParent()
-
-        self.control = panel
+        self.progress._create_message(control, layout)
+        self.progress._create_gauge(control, layout)
+        self.progress._create_percent(control, layout)
+        self.progress._create_timer(control, layout)
+        self.progress._create_buttons(control, layout)
         return self.control
 
 
@@ -87,7 +80,7 @@ class SimpleEditor(Editor):
         """
         self.progress.min = self.min
         self.progress.max = self.max
-        self.progress.change_message(self.message)
+        self.progress.message = self.message
         if self.value:
             self.progress.update(self.value)
         return

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -101,6 +101,11 @@ class SimpleEditor ( Editor ):
                     self.update_object)
 
         self.control = control
+        # default horizontal policy is Expand, set this to Minimum
+        if not (self.item.resizable == True) and not self.item.springy:
+            policy = self.control.sizePolicy()
+            policy.setHorizontalPolicy(QtGui.QSizePolicy.Minimum)
+            self.control.setSizePolicy(policy)
         self.set_error_state( False )
         self.set_tooltip()
 


### PR DESCRIPTION
Fixed by setting default horizontalPolicy to "Minimum"

See attached images for illustration with a view like:

                HGroup(
                    VGroup(
                        Item('show_landmarks', label='Landmarks'),
                        Item('show_boxes', label='Boxes'),
                        Item('show_hulls', label='Hulls'),
                        ),
                    VGroup(
                        Item('show_labels', label='Labels'),
                        Item('box_fill', label='Fill'),
                        #Item('landmark_size', label='Point Size'), # version without _fixed
                        Item('landmark_size', label='Point Size', width=-50),
                        ),
                    show_border=True,
                    label='Annotations',
                    id='landmark_view.control.annotations',
                    ),
                VGroup(
                    VGroup(
                        Item('box_filter',
                             label='Filter',
                             editor=CheckListEditor(
                                cols=3,
                                name='box_labels'),
                             style='custom',
                             resizable=True,
                             width=0.9,
                             enabled_when='box_labels',
                             ),
                        show_border=True,
                        label='Box Selection',
                        ),
                    VGroup(
                        Item('window_center', label='Level', resizable=True, width=0.9),
                        Item('window_width', label='Window', resizable=True, width=0.9),
                        ),
                    ),


without width=...:

before:
![before](https://f.cloud.github.com/assets/204942/584807/881d9a0e-c927-11e2-8417-7d43268a0cf6.png)

after:
![after](https://f.cloud.github.com/assets/204942/584806/87fe1b34-c927-11e2-992f-7c6ab3054a39.png)

with forced width: width=-50

before
![fixed_before](https://f.cloud.github.com/assets/204942/584809/883295b2-c927-11e2-8a4e-502b17a9fbab.png)

after
![fixed_after](https://f.cloud.github.com/assets/204942/584808/882f5bfe-c927-11e2-9e72-1e4b2b468f0a.png)
