### PR TITLE
Fix: allow hiding of groups in split layouts. Fix auto_set=False behavior of CodeEditor

### DIFF
--- a/traitsui/qt4/code_editor.py
+++ b/traitsui/qt4/code_editor.py
@@ -121,10 +121,15 @@ class SourceEditor ( Editor ):
 
         # Set up listeners for the signals we care about
         code_editor = self._widget.code
+
         if self.readonly:
             code_editor.setReadOnly(True)
         else:
-            code_editor.textChanged.connect(self.update_object)
+            if factory.auto_set:
+                code_editor.textChanged.connect(self.update_object)
+            else:
+                code_editor.focus_lost.connect(self.update_object)
+
         if factory.selected_text != '':
             code_editor.selectionChanged.connect(self._selection_changed)
         if (factory.line != '') or (factory.column != ''):

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -155,7 +155,7 @@ class Editor ( UIEditor ):
         self._visible_changed_helper(self.control, visible)
 
         page = self.control.parent()
-        if page is None or page.parent() is None or page.parent().parent() is None or page.layout().count() != 1:
+        if page is None or page.parent() is None or page.parent().parent() is None or page.layout() is None or page.layout().count() != 1:
             return
 
         # The TabWidget (representing the notebook) has a StackedWidget inside it,


### PR DESCRIPTION
The first fix is for split layouts when using visible_when to hide groups, which caused an error.

The second fix is for auto_set=False in Qt CodeEditor which was completely ignored (works in WX). Note that this requires also my pyface pull request