### PR TITLE
Revert "Partial fix of a bug concerning scrollbar"

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -245,11 +245,9 @@ def panel(ui):
             w.setLayout(panel)
             panel = w
 
-        size_policy =  panel.sizePolicy()
         sa = QtGui.QScrollArea()
         sa.setWidget(panel)
         sa.setWidgetResizable(True)
-        sa.setSizePolicy(size_policy)
         panel = sa
 
     return panel


### PR DESCRIPTION
This commit breaks resizing of panels with a scrollbar if they contain
multiple elements. The original commit also admits that the fix
was only partial, as the widget borders did not draw properly.

This reverts commit 5eb143aae2b200429c9181647be855f1f5a4b565.
