### PR TITLE
Group builds in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - env: RUNTIME=2.7 TOOLKITS="wx"
     - env: RUNTIME=3.5 TOOLKITS="null pyqt"
     - os: osx
-      env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
+      env: RUNTIME=2.7 TOOLKITS="null pyside wx"
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt"
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@ language: generic
 sudo: false
 matrix:
   include:
-    - env: RUNTIME=2.7 TOOLKITS=null pyqt pyside
-    - env: RUNTIME=2.7 TOOLKITS=wx
-    - env: RUNTIME=3.5 TOOLKITS=null pyqt
+    - env: RUNTIME=2.7 TOOLKITS="null pyqt pyside"
+    - env: RUNTIME=2.7 TOOLKITS="wx"
+    - env: RUNTIME=3.5 TOOLKITS="null pyqt"
     - os: osx
-      env: RUNTIME=2.7 TOOLKITS=null pyqt pyside wx
+      env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
     - os: osx
-      env: RUNTIME=2.7 TOOLKITS=pyqt
+      env: RUNTIME=2.7 TOOLKITS="pyqt"
     - os: osx
-      env: RUNTIME=3.5 TOOLKIT=null pyqt wx
+      env: RUNTIME=3.5 TOOLKIT="null pyqt wx"
   allow_failures:
-    - env: RUNTIME=2.7 TOOLKIT=wx
+    - env: RUNTIME=2.7 TOOLKIT="wx"
     - os: osx
-      env: RUNTIME=2.7 TOOLKIT=pyqt
+      env: RUNTIME=2.7 TOOLKIT="pyqt"
   fast_finish: true
 cache:
   directories:
@@ -24,10 +24,10 @@ before_install:
   - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start ; fi
 install:
   - ./travis_ci_bootstrap_edm.sh
-  - for toolkit in ${TOOLKITS}; do edm run -- invoke install --runtime=${RUNTIME} --toolkit=${TOOLKIT}; done
+  - for toolkit in ${TOOLKITS}; do edm run -- invoke install --runtime=${RUNTIME} --toolkit=${toolkit}; done
 
 script:
-  - for toolkit in ${TOOLKITS}; do edm run -- invoke test --runtime=${RUNTIME} --toolkit=${TOOLKIT}; done
+  - for toolkit in ${TOOLKITS}; do edm run -- invoke test --runtime=${RUNTIME} --toolkit=${toolkit}; done
 after_success:
   - edm run -- pip install codecov
   - edm run -- codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ matrix:
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt"
     - os: osx
-      env: RUNTIME=3.5 TOOLKIT="null pyqt wx"
+      env: RUNTIME=3.5 TOOLKITS="null pyqt wx"
   allow_failures:
-    - env: RUNTIME=2.7 TOOLKIT="wx"
+    - env: RUNTIME=2.7 TOOLKITS="wx"
     - os: osx
-      env: RUNTIME=2.7 TOOLKIT="pyqt"
+      env: RUNTIME=2.7 TOOLKITS="pyqt"
   fast_finish: true
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ sudo: false
 matrix:
   include:
     - env: RUNTIME=2.7 TOOLKITS="null pyqt pyside"
-    - env: RUNTIME=2.7 TOOLKITS="wx"
     - env: RUNTIME=3.5 TOOLKITS="null pyqt"
     - os: osx
-      env: RUNTIME=2.7 TOOLKITS="null pyside wx"
-    - os: osx
-      env: RUNTIME=2.7 TOOLKITS="pyqt"
+      env: RUNTIME=2.7 TOOLKITS="null pyside"
     - os: osx
       env: RUNTIME=3.5 TOOLKITS="null pyqt"
+    - env: RUNTIME=2.7 TOOLKITS="wx"
+    - os: osx
+      env: RUNTIME=2.7 TOOLKITS="pyqt wx"
   allow_failures:
     - env: RUNTIME=2.7 TOOLKITS="wx"
     - os: osx
-      env: RUNTIME=2.7 TOOLKITS="pyqt"
+      env: RUNTIME=2.7 TOOLKITS="pyqt wx"
   fast_finish: true
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,15 @@ language: generic
 sudo: false
 matrix:
   include:
-    - env: RUNTIME=2.7 TOOLKIT=null
-    - env: RUNTIME=2.7 TOOLKIT=pyqt
-    - env: RUNTIME=2.7 TOOLKIT=pyside
-    - env: RUNTIME=2.7 TOOLKIT=wx
-    - env: RUNTIME=3.5 TOOLKIT=null
-    - env: RUNTIME=3.5 TOOLKIT=pyqt
+    - env: RUNTIME=2.7 TOOLKITS=null pyqt pyside
+    - env: RUNTIME=2.7 TOOLKITS=wx
+    - env: RUNTIME=3.5 TOOLKITS=null pyqt
     - os: osx
-      env: RUNTIME=2.7 TOOLKIT=null
+      env: RUNTIME=2.7 TOOLKITS=null pyqt pyside wx
     - os: osx
-      env: RUNTIME=2.7 TOOLKIT=pyqt
+      env: RUNTIME=2.7 TOOLKITS=pyqt
     - os: osx
-      env: RUNTIME=2.7 TOOLKIT=pyside
-    - os: osx
-      env: RUNTIME=2.7 TOOLKIT=wx
-    - os: osx
-      env: RUNTIME=3.5 TOOLKIT=null
-    - os: osx
-      env: RUNTIME=3.5 TOOLKIT=pyqt
+      env: RUNTIME=3.5 TOOLKIT=null pyqt wx
   allow_failures:
     - env: RUNTIME=2.7 TOOLKIT=wx
     - os: osx
@@ -31,11 +22,12 @@ cache:
 before_install:
   - export DISPLAY=:99.0
   - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start ; fi
-  - ./travis_ci_bootstrap_edm.sh
 install:
-  - edm run -- invoke install --runtime=${RUNTIME} --toolkit=${TOOLKIT}
+  - ./travis_ci_bootstrap_edm.sh
+  - for toolkit in ${TOOLKITS}; do edm run -- invoke install --runtime=${RUNTIME} --toolkit=${TOOLKIT}; done
+
 script:
-  - edm run -- invoke test --runtime=${RUNTIME} --toolkit=${TOOLKIT}
+  - for toolkit in ${TOOLKITS}; do edm run -- invoke test --runtime=${RUNTIME} --toolkit=${TOOLKIT}; done
 after_success:
   - edm run -- pip install codecov
   - edm run -- codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 install:
   - ./travis_ci_bootstrap_edm.sh
   - for toolkit in ${TOOLKITS}; do edm run -- invoke install --runtime=${RUNTIME} --toolkit=${toolkit}; done
-
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- invoke test --runtime=${RUNTIME} --toolkit=${toolkit}; done
 after_success:
+  - edm run -- coverage combine
   - edm run -- pip install codecov
   - edm run -- codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt"
     - os: osx
-      env: RUNTIME=3.5 TOOLKITS="null pyqt wx"
+      env: RUNTIME=3.5 TOOLKITS="null pyqt"
   allow_failures:
     - env: RUNTIME=2.7 TOOLKITS="wx"
     - os: osx

--- a/tasks.py
+++ b/tasks.py
@@ -235,15 +235,17 @@ def do_in_tempdir(files=(), capture_files=()):
 
     # send across any files we need
     for filepath in files:
+        print('copying file to tempdir: {}'.format(filepath))
         copyfile(filepath, path)
 
     os.chdir(path)
     try:
         yield path
 
-        # retrieve any result files we want
+        retrieve any result files we want
         for pattern in capture_files:
             for filepath in glob.iglob(pattern):
+                print('copying file back: {}'.format(filepath))
                 copyfile(filepath, old_path)
     finally:
         os.chdir(old_path)

--- a/tasks.py
+++ b/tasks.py
@@ -242,7 +242,7 @@ def do_in_tempdir(files=(), capture_files=()):
     try:
         yield path
 
-        retrieve any result files we want
+        # retrieve any result files we want
         for pattern in capture_files:
             for filepath in glob.iglob(pattern):
                 print('copying file back: {}'.format(filepath))

--- a/tasks.py
+++ b/tasks.py
@@ -64,6 +64,7 @@ how to run commands within an EDM enviornment.
 """
 
 from contextlib import contextmanager
+import glob
 import os
 from shutil import rmtree, copy as copyfile
 from tempfile import mkdtemp
@@ -151,7 +152,7 @@ def test(ctx, runtime='3.5', toolkit='null', environment=None):
     # code from a local dir.  We need to ensure a good .coveragerc is in
     # that directory, plus coverage has a bug that means a non-local coverage
     # file doesn't get populated correctly.
-    with do_in_tempdir(files=['.coveragerc'], capture_files=['.coverage*']):
+    with do_in_tempdir(files=['.coveragerc'], capture_files=['./.coverage*']):
         for command in commands:
             ctx.run(command.format(**parameters), env=environ)
 
@@ -241,8 +242,9 @@ def do_in_tempdir(files=(), capture_files=()):
         yield path
 
         # retrieve any result files we want
-        for filepath in capture_files:
-            copyfile(filepath, old_path)
+        for pattern in capture_files:
+            for filepath in glob.iglob(pattern):
+                copyfile(filepath, old_path)
     finally:
         os.chdir(old_path)
         rmtree(path)

--- a/tasks.py
+++ b/tasks.py
@@ -142,7 +142,7 @@ def test(ctx, runtime='3.5', toolkit='null', environment=None):
     if toolkit in {'pyqt', 'pyside'}:
         commands += [
             # run the qt4 toolkit test suite
-            "edm run -e '{environment}' -- coverage run -m nose.core -v traitsui.qt4.tests"
+            "edm run -e '{environment}' -- coverage run -p -m nose.core -v traitsui.qt4.tests"
         ]
 
     # run tests & coverage

--- a/tasks.py
+++ b/tasks.py
@@ -136,7 +136,7 @@ def test(ctx, runtime='3.5', toolkit='null', environment=None):
 
     commands = [
         # run the main test suite
-        "edm run -e '{environment}' -- coverage run -m nose.core -v traitsui.tests",
+        "edm run -e '{environment}' -- coverage run -p -m nose.core -v traitsui.tests",
     ]
     if toolkit in {'pyqt', 'pyside'}:
         commands += [
@@ -151,7 +151,7 @@ def test(ctx, runtime='3.5', toolkit='null', environment=None):
     # code from a local dir.  We need to ensure a good .coveragerc is in
     # that directory, plus coverage has a bug that means a non-local coverage
     # file doesn't get populated correctly.
-    with do_in_tempdir(files=['.coveragerc'], capture_files=['.coverage']):
+    with do_in_tempdir(files=['.coveragerc'], capture_files=['.coverage*']):
         for command in commands:
             ctx.run(command.format(**parameters), env=environ)
 

--- a/travis_ci_bootstrap_edm.sh
+++ b/travis_ci_bootstrap_edm.sh
@@ -12,4 +12,4 @@ else
 fi
 
 # install pip and invoke into default EDM environment
-edm install -y pip invoke
+edm install -y pip invoke coverage


### PR DESCRIPTION
This PR goups the builds in travis based on the used runtime to reduce the cache size

In more details

- There are 6 ( < 9) builds now
- The retrieve files functionality now support glob patterns
- Coverage is combined at the end of the build so that we still get the right combined coverage in codecov
