### PR TITLE
Fix Qt TreeEditor to honor node bg/fg colors and column labels.

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -418,6 +418,7 @@ class SimpleEditor ( Editor ):
             cnid.setText(0, node.get_label(object))
         cnid.setIcon(0, self._get_icon(node, object))
         cnid.setToolTip(0, node.get_tooltip(object))
+        self._set_column_labels(cnid, node.get_column_labels(object))
 
         color = node.get_background(object)
         if color : cnid.setBackground(0, self._get_brush(color))


### PR DESCRIPTION
The code was misplaced, likely due to a bad merge.
Please verify that the new code is in correct place.
Also, i am not sure if background (and foreground) color should be set for all columns, but i did not change the behavior which i thought was implemented.

It seems work in a simple example ( https://gist.github.com/pankajp/9289e669b014ea3c613f/revisions ).

![screenshot from 2013-09-24 17 12 50](https://f.cloud.github.com/assets/776111/1199398/9e516c18-250e-11e3-9d23-ddd5da715a1d.png)
