### PR TITLE
BUG: Qt: TableEditor: User column resizing not preserved.

### DIFF
--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -829,6 +829,7 @@ class TableView(QtGui.QTableView):
         else:
             vheader.hide()
         self.setAlternatingRowColors(factory.alternate_bg_color)
+        self.setHorizontalScrollMode(QtGui.QAbstractItemView.ScrollPerPixel)
 
         # Configure the column headings.
         # We detect if there are any stretchy sections at all; if not, then


### PR DESCRIPTION
For columns with resize mode == "interactive" with no explicit
width set, the user's resizing of the column should be preserved
when a value changes.
