### PR TITLE
bugfix: notebook list editor works with extended name notation

### DIFF
--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -563,9 +563,13 @@ class NotebookEditor ( Editor ):
             self.control.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
 
         # Set up the additional 'list items changed' event handler needed for
-        # a list based trait:
+        # a list based trait. Note that we want to fire the update_editor_item
+        # only when the items in the list change and not when intermediate
+        # traits change. Therefore, replace "." by ":" in the extended_name
+        # when setting up the listener.
+        extended_name = self.extended_name.replace('.', ':')
         self.context_object.on_trait_change( self.update_editor_item,
-                               self.extended_name + '_items?', dispatch = 'ui' )
+                               extended_name + '_items?', dispatch = 'ui' )
 
         # Set of selection synchronization:
         self.sync_value( self.factory.selected, 'selected' )

--- a/traitsui/wx/list_editor.py
+++ b/traitsui/wx/list_editor.py
@@ -586,9 +586,13 @@ class NotebookEditor ( Editor ):
         self.control.SetSizer( self._sizer )
 
         # Set up the additional 'list items changed' event handler needed for
-        # a list based trait:
+        # a list based trait. Note that we want to fire the update_editor_item
+        # only when the items in the list change and not when intermediate
+        # traits change. Therefore, replace "." by ":" in the extended_name
+        # when setting up the listener.
+        extended_name = self.extended_name.replace('.', ':')
         self.context_object.on_trait_change( self.update_editor_item,
-                               self.extended_name + '_items?', dispatch = 'ui' )
+                               extended_name + '_items?', dispatch = 'ui' )
 
         # Set of selection synchronization:
         self.sync_value( self.factory.selected, 'selected' )


### PR DESCRIPTION
ListEditor in notebook style crashes with the following error whenever the model object is given in extended name notation:

traits.trait_errors.TraitError: Trait notification dispatch type 'ui' is not compatible with handler signature and extended trait name notification style

A search through old emails reveals that this bug was found in 2009, but the fix was never propagated to the notebook editor.