### PR TITLE
TableEditor column with progress bar

### DIFF
--- a/docs/source/traitsui_user_manual/factories_advanced_extra.rst
+++ b/docs/source/traitsui_user_manual/factories_advanced_extra.rst
@@ -252,12 +252,13 @@ parameter.
 The items in the list must be instances of traitsui.api.TableColumn,
 or of a subclass of TableColumn. Some subclasses of TableColumn that are
 provided by the TraitsUI package include ObjectColumn, ListColumn,
-NumericColumn, and ExpressionColumn. (See the *Traits API Reference* for details
-about these classes.) In practice, most columns are derived from one of these
-subclasses, rather than from TableColumn. For the usual case of editing trait
-attributes on objects in the list, use ObjectColumn. You must specify the *name*
-parameter to the ObjectColumn() constructor, referencing the name of the trait
-attribute to be edited.
+NumericColumn, ExpressionColumn, CheckboxColumn and ProgressColumn.
+(See the *Traits API Reference* for details about these classes.) In practice,
+most columns are derived from one of these subclasses, rather than from
+TableColumn. For the usual case of editing trait attributes on objects in the
+list, use ObjectColumn. You must specify the *name* parameter to the
+ObjectColumn() constructor, referencing the name of the trait attribute to be
+edited.
 
 You can specify additional columns that are not initially displayed using the
 *other_columns* parameter. If the *configurable* parameter is True (the

--- a/examples/demo/Advanced/Table_editor_with_progress_column.py
+++ b/examples/demo/Advanced/Table_editor_with_progress_column.py
@@ -1,0 +1,56 @@
+import random
+
+from pyface.api import GUI
+from traits.api import Button, HasTraits, Instance, Int, List, Str
+from traitsui.api import ObjectColumn, TableEditor, UItem, View
+from traitsui.extras.progress_column import ProgressColumn
+
+
+class Job(HasTraits):
+
+    name = Str
+
+    percent_complete = Int
+
+
+class JobManager(HasTraits):
+
+    jobs = List(Instance(Job))
+
+    start = Button
+
+    def populate(self):
+        self.jobs = [
+            Job(name='job %02d' % i, percent_complete=0)
+            for i in range(1, 25)
+        ]
+
+    def process(self):
+        for job in self.jobs:
+            job.percent_complete = min(
+                job.percent_complete+random.randint(0, 3), 100)
+
+        if any(job.percent_complete < 100 for job in self.jobs):
+            GUI.invoke_after(100, self.process)
+
+    def _start_fired(self):
+        self.populate()
+        GUI.invoke_after(1000, self.process)
+
+    view = View(
+        UItem('jobs', editor=TableEditor(
+            columns=[
+                ObjectColumn(name='name'),
+                ProgressColumn(name='percent_complete'),
+            ]
+        )),
+        UItem('start'),
+        resizable=True,
+    )
+
+
+demo = view = job_manager = JobManager()
+
+# Run the demo (if invoked from the command line):
+if __name__ == '__main__':
+    demo.configure_traits()

--- a/traitsui/extras/progress_column.py
+++ b/traitsui/extras/progress_column.py
@@ -25,7 +25,7 @@ from traitsui.table_column import ObjectColumn
 if ETSConfig.toolkit == 'qt4':
     from traitsui.qt4.extra.progress_renderer import ProgressRenderer
 else:
-    raise NotImplementedError("No checkbox renderer for backend")
+    raise NotImplementedError("No pregress column renderer for backend")
 
 
 class ProgressColumn(ObjectColumn):

--- a/traitsui/extras/progress_column.py
+++ b/traitsui/extras/progress_column.py
@@ -16,10 +16,8 @@
 
 """ A column class for for the TableEditor that displays progress bars. """
 
-from __future__ import absolute_import
-
 from traits.etsconfig.api import ETSConfig
-from traits.api import Str
+from traits.api import Bool, Int, Str
 
 from traitsui.table_column import ObjectColumn
 
@@ -31,9 +29,24 @@ else:
 
 
 class ProgressColumn(ObjectColumn):
+    """ A column which displays trait values as a progress bar
 
-    # Format string to apply to column values:
+    Progress values must be an integer value between the maximum and minimum
+    values.  By default it is assumed to be a percentage.
+    """
+
+    #: Format string to apply to column values.
     format = Str('%s%%')
+
+    #: The minimum value for a progress bar.
+    minimum = Int(0)
+
+    #: The maximum value for a progress bar.
+    maximum = Int(100)
+
+    #: Whether or not to display the text with the progress bar.
+    #: This may not display with some progress bar styles, eg. on OS X.
+    text_visible = Bool(True)
 
     def __init__(self, **traits):
         super(ProgressColumn, self).__init__(**traits)
@@ -43,21 +56,19 @@ class ProgressColumn(ObjectColumn):
     def is_editable(self, object):
         """ Returns whether the column is editable for a specified object.
         """
-        # Although a checkbox column is always editable, we return this
-        # to keep a standard editor from appearing. The editing is handled
-        # in the renderer's handlers.
+        # Progress columns are always read-only
         return False
 
     def get_minimum(self, object):
-        return 0
+        return self.minimum
 
     def get_maximum(self, object):
-        return 100
+        return self.maximum
 
-    def get_text_visible(self, object):
+    def get_text_visible(self):
         """ Whether or not to display text in column.
 
         Note, may not render on some platforms (eg. OS X) due to
         the rendering style.
         """
-        return True
+        return self.text_visible

--- a/traitsui/extras/progress_column.py
+++ b/traitsui/extras/progress_column.py
@@ -1,0 +1,63 @@
+#------------------------------------------------------------------------------
+#
+#  Copyright (c) 2016, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+#  Author: Corran Webster
+#
+#------------------------------------------------------------------------------
+
+""" A column class for for the TableEditor that displays progress bars. """
+
+from __future__ import absolute_import
+
+from traits.etsconfig.api import ETSConfig
+from traits.api import Str
+
+from traitsui.table_column import ObjectColumn
+
+
+if ETSConfig.toolkit == 'qt4':
+    from traitsui.qt4.extra.progress_renderer import ProgressRenderer
+else:
+    raise NotImplementedError("No checkbox renderer for backend")
+
+
+class ProgressColumn(ObjectColumn):
+
+    # Format string to apply to column values:
+    format = Str('%s%%')
+
+    def __init__(self, **traits):
+        super(ProgressColumn, self).__init__(**traits)
+        # force the renderer to be a progress bar renderer
+        self.renderer = ProgressRenderer()
+
+    def is_editable(self, object):
+        """ Returns whether the column is editable for a specified object.
+        """
+        # Although a checkbox column is always editable, we return this
+        # to keep a standard editor from appearing. The editing is handled
+        # in the renderer's handlers.
+        return False
+
+    def get_minimum(self, object):
+        return 0
+
+    def get_maximum(self, object):
+        return 100
+
+    def get_text_visible(self, object):
+        """ Whether or not to display text in column.
+
+        Note, may not render on some platforms (eg. OS X) due to
+        the rendering style.
+        """
+        return True

--- a/traitsui/qt4/extra/progress_renderer.py
+++ b/traitsui/qt4/extra/progress_renderer.py
@@ -1,0 +1,52 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2016, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+#
+# Author: Corran Webster
+#------------------------------------------------------------------------------
+
+""" A renderer which displays a progress bar based on a 0.0 to 1.0 value.
+"""
+
+# System library imports
+from pyface.qt import QtCore, QtGui
+
+# ETS imports
+from traitsui.qt4.table_editor import TableDelegate
+
+
+class ProgressRenderer(TableDelegate):
+    """ A renderer which displays a progress bar for a True value and an
+        unchecked box for a false value.
+    """
+
+    #---------------------------------------------------------------------------
+    #  QAbstractItemDelegate interface
+    #---------------------------------------------------------------------------
+
+    def paint(self, painter, option, index):
+        """ Reimplemented to paint the checkbox.
+        """
+        # Get the progress value
+        column = index.model()._editor.columns[index.column()]
+        obj = index.data(QtCore.Qt.UserRole)
+
+        # set up progress bar options
+        progress_bar_option = QtGui.QStyleOptionProgressBarV2()
+        progress_bar_option.rect = option.rect
+        progress_bar_option.minimum = column.get_minimum(obj)
+        progress_bar_option.maximum = column.get_maximum(obj)
+        progress_bar_option.progress = column.get_raw_value(obj)
+        progress_bar_option.textVisible = column.get_text_visible(obj)
+        progress_bar_option.text = column.get_value(obj)
+
+        # Draw it
+        style = QtGui.QApplication.instance().style()
+        style.drawControl(QtGui.QStyle.CE_ProgressBar, progress_bar_option,
+                          painter)

--- a/traitsui/qt4/extra/progress_renderer.py
+++ b/traitsui/qt4/extra/progress_renderer.py
@@ -11,8 +11,7 @@
 # Author: Corran Webster
 #------------------------------------------------------------------------------
 
-""" A renderer which displays a progress bar based on a 0.0 to 1.0 value.
-"""
+""" A renderer which displays a progress bar. """
 
 # System library imports
 from pyface.qt import QtCore, QtGui
@@ -22,8 +21,7 @@ from traitsui.qt4.table_editor import TableDelegate
 
 
 class ProgressRenderer(TableDelegate):
-    """ A renderer which displays a progress bar for a True value and an
-        unchecked box for a false value.
+    """ A renderer which displays a progress bar.
     """
 
     #---------------------------------------------------------------------------
@@ -31,8 +29,7 @@ class ProgressRenderer(TableDelegate):
     #---------------------------------------------------------------------------
 
     def paint(self, painter, option, index):
-        """ Reimplemented to paint the checkbox.
-        """
+        """ Paint the progressbar. """
         # Get the column and object
         column = index.model()._editor.columns[index.column()]
         obj = index.data(QtCore.Qt.UserRole)

--- a/traitsui/qt4/extra/progress_renderer.py
+++ b/traitsui/qt4/extra/progress_renderer.py
@@ -33,17 +33,17 @@ class ProgressRenderer(TableDelegate):
     def paint(self, painter, option, index):
         """ Reimplemented to paint the checkbox.
         """
-        # Get the progress value
+        # Get the column and object
         column = index.model()._editor.columns[index.column()]
         obj = index.data(QtCore.Qt.UserRole)
 
         # set up progress bar options
-        progress_bar_option = QtGui.QStyleOptionProgressBarV2()
+        progress_bar_option = QtGui.QStyleOptionProgressBar()
         progress_bar_option.rect = option.rect
         progress_bar_option.minimum = column.get_minimum(obj)
         progress_bar_option.maximum = column.get_maximum(obj)
-        progress_bar_option.progress = column.get_raw_value(obj)
-        progress_bar_option.textVisible = column.get_text_visible(obj)
+        progress_bar_option.progress = int(column.get_raw_value(obj))
+        progress_bar_option.textVisible = column.get_text_visible()
         progress_bar_option.text = column.get_value(obj)
 
         # Draw it

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -1,0 +1,73 @@
+
+from pyface.gui import GUI
+from traits.api import HasTraits, Instance, Int, List, Str
+
+from traitsui.api import Item, ObjectColumn, TableEditor, View
+from traitsui.tests._tools import (
+    skip_if_not_qt4, press_ok_button,
+    skip_if_null, store_exceptions_on_all_threads)
+
+
+class ListItem(HasTraits):
+    """ Items to visualize in a table editor """
+    value = Str
+    other_value = Int
+
+
+class ObjectList(HasTraits):
+    values = List(Instance(ListItem))
+
+
+simple_view = View(
+    Item(
+        'values',
+        show_label=False,
+        editor=TableEditor(
+            columns=[
+                ObjectColumn(name='value'),
+                ObjectColumn(name='other_value'),
+            ],
+        )
+    ),
+    buttons=['OK'],
+)
+
+
+@skip_if_null
+def test_table_editor():
+    gui = GUI()
+    object_list = ObjectList(
+        values=[ListItem(value=str(i**2)) for i in range(10)]
+    )
+
+    with store_exceptions_on_all_threads():
+        ui = object_list.edit_traits(view=simple_view)
+        press_ok_button(ui)
+        gui.process_events()
+
+
+@skip_if_not_qt4
+def test_progress_column():
+    from traitsui.extras.progress_column import ProgressColumn
+    progress_view = View(
+        Item(
+            'values',
+            show_label=False,
+            editor=TableEditor(
+                columns=[
+                    ObjectColumn(name='value'),
+                    ProgressColumn(name='other_value'),
+                ],
+            )
+        ),
+        buttons=['OK'],
+    )
+    gui = GUI()
+    object_list = ObjectList(
+        values=[ListItem(value=str(i**2)) for i in range(10)]
+    )
+
+    with store_exceptions_on_all_threads():
+        ui = object_list.edit_traits(view=progress_view)
+        press_ok_button(ui)
+        gui.process_events()

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -69,5 +69,6 @@ def test_progress_column():
 
     with store_exceptions_on_all_threads():
         ui = object_list.edit_traits(view=progress_view)
+        gui.process_events()
         press_ok_button(ui)
         gui.process_events()

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -42,6 +42,7 @@ def test_table_editor():
 
     with store_exceptions_on_all_threads():
         ui = object_list.edit_traits(view=simple_view)
+        gui.process_events()
         press_ok_button(ui)
         gui.process_events()
 


### PR DESCRIPTION
Probably want a little more customization, but this is the basics of `TableEditor` column which displays progress bars.

<img width="451" alt="screen shot 2016-05-19 at 4 27 59 pm" src="https://cloud.githubusercontent.com/assets/600761/15399210/afc1f5e6-1dde-11e6-830c-691484eeb475.png"> ![image](https://cloud.githubusercontent.com/assets/600761/15423395/33f99efe-1e75-11e6-8812-3c6e7d1dba66.png)

