### PR TITLE
Qt Tabbed List Editor Styles

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ New Features
 
 Enhancements
 
+ * Add minimal support for dock_styles for the Qt tabbed ListEditor. (#142)
+
  * Add Travis-CI support.
    
  * Remove the use of the deprecated PySimpleApp under Wx and several other

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -543,7 +543,7 @@ class NotebookEditor ( Editor ):
         signal = QtCore.SIGNAL( 'currentChanged(int)' )
         QtCore.QObject.connect( self.control, signal, self._tab_activated )
 
-        # if the dock_style is 'tab', use document style on OS X
+        # minimal dock_style handling
         if self.factory.dock_style == 'tab':
             self.control.setDocumentMode(True)
             self.control.tabBar().setDocumentMode(True)


### PR DESCRIPTION
This PR adds a minimal set of support for the `dock_style` trait of `ListEditor`s under Qt.  In particular:
- if the dock style is set to `tab` then document-style tabs are used (which is most noticeable on OS X)
- if the dock style is set to `vertical` then the tabs are rendered with the `West` Qt `QTabPosition`
