### PR TITLE
BUG: Keep UI instances alive when `configure_traits()` is called while an event loop is running

### DIFF
--- a/traitsui/qt4/view_application.py
+++ b/traitsui/qt4/view_application.py
@@ -27,6 +27,20 @@ from pyface.qt import QtGui
 from pyface.util.guisupport import is_event_loop_running_qt4, \
     start_event_loop_qt4
 
+
+KEEP_ALIVE_UIS = set()
+
+
+def on_ui_destroyed(object, name, old, destroyed):
+    """ Remove the UI object from KEEP_ALIVE_UIS.
+    """
+    assert name == 'destroyed'
+    if destroyed:
+        assert object in KEEP_ALIVE_UIS
+        KEEP_ALIVE_UIS.remove(object)
+        object.on_trait_change(on_ui_destroyed, 'destroyed', remove=True)
+
+
 #-------------------------------------------------------------------------------
 #  Creates a 'stand-alone' PyQt application to display a specified traits UI
 #  View:
@@ -68,12 +82,19 @@ def view_application ( context, view, kind, handler, id, scrollable, args ):
         return ViewApplication( context, view, kind, handler, id,
                                 scrollable, args ).ui.result
 
-    return view.ui( context,
-                    kind       = kind,
-                    handler    = handler,
-                    id         = id,
-                    scrollable = scrollable,
-                    args       = args ).result
+    ui = view.ui( context,
+                  kind       = kind,
+                  handler    = handler,
+                  id         = id,
+                  scrollable = scrollable,
+                  args       = args )
+
+    # If the UI has not been closed yet, we need to keep a reference to
+    # it until it does close.
+    if not ui.destroyed:
+        KEEP_ALIVE_UIS.add(ui)
+        ui.on_trait_change(on_ui_destroyed, 'destroyed')
+    return ui.result
 
 #-------------------------------------------------------------------------------
 #  'ViewApplication' class:

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -124,6 +124,9 @@ class UI ( HasPrivateTraits ):
     # The code used to rebuild an updated user interface
     rebuild = Callable
 
+    # Set to True when the UI has finished being destroyed.
+    destroyed = Bool( False )
+
     #-- Private Traits ---------------------------------------------------------
 
     # Original context when used with a modal dialog
@@ -289,6 +292,8 @@ class UI ( HasPrivateTraits ):
         # Remove specified symbols from our dictionary to aid in clean-up:
         self.reset_traits( self.recyclable_traits )
         self.reset_traits( self.disposable_traits )
+
+        self.destroyed = True
 
     #---------------------------------------------------------------------------
     #  Resets the contents of the user interface:


### PR DESCRIPTION
`configure_traits()` returns the `.result` of the dialog it raises. In normal use, where `configure_traits()` also starts up the event loop, this is fine, as it will only return control after the UI event loop has completed. When the event loop has already been started, it returns without keeping any reference to the `traitsui.ui.UI` instance that keeps the dialog alive. Only the tangled nest of cyclical references keeps it alive until the garbage collector happens to clean it up. This PR keeps references to these `UI` instances until they are destroyed through the normal GUI interactions that dispose of the dialog.
