### PR TITLE
Add a link to a Qt version of the code in Gaël Varoquaux's tutorial.

### DIFF
--- a/docs/source/tutorials/traits_ui_scientific_app.rst
+++ b/docs/source/tutorials/traits_ui_scientific_app.rst
@@ -822,7 +822,9 @@ Toronto.
 The reason I am providing this code is to give an example to study of how
 a full-blown application can be built. This code can be found in the
 `tutorial's zip file <http://gael-varoquaux.info/computers/traits_tutorial/traits_tutorial.zip>`_ 
-(it is the file `application.py`).
+(it is the file `application.py`). An alternative version of this code
+using Qt instead of wx as widget toolbox can be found
+`here <https://github.com/FelixHartmann/traitsui-tutorial-qt>`_.
 
 * The camera will be built as an object. Its real attributes (exposure
   time, gain...) will be represented as the object's attributes, and


### PR DESCRIPTION
Some code snippets can be found on the Internet for writing a Qt-based TraitsUI application which embeds a Matplotlib figure, but it would be much easier if there were a link for that directly in Gaël's tutorial (which is great and very useful, by the way).
