### PR TITLE
Enthought Sphinx Theme Support

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,7 @@ pygments_style = 'sphinx'
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
-html_style = 'default.css'
+#html_style = 'default.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -94,7 +94,7 @@ html_title = "TraitsUI 4 User Manual"
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
-html_logo = "e-logo-rev.png"
+#html_logo = "e-logo-rev.png"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
@@ -144,6 +144,21 @@ html_use_modindex = False
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Traitsuidoc'
+
+# html theme information
+try:
+    import enthought_sphinx_theme
+
+    html_theme_path = [enthought_sphinx_theme.theme_path]
+    html_theme = 'enthought'
+except ImportError as exc:
+    import warnings
+    msg = "Can't find Enthought Sphinx Theme, using default.\nException was:\n{}"
+    warnings.warn(RuntimeWarning(msg.format(exc)))
+
+    # old defaults
+    html_logo = "e-logo-rev.png"
+    html_style = 'default.css'
 
 # Useful aliases to avoid repeating long URLs.
 extlinks = {'github-demo': (


### PR DESCRIPTION
Use @rkern's `enthought_sphinx_theme` if installed when building the docs.  If not available, it will default to the old style.

I haven't added any formal dependency, since we haven't published the theme to PyPI.