### PR TITLE
Make numpy dependency optional.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Fixes
  * Fix TableEditor so that Qt.QSplitter honors 'orientation' trait (#171)
  * Show row labels in Qt TableEditor when requested (#176)
  * Fix TupleEditor so that multiple change events are not fired (#179)
+ * Numpy dependency is now optional. `ArrayEditor` will not be available
+   if numpy cannot be imported (#181)
 
 
 Release 4.4.0

--- a/traitsui/api.py
+++ b/traitsui/api.py
@@ -32,7 +32,13 @@ from .editor import Editor
 
 from .editor_factory import EditorFactory
 
-from .editors.api import (ArrayEditor, BooleanEditor, ButtonEditor,
+try:
+    from .editors.api import ArrayEditor
+except ImportError:
+    # ArrayEditor depends on numpy, so ignore if numpy is not present.
+    pass
+
+from .editors.api import (BooleanEditor, ButtonEditor,
     CheckListEditor, CodeEditor, ColorEditor, CompoundEditor, CustomEditor,
     CSVListEditor,
     DNDEditor, StyledDateEditor, DateEditor, DefaultOverride, DirectoryEditor, DropEditor,

--- a/traitsui/editors/__init__.py
+++ b/traitsui/editors/__init__.py
@@ -19,7 +19,12 @@
 
 from __future__ import absolute_import
 
-from .api import (toolkit, ArrayEditor, BooleanEditor, ButtonEditor,
+try:
+    from .api import ArrayEditor
+except ImportError:
+    pass
+
+from .api import (toolkit, BooleanEditor, ButtonEditor,
     CheckListEditor, CodeEditor, ColorEditor, CompoundEditor, CustomEditor,
     DateEditor, DefaultOverride, DirectoryEditor, DNDEditor, DropEditor,
     EnumEditor, FileEditor, FontEditor, KeyBindingEditor, ImageEditor,

--- a/traitsui/editors/api.py
+++ b/traitsui/editors/api.py
@@ -3,7 +3,16 @@ from __future__ import absolute_import
 
 from ..toolkit import toolkit
 
-from .array_editor import ArrayEditor
+
+try:
+    from .array_editor import ArrayEditor
+except ImportError as e:
+    if 'numpy' not in e.message:
+        raise
+    import warnings
+    warnings.warn('ArrayEditor is not available due to missing numpy',
+                  ImportWarning)
+
 from .boolean_editor import BooleanEditor
 from .button_editor import ButtonEditor
 from .check_list_editor import CheckListEditor


### PR DESCRIPTION
`ArrayEditor` will not be available if `numpy` is not installed.

Let me know if making `ArrayEditor` a string is ugly (hint), and i'll change `traitsui.api` to add a try:except there as well.
