### PR TITLE
Fix skip kill-focus events

### DIFF
--- a/traitsui/wx/color_editor.py
+++ b/traitsui/wx/color_editor.py
@@ -248,6 +248,7 @@ class CustomColorEditor(BaseSimpleEditor):
         """ Handles the user changing the contents of the edit control.
         """
         if not isinstance(event, wx._core.CommandEvent):
+            event.Skip()
             return
         try:
             # The TextCtrl object was saved as self._text_control in init().

--- a/traitsui/wx/editor_factory.py
+++ b/traitsui/wx/editor_factory.py
@@ -145,6 +145,8 @@ class TextEditor ( Editor ):
     def update_object ( self, event ):
         """ Handles the user changing the contents of the edit control.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         try:
             self.value = self.control.GetValue()
         except TraitError as excp:

--- a/traitsui/wx/extra/bounds_editor.py
+++ b/traitsui/wx/extra/bounds_editor.py
@@ -92,7 +92,9 @@ class _BoundsEditor(Editor):
         panel.SetSizerAndFit(sizer)
 
 
-    def update_low_on_enter(self, value):
+    def update_low_on_enter(self, event):
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         try:
             try:
                 low = eval(unicode(self._label_lo.GetValue()).strip())
@@ -114,7 +116,9 @@ class _BoundsEditor(Editor):
         except:
             pass
 
-    def update_high_on_enter(self, value):
+    def update_high_on_enter(self, event):
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         try:
             try:
                 high = eval(unicode(self._label_hi.GetValue()).strip())

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -153,6 +153,8 @@ class SimpleEditor ( SimpleTextEditor ):
     def update_object ( self, event ):
         """ Handles the user changing the contents of the edit control.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         self._update( self._file_name.GetValue() )
 
     #---------------------------------------------------------------------------

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -213,6 +213,8 @@ class SimpleSliderEditor ( BaseRangeEditor ):
     def update_object_on_enter ( self, event ):
         """ Handles the user pressing the Enter key in the text field.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
 
         # There are cases where this method is called with self.control == None.
         if self.control is None:
@@ -523,6 +525,8 @@ class LargeRangeSliderEditor ( BaseRangeEditor ):
     def update_object_on_enter ( self, event ):
         """ Handles the user pressing the Enter key in the text field.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         try:
             value = self.control.text.GetValue().strip()
             try:
@@ -873,6 +877,8 @@ class RangeTextEditor ( TextEditor ):
     def update_object ( self, event ):
         """ Handles the user entering input data in the edit control.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
 
         # There are cases where this method is called with self.control == None.
         if self.control is None:

--- a/traitsui/wx/scrubber_editor.py
+++ b/traitsui/wx/scrubber_editor.py
@@ -571,6 +571,8 @@ class _ScrubberEditor ( Editor ):
     def _text_completed ( self, event ):
         """ Handles the user pressing the 'Enter' key in the text control.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         if self._update_value( event ):
             self._destroy_text()
 

--- a/traitsui/wx/text_editor.py
+++ b/traitsui/wx/text_editor.py
@@ -118,6 +118,11 @@ class SimpleEditor ( Editor ):
     def update_object ( self, event ):
         """ Handles the user entering input data in the edit control.
         """
+        if isinstance(event, wx.FocusEvent):
+            # Ensure that the base class' focus event handlers are run, some
+            # built-in behavior may break on some platforms otherwise.
+            event.Skip()
+
         if (not self._no_update) and (self.control is not None):
             try:
                 self.value = self._get_user_value()

--- a/traitsui/wx/themed_slider_editor.py
+++ b/traitsui/wx/themed_slider_editor.py
@@ -419,6 +419,8 @@ class _ThemedSliderEditor ( Editor ):
     def _text_completed ( self, event ):
         """ Handles the user pressing the 'Enter' key in the text control.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         if self._update_value( event ):
             self._destroy_text()
 

--- a/traitsui/wx/themed_text_editor.py
+++ b/traitsui/wx/themed_text_editor.py
@@ -445,6 +445,8 @@ class _ThemedTextEditor ( Editor ):
     def _text_completed ( self, event ):
         """ Handles the user transferring focus out of the text control.
         """
+        if isinstance(event, wx.FocusEvent):
+            event.Skip()
         if self.update_object( event ):
             self._destroy_text()
 


### PR DESCRIPTION
`Skip()` should always be called for kill-focus events of native widgets, especially `wx.TextCtrl`s.

Not calling Skip for these events is one of those things that may accidentally work in some cases, but was never the correct thing to do unless it is a generic widget or you are overriding all the native behavior.

See https://enthought.zendesk.com/agent/tickets/63321 for an example of breakage with wxPython 3.0.

Fixes #282