### PR TITLE
Fix Qt table model drop mime typo

### DIFF
--- a/traitsui/qt4/table_model.py
+++ b/traitsui/qt4/table_model.py
@@ -275,7 +275,7 @@ class TableModel(QtCore.QAbstractTableModel):
                 if not parent.isValid():
                     row = len(self._editor.items()) - 1
                 else:
-                    row == parent.row()
+                    row = parent.row()
 
                 self.moveRows(current_rows, row)
                 return True


### PR DESCRIPTION
Dragging and dropping fails for Qt tables, this clearly looks like a typo.