### PR TITLE
Fixes exception occurring during disposal of ListStrEditor

### DIFF
--- a/traitsui/list_str_adapter.py
+++ b/traitsui/list_str_adapter.py
@@ -201,7 +201,11 @@ class ListStrAdapter ( HasPrivateTraits ):
     def len ( self, object, trait ):
         """ Returns the number of items in the specified *object.trait* list.
         """
-        return len( getattr( object, trait ) )
+        # Sometimes, during shutdown, the object has been set to None.
+        if object is None:
+            return 0
+        else:
+            return len( getattr( object, trait ) )
 
     def get_default_value ( self, object, trait ):
         """ Returns a new default value for the specified *object.trait* list.

--- a/traitsui/tests/editors/test_liststr_editor.py
+++ b/traitsui/tests/editors/test_liststr_editor.py
@@ -1,0 +1,39 @@
+#------------------------------------------------------------------------------
+#
+#  Copyright (c) 2013, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Author: Stefano Borini
+#  Date:   Oct 2016
+#
+#------------------------------------------------------------------------------
+
+"""
+Test case for ListStrEditor and ListStrAdapter
+"""
+
+from traits.has_traits import HasTraits
+from traits.trait_types import List, Str
+from traitsui.list_str_adapter import ListStrAdapter
+
+class TraitObject(HasTraits):
+    list_str = List(Str)
+
+
+def test_list_str_adapter_length():
+    """Test the ListStringAdapter len method"""
+
+    object = TraitObject()
+    object.list_str = ["hello"]
+
+    adapter = ListStrAdapter()
+
+    assert adapter.len(object, "list_str") == 1
+    assert adapter.len(None, "list_str") == 0
+
+


### PR DESCRIPTION
Solves issue #269. The root cause was that the adapter was not able to deal with
None objects. This is already performed in the TabularAdapter, and was missing in
the ListStrAdapter. The result was that ListStrModel.rowCount was raising exception
because at deinitialization, the editor trait object can be None. It is sensible in
this case that the adapter simply returns zero.