### PR TITLE
Fix TypeError in Python3

### DIFF
--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -454,7 +454,7 @@ class RadioEditor(BaseEditor):
                     self.set_tooltip(rb)
                     layout.addWidget(rb, i, j)
 
-                    index += incr[j]
+                    index += int(round(incr[j]))
                     n -= 1
 
     #-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes "TypeError: list indices must be integers or slices, not float"

``incr`` is a list of floats due to its computation. In python3 floats cannot be used for indexing.


