### PR TITLE
Fix wx capture mouse issue.

### DIFF
--- a/traitsui/wx/themed_window.py
+++ b/traitsui/wx/themed_window.py
@@ -79,15 +79,13 @@ class ThemedWindow ( HasPrivateTraits ):
     def capture_mouse ( self ):
         """ Grab control of the mouse and indicate that we are controlling it.
         """
-        if not self._has_capture:
-            self._has_capture = True
+        if not self.control.HasCapture():
             self.control.CaptureMouse()
 
     def release_mouse ( self ):
         """ Grab control of the mouse and indicate that we are controlling it.
         """
-        if self._has_capture:
-            self._has_capture = False
+        if self.control.HasCapture():
             self.control.ReleaseMouse()
 
     #-- Trait Event Handlers ---------------------------------------------------
@@ -184,8 +182,7 @@ class ThemedWindow ( HasPrivateTraits ):
     def _left_up ( self, event ):
         """ Handles a left mouse button up event.
         """
-        if self._has_capture:
-            self._has_capture = False
+        if self.control.HasCapture():
             self.control.ReleaseMouse()
             self._mouse_event( 'left_up', event )
 


### PR DESCRIPTION
This PR changes ThemedWindow to use the wx HasCapture method instead of trying to track the state itself.

wxPython 3 is more strict about capturing the mouse, and no longer allows a widget to capture it if it already holds the capture, and it's also possible for the capture to be stolen by another widget.  So trying to track the state of the capture in a local attribute can sometimes have holes, resulting in assertion errors from wx.  
