### PR TITLE
Fix comment saying vertical springs don't work

### DIFF
--- a/examples/demo/Useful/using_springs.py
+++ b/examples/demo/Useful/using_springs.py
@@ -50,8 +50,7 @@ class SpringDemo(HasTraits):
                    'with springs after the 2nd and 4th '
                    'buttons'),
             spring,
-            Label('But spring in vertical group does not move '
-                  'widget down at present.'),
+            Label('A spring in a vertical group moves widget down.'),
             button
         ),
         width=600,

--- a/examples/demo/Useful/using_springs.py
+++ b/examples/demo/Useful/using_springs.py
@@ -50,7 +50,8 @@ class SpringDemo(HasTraits):
                    'with springs after the 2nd and 4th '
                    'buttons'),
             spring,
-            Label('A spring in a vertical group moves widget down.'),
+            Label('Spring in vertical group moves widget down '
+                  '(does not work on Wx backend).'),
             button
         ),
         width=600,


### PR DESCRIPTION
The `using_springs` demo mentioned that using a Spring didn't move
widgets down, but it actually does. This updates the statement to say
that it works.

"Proof" that it works:

![screen shot 2016-12-09 at 15 15 47](https://cloud.githubusercontent.com/assets/479013/21064774/66bf221c-be22-11e6-9617-23ce0770488d.png)
