### PR TITLE
Qt4 TreeEditor Drag and Drop Improvements

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1880,7 +1880,7 @@ class _TreeWidget(QtGui.QTreeWidget):
             if to_node is None:
                 # no parent, can't do anything
                 action = None
-            if editor._is_droppable(to_node, to_object, data, True):
+            elif editor._is_droppable(to_node, to_object, data, True):
                 # insert into the parent of the node being dropped on
                 action = 'insert'
             elif editor._is_droppable(to_node, to_object, data, False):


### PR DESCRIPTION
This PR does two things: ignore drags on Qt4 TreeEditor if no associated Python object, and handle drops more gracefully when the root node is hidden.

Three things: ignore drags on Qt4 TreeEditor if no associated Python object, handle drops more gracefully when the root node is hidden, and generally overhaul the handling of determining what action to perform on a drop.

And fixes a bug in the insert code.  Four things.

Prior to this, dragging an object into the tree editor which could not be converted to a PyMimeData with an associated local instance caused the enter to be accepted, but all other drag events to be refused.  This effectively swallowed the events, preventing any other widget from getting them.

This change applies the same check for the existence of PyMimeData instance() in the dragEnterEvent as are used in the dragMoveEvent and dropEvent handlers.

The second change special-cases when there the root node is hidden, so that drags that are not on any node are treated as drags onto the root node, and fixes parent node lookup to account for hidden parent nodes.

The third change is more substantial: if the node under the mouse at drop time doesn't accept appends, then we check to see if we can insert or append to the parent instead.  This is, I think, a more intuitive UI.  I'm still not entirely happy with the way that it (ab)uses the distinction between CopyActions and MoveActions, but I'm not quite ready to change this yet.

All this and a fanatical devotion to the Pope.
