### PR TITLE
Fix enabled_when for TabularAdapter context menus

### DIFF
--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -487,7 +487,6 @@ class TabularEditor(Editor):
         column, row = self.control.columnAt(pos.x()), self.control.rowAt(pos.y())
         menu = self.adapter.get_menu(self.object, self.name, row, column)
         if menu :
-            qmenu = menu.create_menu( self.control, self )
             self._menu_context = {'selection' : self.object,
                              'object':  self.object,
                              'editor':  self,
@@ -496,6 +495,7 @@ class TabularEditor(Editor):
                              'item':    self.adapter.get_item(self.object, self.name, row),
                              'info':    self.ui.info,
                              'handler': self.ui.handler }
+            qmenu = menu.create_menu( self.control, self )
             qmenu.exec_(self.control.mapToGlobal(pos))
             self._menu_context = None
 
@@ -503,12 +503,12 @@ class TabularEditor(Editor):
         column = self.control.columnAt(pos.x())
         menu = self.adapter.get_column_menu(self.object, self.name, -1, column)
         if menu :
-            qmenu = menu.create_menu( self.control, self )
             self._menu_context = {'selection' : self.object, 'object':  self.object,
                              'editor':  self,
                              'column':  column,
                              'info':    self.ui.info,
                              'handler': self.ui.handler }
+            qmenu = menu.create_menu( self.control, self )
             qmenu.exec_(self.control.mapToGlobal(pos))
             self._menu_context = None
         else:


### PR DESCRIPTION
Apparently, calling `menu.create_menu()` eventually results in `Editor.eval_when()` being called on all the items in the menu which is being constructed. This is unfortunate, as `_menu_context` is `None`, so menu items can't reference any of the useful variables that would normally be there.

Either that or I'm using `TabularAdapter` incorrectly...
