### PR TITLE
Fix segfault when closing TableEditor while editing inline

### DIFF
--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -508,8 +508,7 @@ class SimpleEditor ( CustomEditor ):
         ui = self.value.edit_traits( view, kind=factory.kind, id=factory.id )
 
         # Make sure the editor is properly disposed
-        QtCore.QObject.connect( self._button, QtCore.SIGNAL( 'destroyed()' ),
-                                lambda: ui.dispose() )
+        self._button.destroyed.connect( ui.dispose )
 
         # Check to see if the view was 'modal', in which case it will already
         # have been closed (i.e. is None) by the time we get control back:

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -281,10 +281,6 @@ class TableEditor(Editor, BaseTableEditor):
     def dispose(self):
         """ Disposes of the contents of an editor."""
 
-        # Disconnect the table view from its model to ensure that they do not
-        # continue to interact (the control won't be deleted until later).
-        self.table_view.setModel(None)
-
         # Make sure that the auxillary UIs are properly disposed
         if self.toolbar_ui is not None:
             self.toolbar_ui.dispose()
@@ -302,7 +298,6 @@ class TableEditor(Editor, BaseTableEditor):
         # Remove listeners for column definition changes
         self.on_trait_change(self._update_columns, 'columns', remove=True)
         self.on_trait_change(self._update_columns, 'columns_items', remove=True)
-
 
         super(TableEditor, self).dispose()
 
@@ -387,7 +382,7 @@ class TableEditor(Editor, BaseTableEditor):
         if not isinstance(items, SequenceTypes):
             items = [ items ]
 
-        if self.factory.reverse:
+        if self.factory and self.factory.reverse:
             items = ReversedList(items)
 
         return items

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -232,7 +232,7 @@ class BasePanel(object):
                 method = editor.perform
 
         if method is not None:
-            button.connect(button, QtCore.SIGNAL('clicked()'), method)
+            button.clicked.connect(method)
 
         if action.tooltip != '':
             button.setToolTip(action.tooltip)
@@ -444,8 +444,7 @@ class BaseDialog(BasePanel):
         control.setModal(style == BaseDialog.MODAL)
         control.setWindowTitle(view.title or DefaultTitle)
 
-        QtCore.QObject.connect(control, QtCore.SIGNAL('finished(int)'),
-                self._on_finished)
+        control.finished.connect(self._on_finished)
 
     def add_contents(self, panel, buttons):
         """Add a panel (either a widget, layout or None) and optional buttons

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -257,7 +257,6 @@ def panel(ui):
         panel = QtGui.QTabWidget()
         # Identify ourselves as being a Tabbed group so we can later
         # distinguish this from other QTabWidgets.
-        panel.setProperty("traits_tabbed_group", True)
         _fill_panel(panel, content, ui)
         panel.ui = ui
 
@@ -551,7 +550,6 @@ class _GroupPanel(object):
             # Create the TabWidget or ToolBox.
             if group.layout == 'tabbed':
                 sub = QtGui.QTabWidget()
-                sub.setProperty("traits_tabbed_group", True)
             else:
                 sub = QtGui.QToolBox()
 
@@ -1253,8 +1251,7 @@ class HTMLHelpWindow ( QtGui.QDialog ):
         # Create the OK button
         bbox = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok,
                                       QtCore.Qt.Horizontal)
-        QtCore.QObject.connect(bbox, QtCore.SIGNAL('accepted()'),
-                               self, QtCore.SLOT('accept()'))
+        bbox.accepted.connect(self.accept)
         layout.addWidget(bbox)
 
         # Position and show the dialog


### PR DESCRIPTION
The main culprit is the `table_view.setModel(None)` in
`TableEditor.dispose()`. It is cause of segfault because
when the model is set while editing, the underlying widget
is not in sync with it and something bad ensues.
The segfault happens in a fairly complex app with custom
cell editor spanning multiple rows. Here's a sample traceback:

> Program received signal SIGSEGV, Segmentation fault.
> QHashData::nextNode (node=node@entry=0x5555588f3a50) at tools/qhash.cpp:294
> 294	    if (next->next)
> (gdb) bt
> #0  0x00007fffe1fd2363 in QHashData::nextNode(QHashData::Node*) (node=node@entry=0x5555588f3a50) at tools/qhash.cpp:294
> #1  0x00007fffdfe046a3 in QAbstractItemView::updateEditorGeometries() (this=<synthetic pointer>) at ../../src/corelib/tools/qhash.h:355
> #2  0x00007fffdfe046a3 in QAbstractItemView::updateEditorGeometries() (this=this@entry=0x555558f1d280) at itemviews/qabstractitemview.cpp:2625
> #3  0x00007fffe0a5b778 in QTableViewWrapper::updateEditorGeometries() (this=0x555558f1d280)
>     at /usr/src/debug/pyside-qt4.8+1.2.2/x86_64-redhat-linux-gnu/PySide/QtGui/PySide/QtGui/qtableview_wrapper.cpp:2039
> #4  0x00007fffdfdf8cad in QAbstractItemView::updateGeometries() (this=this@entry=0x555558f1d280) at itemviews/qabstractitemview.cpp:2650
> #5  0x00007fffdfe370f9 in QTableView::updateGeometries() (this=this@entry=0x555558f1d280) at itemviews/qtableview.cpp:2138
> #6  0x00007fffe0a5b8e8 in QTableViewWrapper::updateGeometries() (this=0x555558f1d280)
>     at /usr/src/debug/pyside-qt4.8+1.2.2/x86_64-redhat-linux-gnu/PySide/QtGui/PySide/QtGui/qtableview_wrapper.cpp:2060
> #7  0x00007fffdfe2bea6 in QTableView::columnCountChanged(int, int) (this=0x555558f1d280) at itemviews/qtableview.cpp:2015
> #8  0x00007fffe20d7a50 in QMetaObject::activate(QObject*, QMetaObject const*, int, void**) (sender=0x55555901d5f0, m=m@entry=0x7fffe03cf0c0 <QHeaderView::staticMetaObject>, local_signal_index=local_signal_index@entry=6, argv=argv@entry=0x7fffffffa3b0) at kernel/qobject.cpp:3567
> #9  0x00007fffdfe0aa3f in QHeaderView::sectionCountChanged(int, int) (this=<optimized out>, _t1=3, _t2=0) at .moc/release-shared/moc_qheaderview.cpp:267
> #10 0x00007fffdfe14612 in QHeaderView::setModel(QAbstractItemModel*) (this=0x55555901d5f0, model=0x0) at itemviews/qheaderview.cpp:410
> #11 0x00007fffdfe36b09 in QTableView::setModel(QAbstractItemModel*) (this=0x555558f1d280, model=0x0) at itemviews/qtableview.cpp:1085
> #12 0x00007fffe0a59751 in Sbk_QTableViewFunc_setModel(PyObject*, PyObject*) (self=
>     <VariableTableView(_initial_size=True, _editor=<TableEditor(control=<...>, _ui=None, source_model=<TableModel(_editor=<...>) at remote 0x7fff3936e1b8>, images={}, __traits_listener__={'selected': [<ListenerNotifyWrapper(name=None, argument_transform=<function at remote 0x7fffeeb168c0>, object=<weakref at remote 0x7fff38320998>, listener=<ListenerItem(name='selected', dispatch='same', wrapped_handler_ref=<weakref at remote 0x7fff38320730>, priority=True, deferred=False, handler=<ListenerHandler(handler=<function at remote 0x7fff38319e60>) at remote 0x7fff393b6e10>, active=<WeakKeyDictionary(_remove=<function at remote 0x7fff383191b8>, _pending_removals=[], _iterating=set([]), data={<weakref at remote 0x7fff38320db8>: [('selected', '_register_simple')]}) at remote 0x7fff38309d88>, next=None, type=0) at remote 0x7fff3830cc50>, handler=<function at remote 0x7fff38319e60>, notify_listener=<instancemethod at remote 0x7fff394d1f00>, owner=<weakref at remote 0x7fff38320d60>, type=0, id='selected') at remote 0x7fff393...(truncated), pyArg=None)
>     at /usr/src/debug/pyside-qt4.8+1.2.2/x86_64-redhat-linux-gnu/PySide/QtGui/PySide/QtGui/qtableview_wrapper.cpp:4635
> #13 0x00007ffff7af20c1 in PyEval_EvalFrameEx (oparg=<optimized out>, pp_stack=0x7fffffffa550) at /usr/src/debug/Python-2.7.11/Python/ceval.c:4415
> #14 0x00007ffff7af20c1 in PyEval_EvalFrameEx (f=f@entry=
>     Frame 0x55555825c8d0, for file /home/pankaj/work/enthought/ETS/traitsui/traitsui/qt4/table_editor.py, line 289, in dispose (self=<TableEditor(control=<VariableTableView(_initial_size=True, _editor=<...>) at remote 0x7fff38309ea8>, _ui=None, source_model=<TableModel(_editor=<...>) at remote 0x7fff3936e1b8>, images={}, __traits_listener__={'selected': [<ListenerNotifyWrapper(name=None, argument_transform=<function at remote 0x7fffeeb168c0>, object=<weakref at remote 0x7fff38320998>, listener=<ListenerItem(name='selected', dispatch='same', wrapped_handler_ref=<weakref at remote 0x7fff38320730>, priority=True, deferred=False, handler=<ListenerHandler(handler=<function at remote 0x7fff38319e60>) at remote 0x7fff393b6e10>, active=<WeakKeyDictionary(_remove=<function at remote 0x7fff383191b8>, _pending_removals=[], _iterating=set([]), data={<weakref at remote 0x7fff38320db8>: [('selected', '_register_simple')]}) at remote 0x7fff38309d88>, next=None, type=0) at remote 0x7fff3830cc50>, handler=<function at remote 0x7f...(truncated), throwflag=throwflag@entry=0) at /usr/src/debug/Python-2.7.11/Python/ceval.c:3061
> #15 0x00007ffff7af2362 in PyEval_EvalFrameEx (nk=<optimized out>, na=<optimized out>, n=1, pp_stack=0x7fffffffa690, func=<optimized out>) at /usr/src/debug/Python-2.7.11/Python/ceval.c:4513
> #16 0x00007ffff7af2362 in PyEval_EvalFrameEx (oparg=<optimized out>, pp_stack=0x7fffffffa690) at /usr/src/debug/Python-2.7.11/Python/ceval.c:4448
> #17 0x00007ffff7af2362 in PyEval_EvalFrameEx (f=f@entry=Frame 0x555558bcb9e0, for file /home/pankaj/work/enthought/ETS/traitsui/traitsui/ui.py, line 309, in reset (self=<UI(control=<_GroupSplitter(sizeHint=<function at remote 0x7fff3804d6e0>, _initialized=True, _parent=<PySide.QtGui.QWidget at remote 0x7fff393ea0e0>, _object=<VariableBrowser(variables=<TraitListObject(trait=<List(default_value=[], item_trait=<CTrait(instance_handler='_instance_changed_handler', copy='deep', type='trait') at remote 0x7fff3a9f2aa0>, _metadata={'instance_handler': '_list_changed_handler', 'copy': 'deep', 'type': 'trait'}, minlen=0, has_items=True, maxlen=9223372036854775807) at remote 0x7fff3a9f1910>, name_items='variables_items', object=<weakref at remote 0x7fff27b49368>, name='variables') at remote 0x7fff272a3e10>, show_details=True, watches=<TraitListObject(trait=<List(default_value=[], item_trait=<CTrait(instance_handler='_instance_changed_handler', copy='deep', type='trait') at remote 0x7fff3a9f29f0>, _metadata={'instance_handler': '_list_changed_handler', 'copy': 'deep', 'type'...(truncated), throwflag=throwflag@entry=0)
>     at /usr/src/debug/Python-2.7.11/Python/ceval.c:3061
> #18 0x00007ffff7af55a4 in PyEval_EvalCodeEx (co=<optimized out>, globals=<optimized out>, locals=locals@entry=0x0, args=<optimized out>, argcount=1, kws=kws@entry=0x555558ba1420, kwcount=1, defs=0x7fffd2147c28, defcount=1, closure=0x0) at /usr/src/debug/Python-2.7.11/Python/ceval.c:3659
> #19 0x00007ffff7af222e in PyEval_EvalFrameEx (nk=1, na=<optimized out>, n=<optimized out>, pp_stack=0x7fffffffa890, func=<optimized out>) at /usr/src/debug/Python-2.7.11/Python/ceval.c:4523
> #20 0x00007ffff7af222e in PyEval_EvalFrameEx (oparg=<optimized out>, pp_stack=0x7fffffffa890) at /usr/src/debug/Python-2.7.11/Python/ceval.c:4448
> #21 0x00007ffff7af222e in PyEval_EvalFrameEx (f=f@entry=Frame 0x555558ba1290, for file /home/pankaj/work/enthought/ETS/traitsui/traitsui/ui.py, line 267, in finish (self=<UI(control=<_GroupSplitter(sizeHint=<function at remote 0x7fff3804d6e0>, _initialized=True, _parent=<PySide.QtGui.QWidget at remote 0x7fff393ea0e0>, _object=<VariableBrowser(variables=<TraitListObject(trait=<List(default_value=[], item_trait=<CTrait(instance_handler='_instance_changed_handler', copy='deep', type='trait') at remote 0x7fff3a9f2aa0>, _metadata={'instance_handler': '_list_changed_handler', 'copy': 'deep', 'type': 'trait'}, minlen=0, has_items=True, maxlen=9223372036854775807) at remote 0x7fff3a9f1910>, name_items='variables_items', object=<weakref at remote 0x7fff27b49368>, name='variables') at remote 0x7fff272a3e10>, show_details=True, watches=<TraitListObject(trait=<List(default_value=[], item_trait=<CTrait(instance_handler='_instance_changed_handler', copy='deep', type='trait') at remote 0x7fff3a9f29f0>, _metadata={'instance_handler': '_list_changed_handler', 'copy': 'deep', 'type...(truncated), throwflag=throwflag@entry=0)
> ---Type <return> to continue, or q <return> to quit---q
> 