### PR TITLE
Better TabularEditor Drag and Drop in Qt

### DIFF
--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -254,13 +254,18 @@ class TabularModel(QtCore.QAbstractTableModel):
         if action == QtCore.Qt.IgnoreAction:
             return False
 
+        # this is an internal drag
         data = mime_data.data(tabular_mime_type)
-        if data.isNull():
-            return False
-
-        current_rows = map(int, str(data).split(' '))
-        self.moveRows(current_rows, parent.row())
-        return True
+        if not data.isNull():
+            current_rows = map(int, str(data).split(' '))
+            self.moveRows(current_rows, parent.row())
+            return True
+        else:
+            data = PyMimeData.coerce(mime_data).instance()
+            if data is not None:
+                return self._editor.adapter.can_drop(self._editor.object,
+                    self._editor.name, row, data)
+        return False
 
     def supportedDropActions(self):
         """ Reimplemented to allow items to be moved.


### PR DESCRIPTION
Currently the drag methods for a TabularEditor in Qt just generate a list of indices being moved (as a string, no less).  This means that the TabularAdapter methods such as get_drag() are not supported, and objects cannot be dragged out of a TabularEditor under Qt.

This PR changes the mime data generated by the TabularModel to a PyMimeData with a list of the actual objects generated by get_drag() for the selected rows, and adds the original list of indices to this so that the internal drag and drop still works.
