### PR TITLE
Fix empty tree nodes not changing when adding children.

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1521,9 +1521,14 @@ class SimpleEditor ( Editor ):
                     if child_node is not None:
                         self._append_node( nid, child_node, child )
             else:
-                # if model has children, but is not expanded, add dummy child
-                if len(children) > 0:
+                dummy = getattr(nid, '_dummy', None)
+                if dummy is None and len(children) > 0:
+                    # if model now has children add dummy child
                     nid._dummy = QtGui.QTreeWidgetItem(nid)
+                elif dummy is not None and len(children) == 0:
+                    # if model no longer has children remove dummy child
+                    nid.removeChild(dummy)
+                    del nid._dummy
 
             # Try to expand the node (if requested):
             if node.can_auto_open( object ):
@@ -1573,9 +1578,14 @@ class SimpleEditor ( Editor ):
                                         child )
                         child_index += 1
             else:
-                # if model has children, but is not expanded, add dummy child
-                if len(children) > 0:
+                dummy = getattr(nid, '_dummy', None)
+                if dummy is None and len(children) > 0:
+                    # if model now has children add dummy child
                     nid._dummy = QtGui.QTreeWidgetItem(nid)
+                elif dummy is not None and len(children) == 0:
+                    # if model no longer has children remove dummy child
+                    nid.removeChild(dummy)
+                    del nid._dummy
 
             # Try to expand the node (if requested):
             if node.can_auto_open( object ):

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1520,6 +1520,10 @@ class SimpleEditor ( Editor ):
                     child, child_node = self._node_for( child )
                     if child_node is not None:
                         self._append_node( nid, child_node, child )
+            else:
+                # if model has children, but is not expanded, add dummy child
+                if len(children) > 0:
+                    nid._dummy = QtGui.QTreeWidgetItem(nid)
 
             # Try to expand the node (if requested):
             if node.can_auto_open( object ):
@@ -1568,6 +1572,10 @@ class SimpleEditor ( Editor ):
                         self._insert_node( nid, insert_index, child_node,
                                         child )
                         child_index += 1
+            else:
+                # if model has children, but is not expanded, add dummy child
+                if len(children) > 0:
+                    nid._dummy = QtGui.QTreeWidgetItem(nid)
 
             # Try to expand the node (if requested):
             if node.can_auto_open( object ):


### PR DESCRIPTION
Fixes #250.

When going from having no children to having children, nodes were not being updated to indicate that they could be expanded.  The tree editor handles this by adding a dummy child to the unexpanded node so that Qt will flag it as expandable.  This was not happening in the handlers for replacing all children or updating children for a node in the case where they were not expanded and started with no children.

A better fix for this would be to replace the nodes in the Qt model with `QModelViewItem` subclasses instead of `QTreeWidgetItem`s, but that's a substantial amount of work.