### PR TITLE
BUG: configure_traits should turn 'live' views to 'livemodal'.

### DIFF
--- a/traitsui/qt4/view_application.py
+++ b/traitsui/qt4/view_application.py
@@ -62,6 +62,8 @@ def view_application ( context, view, kind, handler, id, scrollable, args ):
     """
     if (kind == 'panel') or ((kind is None) and (view.kind == 'panel')):
         kind = 'modal'
+    if (kind is None) and (view.kind == 'live'):
+        kind = 'livemodal'
 
     app = QtGui.QApplication.instance()
     if app is None or not is_event_loop_running_qt4(app):

--- a/traitsui/wx/view_application.py
+++ b/traitsui/wx/view_application.py
@@ -73,6 +73,8 @@ def view_application ( context, view, kind, handler, id, scrollable, args ):
     """
     if (kind == 'panel') or ((kind is None) and (view.kind == 'panel')):
         kind = 'modal'
+    if (kind is None) and (view.kind == 'live'):
+        kind = 'livemodal'
 
     app = wx.GetApp()
     if app is None or not is_event_loop_running_wx(app):


### PR DESCRIPTION
This PR solves a problem that rears its head when using IPython in one of its GUI modes. Previously, `configure_traits()` would return immediately with no way to hold onto the root control. Eventually, a random garbage collection would delete the whole UI. Now, it creates a modal dialog that does not return control to the shell until the user has closed the dialog and thus fulfils its documented promise to block.
