### PR TITLE
BUG: Tree editor icon size not respected in Qt backend.

### DIFF
--- a/traitsui/editors/tree_editor.py
+++ b/traitsui/editors/tree_editor.py
@@ -89,7 +89,6 @@ class ToolkitEditorFactory ( EditorFactory ):
     auto_open = Int
 
     # Size of the tree node icons
-    # FIXME: Document as unimplemented or wx specific.
     icon_size = IconSize
 
     # Called when a node is selected

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1670,6 +1670,8 @@ class _TreeWidget(QtGui.QTreeWidget):
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.setDragEnabled(True)
         self.setAcceptDrops(True)
+        self.setIconSize(QtCore.QSize(*editor.factory.icon_size))
+
         # Set up headers if necessary.
         column_count = len(editor.factory.column_headers)
         if column_count > 0:


### PR DESCRIPTION
This feature is implemented in the wx backend, but currently not in the Qt backend.
