### PR TITLE
Fix regression from removing old-style signals & slots

### DIFF
--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -191,7 +191,7 @@ class SimpleEditor(BaseEditor):
         self.control = control = self.create_combo_box()
         control.addItems(self.names)
 
-        control.currentIndexChanged.connect(self.update_object)
+        control.currentIndexChanged[str].connect(self.update_object)
 
         if self.factory.evaluate is not None:
             control.setEditable(True)


### PR DESCRIPTION
Enum editor was using the wrong typed version of the `QComboBox` `currentIndexChanged` signal.  This is a regression introduced by #330.