### PR TITLE
Add toolbar in Qt UI panel (fix for Mayavi)

### DIFF
--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -1,0 +1,69 @@
+import unittest
+
+from traits.api import HasTraits, Int, Str, Instance
+from traitsui.api import View, Item
+from traitsui.menu import ToolBar, Action
+
+from traitsui.tests._tools import skip_if_not_qt4
+
+
+class FooPanel(HasTraits):
+
+    my_int = Int(2)
+    my_str = Str("I am a panel/subpanel")
+    toolbar = Instance(ToolBar)
+
+    def default_traits_view(self):
+        view = View(
+            Item(name='my_int'),
+            Item(name='my_str'),
+            title="FooPanel",
+            buttons=["OK", "Cancel"],
+            toolbar=self.toolbar)
+        return view
+
+    def _toolbar_default(self):
+        return ToolBar(Action(name="Open file"))
+
+
+@skip_if_not_qt4
+class TestUIPanel_Qt4(unittest.TestCase):
+
+    def setup_qt4_dock_window(self):
+        from pyface.qt import QtGui
+
+        # set up the dock window for qt
+        main_window = QtGui.QMainWindow()
+        dock = QtGui.QDockWidget("testing", main_window)
+        dock.setWidget(QtGui.QMainWindow())
+        return main_window, dock
+
+    def test_panel_has_toolbar_buttons_qt4(self):
+        from pyface.qt import QtGui
+
+        main_window, dock = self.setup_qt4_dock_window()
+
+        # add panel
+        panel = FooPanel()
+        ui = panel.edit_traits(parent=dock.widget(), kind="panel")
+        dock.widget().setCentralWidget(ui.control)
+
+        # There should be a toolbar for the panel
+        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+        # There should be buttons too
+        self.assertIsNotNone(dock.findChild(QtGui.QPushButton))
+
+    def test_subpanel_has_toolbar_no_buttons_qt4(self):
+        from pyface.qt import QtGui
+
+        main_window, dock = self.setup_qt4_dock_window()
+
+        # add panel
+        panel = FooPanel()
+        ui = panel.edit_traits(parent=dock.widget(), kind="subpanel")
+        dock.widget().setCentralWidget(ui.control)
+
+        # There should be a toolbar for the panel
+        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+        # Buttons should not be shown for subpanel
+        self.assertIsNone(dock.findChild(QtGui.QPushButton))

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -66,9 +66,9 @@ class TestUIPanel(unittest.TestCase):
         dock.widget().setCentralWidget(ui.control)
 
         # There should be a toolbar for the panel
-        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+        self.assertIsNotNone(dock.widget().findChild(QtGui.QToolBar))
         # There should be buttons too
-        self.assertIsNotNone(dock.findChild(QtGui.QPushButton))
+        self.assertIsNotNone(ui.control.findChild(QtGui.QPushButton))
 
     def test_subpanel_has_toolbar_no_buttons_qt4(self):
         from pyface.qt import QtGui
@@ -81,9 +81,9 @@ class TestUIPanel(unittest.TestCase):
         dock.widget().setCentralWidget(ui.control)
 
         # There should be a toolbar for the subpanel
-        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+        self.assertIsNotNone(dock.widget().findChild(QtGui.QToolBar))
         # Buttons should not be shown for subpanel
-        self.assertIsNone(dock.findChild(QtGui.QPushButton))
+        self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
 
     def test_subpanel_no_toolbar_nor_button_in_widget(self):
         from pyface.qt import QtGui

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -41,7 +41,7 @@ class TestUIPanel_Qt4(unittest.TestCase):
     def test_panel_has_toolbar_buttons_qt4(self):
         from pyface.qt import QtGui
 
-        main_window, dock = self.setup_qt4_dock_window()
+        _, dock = self.setup_qt4_dock_window()
 
         # add panel
         panel = FooPanel()
@@ -56,7 +56,7 @@ class TestUIPanel_Qt4(unittest.TestCase):
     def test_subpanel_has_toolbar_no_buttons_qt4(self):
         from pyface.qt import QtGui
 
-        main_window, dock = self.setup_qt4_dock_window()
+        _, dock = self.setup_qt4_dock_window()
 
         # add panel
         panel = FooPanel()

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -67,8 +67,11 @@ class TestUIPanel(unittest.TestCase):
 
         # There should be a toolbar for the panel
         self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+
         # There should be buttons too
-        self.assertIsNotNone(dock.findChild(QtGui.QPushButton))
+        # Not searching from dock because the dock panel has buttons for
+        # popping up and closing the panel
+        self.assertIsNotNone(ui.control.findChild(QtGui.QPushButton))
 
     def test_subpanel_has_toolbar_no_buttons_qt4(self):
         from pyface.qt import QtGui
@@ -82,8 +85,11 @@ class TestUIPanel(unittest.TestCase):
 
         # There should be a toolbar for the subpanel
         self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+
         # Buttons should not be shown for subpanel
-        self.assertIsNone(dock.findChild(QtGui.QPushButton))
+        # Not searching from dock because the dock panel has buttons for
+        # popping up and closing the panel
+        self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
 
     def test_subpanel_no_toolbar_nor_button_in_widget(self):
         from pyface.qt import QtGui
@@ -93,7 +99,8 @@ class TestUIPanel(unittest.TestCase):
         foo_window = FooDialog()
         ui = foo_window.edit_traits()
 
-        # No toolbar
+        # No toolbar for the dialog
         self.assertIsNone(ui.control.findChild(QtGui.QToolBar))
+
         # No button
         self.assertIsNone(ui.control.findChild(QtGui.QPushButton))

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -1,7 +1,7 @@
 import unittest
 
 from traits.api import HasTraits, Int, Str, Instance
-from traitsui.api import View, Item
+from traitsui.api import View, Item, Group
 from traitsui.menu import ToolBar, Action
 
 from traitsui.tests._tools import skip_if_not_qt4
@@ -26,9 +26,26 @@ class FooPanel(HasTraits):
         return ToolBar(Action(name="Open file"))
 
 
-@skip_if_not_qt4
-class TestUIPanel_Qt4(unittest.TestCase):
+class FooDialog(HasTraits):
 
+    panel1 = Instance(FooPanel)
+    panel2 = Instance(FooPanel)
+
+    view = View(
+        Group(Item("panel1"),
+              Item("panel2"),
+              layout="split",
+              style="custom"))
+
+    def _panel1_default(self):
+        return FooPanel()
+
+    def _panel2_default(self):
+        return FooPanel()
+
+
+@skip_if_not_qt4
+class TestUIPanel(unittest.TestCase):
     def setup_qt4_dock_window(self):
         from pyface.qt import QtGui
 
@@ -63,7 +80,20 @@ class TestUIPanel_Qt4(unittest.TestCase):
         ui = panel.edit_traits(parent=dock.widget(), kind="subpanel")
         dock.widget().setCentralWidget(ui.control)
 
-        # There should be a toolbar for the panel
+        # There should be a toolbar for the subpanel
         self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
         # Buttons should not be shown for subpanel
         self.assertIsNone(dock.findChild(QtGui.QPushButton))
+
+    def test_subpanel_no_toolbar_nor_button_in_widget(self):
+        from pyface.qt import QtGui
+
+        # FooDialog uses a QWidget to contain the panels
+        # No attempt should be made for adding the toolbars
+        foo_window = FooDialog()
+        ui = foo_window.edit_traits()
+
+        # No toolbar
+        self.assertIsNone(ui.control.findChild(QtGui.QToolBar))
+        # No button
+        self.assertIsNone(ui.control.findChild(QtGui.QPushButton))

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -66,9 +66,9 @@ class TestUIPanel(unittest.TestCase):
         dock.widget().setCentralWidget(ui.control)
 
         # There should be a toolbar for the panel
-        self.assertIsNotNone(dock.widget().findChild(QtGui.QToolBar))
+        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
         # There should be buttons too
-        self.assertIsNotNone(ui.control.findChild(QtGui.QPushButton))
+        self.assertIsNotNone(dock.findChild(QtGui.QPushButton))
 
     def test_subpanel_has_toolbar_no_buttons_qt4(self):
         from pyface.qt import QtGui
@@ -81,9 +81,9 @@ class TestUIPanel(unittest.TestCase):
         dock.widget().setCentralWidget(ui.control)
 
         # There should be a toolbar for the subpanel
-        self.assertIsNotNone(dock.widget().findChild(QtGui.QToolBar))
+        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
         # Buttons should not be shown for subpanel
-        self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
+        self.assertIsNone(dock.findChild(QtGui.QPushButton))
 
     def test_subpanel_no_toolbar_nor_button_in_widget(self):
         from pyface.qt import QtGui

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -277,6 +277,45 @@ class BasePanel(object):
         """
         self.revert.setEnabled(state)
 
+    #---------------------------------------------------------------------------
+    #  Adds a menu item to the menu bar being constructed:
+    #---------------------------------------------------------------------------
+
+    def add_to_menu ( self, menu_item ):
+        """ Adds a menu item to the menu bar being constructed.
+        """
+        item   = menu_item.item
+        action = item.action
+
+        if action.id != '':
+            self.ui.info.bind( action.id, menu_item )
+
+        if action.style == 'radio':
+            if ((self._last_group is None) or
+                (self._last_parent is not item.parent)):
+                self._last_group = RadioGroup()
+                self._last_parent = item.parent
+            self._last_group.items.append( menu_item )
+            menu_item.group = self._last_group
+
+        if action.visible_when != '':
+            self.ui.add_visible( action.visible_when, menu_item )
+
+        if action.enabled_when != '':
+            self.ui.add_enabled( action.enabled_when, menu_item )
+
+        if action.checked_when != '':
+            self.ui.add_checked( action.checked_when, menu_item )
+
+    #---------------------------------------------------------------------------
+    #  Adds a tool bar item to the tool bar being constructed:
+    #---------------------------------------------------------------------------
+
+    def add_to_toolbar ( self, toolbar_item ):
+        """ Adds a toolbar item to the toolbar being constructed.
+        """
+        self.add_to_menu( toolbar_item )
+        
 
 class _StickyDialog(QtGui.QDialog):
     """A QDialog that will only close if the traits handler allows it."""
@@ -555,45 +594,6 @@ class BaseDialog(BasePanel):
             control.setText(text)
 
         return set_status_text
-
-    #---------------------------------------------------------------------------
-    #  Adds a menu item to the menu bar being constructed:
-    #---------------------------------------------------------------------------
-
-    def add_to_menu ( self, menu_item ):
-        """ Adds a menu item to the menu bar being constructed.
-        """
-        item   = menu_item.item
-        action = item.action
-
-        if action.id != '':
-            self.ui.info.bind( action.id, menu_item )
-
-        if action.style == 'radio':
-            if ((self._last_group is None) or
-                (self._last_parent is not item.parent)):
-                self._last_group = RadioGroup()
-                self._last_parent = item.parent
-            self._last_group.items.append( menu_item )
-            menu_item.group = self._last_group
-
-        if action.visible_when != '':
-            self.ui.add_visible( action.visible_when, menu_item )
-
-        if action.enabled_when != '':
-            self.ui.add_enabled( action.enabled_when, menu_item )
-
-        if action.checked_when != '':
-            self.ui.add_checked( action.checked_when, menu_item )
-
-    #---------------------------------------------------------------------------
-    #  Adds a tool bar item to the tool bar being constructed:
-    #---------------------------------------------------------------------------
-
-    def add_to_toolbar ( self, toolbar_item ):
-        """ Adds a toolbar item to the toolbar being constructed.
-        """
-        self.add_to_menu( toolbar_item )
 
     def can_add_to_menu(self, action, action_event=None):
         """Returns whether the action should be defined in the user interface.

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -205,8 +205,7 @@ class _Panel(BasePanel):
                 layout.addWidget(bbox)
 
         # If the UI has a toolbar, should add it to the panel too
-        if self.ui.view.toolbar:
-            self._add_toolbar(parent)
+        self._add_toolbar(parent)
 
         # Ensure the control has a size hint reflecting the View specification.
         # Yes, this is a hack, but it's too late to repair this convoluted

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -215,6 +215,10 @@ class _Panel(BasePanel):
     def _add_toolbar (self, parent):
         """ Adds a toolbar to the `parent` (QtWindow)
         """
+        if not isinstance(parent, QtGui.QMainWindow):
+            # toolbar cannot be added to non-MainWindow widget
+            return
+
         toolbar = self.ui.view.toolbar
         if toolbar is not None:
             self._last_group = self._last_parent = None

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -204,10 +204,34 @@ class _Panel(BasePanel):
                         self.add_button(button, bbox, role)
                 layout.addWidget(bbox)
 
+        # If the UI has a toolbar, should add it to the panel too
+        if self.ui.view.toolbar:
+            self._add_toolbar(parent)
+
         # Ensure the control has a size hint reflecting the View specification.
         # Yes, this is a hack, but it's too late to repair this convoluted
         # control building process, so we do what we have to...
         self.control.sizeHint = _size_hint_wrapper(self.control.sizeHint, ui)
+
+    def _add_toolbar (self, parent):
+        """ Adds a toolbar to the `parent` (QtWindow)
+        """
+        toolbar = self.ui.view.toolbar
+        if toolbar is not None:
+            self._last_group = self._last_parent = None
+            qt_toolbar = toolbar.create_tool_bar(parent, self )
+            qt_toolbar.setMovable( False )
+            parent.addToolBar( qt_toolbar )
+            self._last_group = self._last_parent = None
+
+    def can_add_to_toolbar(self, action):
+        """Returns whether the toolbar action should be defined in the user
+           interface.
+        """
+        if action.defined_when == '':
+            return True
+
+        return self.ui.eval_when(action.defined_when)
 
 
 def panel(ui):


### PR DESCRIPTION
The Mayavi2 application do not show the toolbar for the pipeline (one of the workbench panels) when the backend is Qt4.

This will allow the panel to add the toolbar to the window.  However, the toolbar would be added to the main window instead of the panel.  The full fix for mayavi would require https://github.com/enthought/pyface/pull/192 for the toolbar to appear in the panel it's associated with.

Before:
![before](https://cloud.githubusercontent.com/assets/3673984/13151298/7e24a264-d661-11e5-91b7-a9e708fbf58c.png)

After:
![after](https://cloud.githubusercontent.com/assets/3673984/13151309/88fd8106-d661-11e5-81ce-7ded7436fa18.png)
