### PR TITLE
Add appveyor setup files

### DIFF
--- a/appveyor-install.cmd
+++ b/appveyor-install.cmd
@@ -1,0 +1,15 @@
+"%sdkverpath%" -q -version:"%sdkver%"
+call setenv /x64
+
+rem install python packages
+pip install --cache-dir c:/temp nose
+pip install --cache-dir c:/temp coverage
+pip install --cache-dir c:/temp pygments
+pip install --cache-dir c:/temp numpy
+pip install --cache-dir c:/temp pandas
+pip install --cache-dir c:/temp pyside
+pip install --cache-dir c:/temp git+http://github.com/enthought/traits.git#egg=traits
+pip install --cache-dir c:/temp git+http://github.com/enthought/pyface.git#egg=pyface
+
+rem install traitsui
+python setup.py develop

--- a/appveyor-test.cmd
+++ b/appveyor-test.cmd
@@ -1,0 +1,7 @@
+mkdir testrun
+copy .coveragerc testrun/
+cd testrun
+if %errorlevel% neq 0 exit /b %errorlevel%
+coverage run -m nose.core -v traitsui.tests
+IF %PYTHON% EQU "C:/Python34-x64" coverage run -a -m nose.core -v traitsui.qt4.tests
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/appveyor-test.cmd
+++ b/appveyor-test.cmd
@@ -3,5 +3,5 @@ copy .coveragerc testrun/
 cd testrun
 if %errorlevel% neq 0 exit /b %errorlevel%
 coverage run -m nose.core -v traitsui.tests
-IF %PYTHON% EQU "C:/Python34-x64" coverage run -a -m nose.core -v traitsui.qt4.tests
+coverage run -a -m nose.core -v traitsui.qt4.tests
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+build: false
+shallow_clone: true
+
+environment:
+
+  global:
+    distutils_use_sdk: 1
+    ets_toolkit: "qt4"
+
+  matrix:
+
+    - python: "C:/Python27-x64"
+      sdkver: "v7.0"
+
+    - python: "C:/Python34-x64"
+      sdkver: "v7.1"
+
+cache:
+  - c:\temp
+
+init:
+  - ps: $Env:sdkbin = "C:\Program Files\Microsoft SDKs\Windows\" + $Env:sdkver + "\Bin"
+  - ps: $Env:sdkverpath = "C:/Program Files/Microsoft SDKs/Windows/" + $Env:sdkver + "/Setup/WindowsSdkVer.exe"
+  - ps: $Env:path = $Env:python + ";" + $Env:python + "\scripts;" + $Env:sdkbin + ";" + $Env:path
+
+install:
+  - ps: if ((Test-Path "c:/temp") -eq 0) { mkdir c:/temp }
+  - ps: (new-object net.webclient).DownloadFile('https://raw.github.com/pypa/pip/master/contrib/get-pip.py', 'c:/get-pip.py')
+  - ps: python c:/get-pip.py
+  - ps: pip --version
+  - cmd /v:on /e:on /c ".\appveyor-install.cmd"
+test_script:
+  - cmd /v:on /e:on /c ".\appveyor-test.cmd"


### PR DESCRIPTION
This PR adds appveyor to the ci setup. There are two builds run on python 2.7 windows 64bit and python 3.4 windows 64bit.

