### PR TITLE
Fix for _popEventHandlers deleting handlers not added by traitsui

### DIFF
--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -339,7 +339,9 @@ class TraitsUIPanel ( wx.Panel ):
         if bg_color:
             self.SetBackgroundColour(bg_color)
         else:
-            self.SetBackgroundColour( parent.GetBackgroundColour() )
+            # Mac/Win needs this, otherwise background color is black
+            attr = self.GetDefaultAttributes()
+            self.SetBackgroundColour(attr.colBg)
 
     def OnChildFocus ( self, event ):
         """ If the ChildFocusEvent contains one of the Panel's direct children,

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -409,7 +409,7 @@ class GUIToolkit ( Toolkit ):
             handler = ui.route_event
 
         id            = control.GetId()
-        event_handler = wx.EvtHandler()
+        event_handler = EventHandlerWrapper()
         connect       = event_handler.Connect
 
         for event in events:
@@ -781,11 +781,24 @@ class WXDockWindowTheme ( Category, DockWindowTheme ):
 
 
 #-------------------------------------------------------------------------------
+
+class EventHandlerWrapper(wx.EvtHandler):
+    """ Simple wrapper around wx.EvtHandler used to determine which event
+    handlers were added by traitui.
+    """
+    pass
+
 def _popEventHandlers(ctrl):
     """ Pop any event handlers that have been pushed on to a window and its
         children.
     """
+    
+    # Assume that all traitsui event handlers are on the top of the stack
     while ctrl is not ctrl.GetEventHandler():
-        ctrl.PopEventHandler(True)
+        handler = ctrl.GetEventHandler()
+        if isinstance(handler, EventHandlerWrapper):
+            ctrl.PopEventHandler(True)
+        else:
+            break
     for child in ctrl.GetChildren():
         _popEventHandlers(child)

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -183,15 +183,7 @@ class Panel ( BaseDialog ):
             cpanel.SetSizer( None )
             cpanel.DestroyChildren()
         else:
-            if is_mac:
-                # Groups with borders have a two-tone background, and the
-                # getter is picking the wrong color.  Set to transparent
-                # and hope that the parent has been painted.
-                bg_color = wx.Colour(224, 224, 224, 0)
-                self.control = cpanel = TraitsUIPanel( parent, -1,
-                                                       bg_color=bg_color )
-            else:
-                self.control = cpanel = TraitsUIPanel( parent, -1 )
+            self.control = cpanel = TraitsUIPanel( parent, -1 )
 
         # Create the actual trait sheet panel and embed it in a scrollable
         # window (if requested):


### PR DESCRIPTION
Fix for problem reported in the mailing list where there was a crash in the DateEditor after a simple configure_traits test.