### PR TITLE
Fix wx _left_up() event for themed windows

### DIFF
--- a/traitsui/wx/themed_window.py
+++ b/traitsui/wx/themed_window.py
@@ -182,9 +182,8 @@ class ThemedWindow ( HasPrivateTraits ):
     def _left_up ( self, event ):
         """ Handles a left mouse button up event.
         """
-        if self.control.HasCapture():
-            self.control.ReleaseMouse()
-            self._mouse_event( 'left_up', event )
+        self.release_mouse()
+        self._mouse_event( 'left_up', event )
 
     def _left_dclick ( self, event ):
         """ Handles a left mouse button double click event.


### PR DESCRIPTION
This is related to enthought/traitsui#265. The behavior of themed_windows was still a little buggy with some missed click events. I think this may solve the issue.