### PR TITLE
Properly handle dialog lifecycle for simple InstanceEditor

### DIFF
--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -515,7 +515,8 @@ class SimpleEditor(CustomEditor):
         view = self.ui.handler.trait_view_for(self.ui.info, factory.view,
                                               self.value, self.object_name,
                                               self.name)
-        self._dialog_ui = self.value.edit_traits(view, kind=factory.kind, id=factory.id)
+        self._dialog_ui = self.value.edit_traits(view, kind=factory.kind,
+                                                 id=factory.id)
 
         # Check to see if the view was 'modal', in which case it will already
         # have been closed (i.e. is None) by the time we get control back:

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -529,7 +529,6 @@ class SimpleEditor(CustomEditor):
                 self._dialog_ui.history = self.ui.history
 
         else:
-            self._button.destroyed.disconnect(self._parent_closed)
             self._dialog_ui = None
 
     #-------------------------------------------------------------------------

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -21,7 +21,7 @@
 from pyface.qt import QtCore, QtGui
 
 from traits.api \
-    import HasTraits, Property
+    import HasTraits, Instance, Property
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
 # compatibility. The class has been moved to the
@@ -481,6 +481,9 @@ class SimpleEditor(CustomEditor):
     the button displays a dialog box in which the instance can be edited.
     """
 
+    #: The ui instance for the currently open editor dialog
+    _dialog_ui = Instance('traitsui.ui.UI')
+
     # Class constants:
     orientation = QtGui.QBoxLayout.LeftToRight
     extra = 2
@@ -496,6 +499,8 @@ class SimpleEditor(CustomEditor):
         layout.addWidget(self._button)
         QtCore.QObject.connect(self._button, QtCore.SIGNAL('clicked()'),
                                self.edit_instance)
+        # Make sure the editor is properly disposed if parent UI is closed
+        self._button.destroyed.connect(self._parent_closed)
 
     #-------------------------------------------------------------------------
     #  Edit the contents of the object trait when the user clicks the button:
@@ -510,21 +515,22 @@ class SimpleEditor(CustomEditor):
         view = self.ui.handler.trait_view_for(self.ui.info, factory.view,
                                               self.value, self.object_name,
                                               self.name)
-        ui = self.value.edit_traits(view, kind=factory.kind, id=factory.id)
-
-        # Make sure the editor is properly disposed
-        self._button.destroyed.connect(ui.dispose)
+        self._dialog_ui = self.value.edit_traits(view, kind=factory.kind, id=factory.id)
 
         # Check to see if the view was 'modal', in which case it will already
         # have been closed (i.e. is None) by the time we get control back:
-        if ui.control is not None:
+        if self._dialog_ui.control is not None:
             # Position the window on the display:
-            position_window(ui.control)
+            position_window(self._dialog_ui.control)
 
             # Chain our undo history to the new user interface if it does not
             # have its own:
-            if ui.history is None:
-                ui.history = self.ui.history
+            if self._dialog_ui.history is None:
+                self._dialog_ui.history = self.ui.history
+
+        else:
+            self._button.destroyed.disconnect(self._parent_closed)
+            self._dialog_ui = None
 
     #-------------------------------------------------------------------------
     #  Resynchronizes the contents of the editor when the object trait changes
@@ -543,3 +549,10 @@ class SimpleEditor(CustomEditor):
 
             button.setText(label)
             button.setEnabled(isinstance(self.value, HasTraits))
+
+    def _parent_closed(self):
+        if self._dialog_ui is not None:
+            if self._dialog_ui.control is not None:
+                self._dialog_ui.control.close()
+            self._dialog_ui.dispose()
+            self._dialog_ui = None

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -17,8 +17,6 @@ class NonmodalInstanceEditor(HasTraits):
 
 @skip_if_not_qt4
 def test_simple_editor():
-    from pyface import qt
-
     with store_exceptions_on_all_threads():
         obj = NonmodalInstanceEditor()
         ui = obj.edit_traits()
@@ -36,8 +34,6 @@ def test_simple_editor():
 
 @skip_if_not_qt4
 def test_simple_editor_parent_closed():
-    from pyface import qt
-
     with store_exceptions_on_all_threads():
         obj = NonmodalInstanceEditor()
         ui = obj.edit_traits()

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,7 +1,8 @@
 from traits.api import HasTraits, Instance, Str
 from traitsui.item import Item
 from traitsui.view import View
-from traitsui.tests._tools import press_ok_button, store_exceptions_on_all_threads, skip_if_not_qt4
+from traitsui.tests._tools import (
+    press_ok_button, skip_if_not_qt4, store_exceptions_on_all_threads)
 
 
 class EditedInstance(HasTraits):

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,0 +1,49 @@
+from traits.api import HasTraits, Instance, Str
+from traitsui.item import Item
+from traitsui.view import View
+from traitsui.tests._tools import press_ok_button, store_exceptions_on_all_threads, skip_if_not_qt4
+
+
+class EditedInstance(HasTraits):
+    value = Str
+    traits_view = View(Item('value'), buttons=['OK'])
+
+
+class NonmodalInstanceEditor(HasTraits):
+    inst = Instance(EditedInstance, ())
+    traits_view = View(Item('inst', style='simple'), buttons=['OK'])
+
+
+@skip_if_not_qt4
+def test_simple_editor():
+    from pyface import qt
+
+    with store_exceptions_on_all_threads():
+        obj = NonmodalInstanceEditor()
+        ui = obj.edit_traits()
+        editor = ui.get_editors('inst')[0]
+
+        # make the dialog appear
+        editor._button.click()
+
+        # close the ui dialog
+        press_ok_button(editor._dialog_ui)
+
+        # close the main ui
+        press_ok_button(ui)
+
+
+@skip_if_not_qt4
+def test_simple_editor_parent_closed():
+    from pyface import qt
+
+    with store_exceptions_on_all_threads():
+        obj = NonmodalInstanceEditor()
+        ui = obj.edit_traits()
+        editor = ui.get_editors('inst')[0]
+
+        # make the dialog appear
+        editor._button.click()
+
+        # close the main ui
+        press_ok_button(ui)


### PR DESCRIPTION
Fixes #331.  The change keeps the sub-dialog UI around so that clean-up can be done for the non-modal version.  This distinctly simplifies the handling of the case where the editor is destroyed before the user closes the child UI.