### PR TITLE
Qt TreeEditor: Offset drag image in presence of column header.

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1744,8 +1744,7 @@ class _TreeWidget(QtGui.QTreeWidget):
 
         # Calculate the hotspot so that the pixmap appears on top of the
         # original item.
-        rect.adjust(self.horizontalOffset(), self.verticalOffset(), 0, 0)
-        hspos = self.mapFromGlobal(QtGui.QCursor.pos()) - nid_rect.topLeft()
+        hspos = self.viewport().mapFromGlobal(QtGui.QCursor.pos()) - nid_rect.topLeft()
 
         # Start the drag.
         drag = QtGui.QDrag(self)


### PR DESCRIPTION
When a tree item in a tree with multi column support was dragged
the dragged image was previously offset vertically from the cursor
due to the presence of column header above from the viewport.
