### PR TITLE
Set the 'shadow' trait first on a ShadowGroup to avoid DelegationErrors.

### DIFF
--- a/traitsui/group.py
+++ b/traitsui/group.py
@@ -612,6 +612,12 @@ class ShadowGroup ( Group ):
         corresponding ShadowGroup objects.
     """
 
+    def __init__( self, shadow, **traits ):
+        # Set the 'shadow' trait before all others, to avoid exceptions
+        # when setting those other traits.
+        self.shadow = shadow
+        super( ShadowGroup, self ).__init__( **traits )
+
     #---------------------------------------------------------------------------
     # Trait definitions:
     #---------------------------------------------------------------------------

--- a/traitsui/tests/test_shadow_group.py
+++ b/traitsui/tests/test_shadow_group.py
@@ -1,0 +1,36 @@
+#------------------------------------------------------------------------------
+#
+#  Copyright (c) 2014, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#------------------------------------------------------------------------------
+""" Tests for the ShadowGroup class.
+"""
+
+import unittest
+
+from traitsui.api import Group
+from traitsui.group import ShadowGroup
+
+
+class TestShadowGroup(unittest.TestCase):
+    def test_creation_sets_shadow_first(self):
+        group = Group()
+        # We end up with a DelegationError if the 'shadow' trait is not set
+        # first.  Initialization order is dependent on dictionary order, which
+        # we can't control, so we throw in a good number of other traits to
+        # increase the chance that some other trait is set first.
+        shadow_group = ShadowGroup(
+            label='dummy',
+            show_border=True,
+            show_labels=True,
+            show_left=True,
+            orientation='horizontal',
+            scrollable=True,
+            shadow=group,
+        )


### PR DESCRIPTION
Running some tests from another TraitsUI-using project with `PYTHONHASHSEED=random`, we saw a number of tracebacks resembling that below.

This PR works around those tracebacks by always setting the `shadow` trait of a `ShadowGroup` before any other traits.

```
Traceback (most recent call last):
  File "geophysics/addon/ui/adapter/tests/three_d_element/properties_view/properties_view_tests.py", line 73, in test_visible
    ui = adapter.edit_traits()
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traits/traits/has_traits.py", line 1859, in edit_traits
    handler, id, scrollable, args )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/view.py", line 433, in ui
    ui.ui( parent, kind )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/ui.py", line 221, in ui
    self.rebuild( self, parent )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/toolkit.py", line 154, in ui_live
    ui_live.ui_live( ui, parent )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_live.py", line 39, in ui_live
    _ui_dialog(ui, parent, BaseDialog.NONMODAL)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_live.py", line 59, in _ui_dialog
    BaseDialog.display_ui(ui, parent, style)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_base.py", line 445, in display_ui
    ui.owner.init(ui, parent, style)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_live.py", line 177, in init
    self.add_contents(panel(ui), bbox)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 231, in panel
    panel = _GroupPanel(content[0], ui).control
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 570, in __init__
    layout = self._add_groups(content, inner)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 649, in _add_groups
    panel = _GroupPanel(subgroup, self.ui).control
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 572, in __init__
    layout = self._add_items(content, inner)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 840, in _add_items
    editor.prepare(inner)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/editor.py", line 158, in prepare
    self.update_editor()
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/instance_editor.py", line 319, in update_editor
    self.resynch_editor()
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/instance_editor.py", line 380, in resynch_editor
    self.factory.id )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/view.py", line 433, in ui
    ui.ui( parent, kind )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/ui.py", line 221, in ui
    self.rebuild( self, parent )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/toolkit.py", line 140, in ui_subpanel
    ui_panel.ui_subpanel( ui, parent )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 79, in ui_subpanel
    _ui_panel_for(ui, parent, True)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 85, in _ui_panel_for
    ui.control = control = _Panel(ui, parent, is_subpanel).control
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 143, in __init__
    self.control = panel(ui)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 231, in panel
    panel = _GroupPanel(content[0], ui).control
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 570, in __init__
    layout = self._add_groups(content, inner)
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 649, in _add_groups
    panel = _GroupPanel(subgroup, self.ui).control
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/qt4/ui_panel.py", line 458, in __init__
    content = group.get_content()
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/group.py", line 740, in get_content
    self._flush_items( content, items )
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/group.py", line 783, in _flush_items
    content     = items ).set(
  File "/Users/mdickinson/Enthought/Source/meta-geophysics/meta-ETS/traitsui/traitsui/group.py", line 210, in __init__
    super( ViewSubElement, self ).__init__( **traits )
DelegationError: The 'show_border' attribute of a 'ShadowGroup' object has a delegate which does not have traits.
```
