### PR TITLE
fix for use with qt5, QPixmapCache

### DIFF
--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -26,6 +26,8 @@ from traits.api import Enum, CTrait, BaseTraitHandler, TraitError
 
 from traitsui.ui_traits import SequenceTypes
 
+is_qt5 = QtCore.__version_info__ >= (5,)
+
 #-------------------------------------------------------------------------
 #  Trait definitions:
 #-------------------------------------------------------------------------
@@ -59,10 +61,16 @@ def pixmap_cache(name, path=None):
             filename = os.path.join(path, name)
     filename = os.path.abspath(filename)
 
-    pm = QtGui.QPixmap()
-    if not QtGui.QPixmapCache.find(filename, pm):
-        pm.load(filename)
-        QtGui.QPixmapCache.insert(filename, pm)
+    if is_qt5:
+        pm = QtGui.QPixmapCache.find(filename)
+        if pm is None:
+            pm = QtGui.QPixmap(filename)
+            QtGui.QPixmapCache.insert(filename, pm)
+    else:
+        pm = QtGui.QPixmap()
+        if not QtGui.QPixmapCache.find(filename, pm):
+            pm.load(filename)
+            QtGui.QPixmapCache.insert(filename, pm)
     return pm
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

this PR fixes failure with Qt5, e.g. for examples/demo/Standard_Editors/ListEditor_demo.py

With PyQt5 (tested with 5.6.0 from conda) QPixmapCache has a slightly different API.