### PR TITLE
Replace file with open in a few places

### DIFF
--- a/traitsui/file_dialog.py
+++ b/traitsui/file_dialog.py
@@ -255,7 +255,7 @@ class TextInfo(MFileDialogModel):
             if getsize(self.file_name) > MAX_SIZE:
                 return 'File too big...'
 
-            fh = file(self.file_name, 'rb')
+            fh = open(self.file_name, 'rb')
             data = fh.read()
             fh.close()
         except:

--- a/traitsui/image/image.py
+++ b/traitsui/image/image.py
@@ -124,7 +124,7 @@ ImageInfoTemplate = \
 def read_file(file_name):
     """ Returns the contents of the specified *file_name*.
     """
-    fh = file(file_name, 'rb')
+    fh = open(file_name, 'rb')
     try:
         return fh.read()
     finally:
@@ -138,7 +138,7 @@ def read_file(file_name):
 def write_file(file_name, data):
     """ Writes the specified data to the specified file.
     """
-    fh = file(file_name, 'wb')
+    fh = open(file_name, 'wb')
     try:
         fh.write(data)
     finally:
@@ -914,7 +914,7 @@ class ZipFileReference(ResourceReference):
 
             # Write the image data to the cache file:
             cache_file = join(cache_dir, self.file_name)
-            fh = file(cache_file, 'wb')
+            fh = open(cache_file, 'wb')
             try:
                 fh.write(data)
             finally:

--- a/traitsui/wx/dnd_editor.py
+++ b/traitsui/wx/dnd_editor.py
@@ -222,7 +222,7 @@ class SimpleEditor(Editor):
         """
         fh = None
         try:
-            fh = file(file_name, 'rb')
+            fh = open(file_name, 'rb')
             object = load(fh)
         except:
             object = None


### PR DESCRIPTION
Fixes #297.

The `2to3` infrastructure apparently doesn't auto-replace uses of `file` with `open` (probably because they aren't equivalent in some versions of Python 2).  This PR does a manual removal of all uses of `file`.