### PR TITLE
Partial fix of a bug concerning scrollbar

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -245,9 +245,11 @@ def panel(ui):
             w.setLayout(panel)
             panel = w
 
+        size_policy =  panel.sizePolicy()
         sa = QtGui.QScrollArea()
         sa.setWidget(panel)
         sa.setWidgetResizable(True)
+        sa.setSizePolicy(size_policy)
         panel = sa
 
     return panel


### PR DESCRIPTION
A widget with a scrollbar tends to request much more room than needed, even if its size is fixed. This fix corrects that, however something is still missing as the widget borders does not draw exactly properly.
