### PR TITLE
Fix setting button label from another traits in CustomEditor

### DIFF
--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -149,7 +149,10 @@ class CustomEditor(SimpleEditor):
         # FIXME: We ignore orientation, width_padding and height_padding.
 
         factory = self.factory
-        label  = factory.label or self.item.get_label(self.ui)
+        if factory.label:
+            label = factory.label
+        else:
+            label = self.item.get_label(self.ui)
         btype = self._STYLE_MAP.get(factory.style, QtGui.QPushButton)
         self.control = btype()
         self.control.setText(self.string_value(label))

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -149,13 +149,14 @@ class CustomEditor(SimpleEditor):
         # FIXME: We ignore orientation, width_padding and height_padding.
 
         factory = self.factory
-
+        label  = factory.label or self.item.get_label(self.ui)
         btype = self._STYLE_MAP.get(factory.style, QtGui.QPushButton)
         self.control = btype()
-        self.control.setText(self.string_value(factory.label))
+        self.control.setText(self.string_value(label))
 
         if factory.image is not None:
             self.control.setIcon(factory.image.create_icon())
 
+        self.sync_value(self.factory.label_value, 'label', 'from')
         self.control.clicked.connect(self.update_object)
         self.set_tooltip()

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -1,0 +1,74 @@
+import unittest
+
+from pyface.gui import GUI
+
+from traits.api import Button, HasTraits, Unicode
+from traitsui.api import ButtonEditor, Item, UItem, View
+from traitsui.tests._tools import (
+    is_current_backend_qt4, is_current_backend_wx, skip_if_null,
+    store_exceptions_on_all_threads)
+
+
+class ButtonTextEdit(HasTraits):
+
+    play_button = Button("Play")
+
+    play_button_label = Unicode("I'm a play button")
+
+
+simple_view = View(
+    UItem(
+        'play_button',
+        editor=ButtonEditor(label_value="play_button_label"),
+    ),
+    Item('play_button_label'),
+    resizable=True,
+)
+
+
+custom_view = View(
+    UItem(
+        'play_button',
+        editor=ButtonEditor(label_value="play_button_label"),
+    ),
+    Item('play_button_label'),
+    resizable=True,
+    style='custom',
+)
+
+
+def get_button_text(button):
+    """ Return the button text given a button control """
+    if is_current_backend_wx():
+        return button.GetLabel()
+
+    elif is_current_backend_qt4():
+        return button.text()
+
+
+class TestButtonEditor(unittest.TestCase):
+
+    def check_button_text_update(self, view):
+        gui = GUI()
+        button_text_edit = ButtonTextEdit()
+
+        with store_exceptions_on_all_threads():
+            ui = button_text_edit.edit_traits(view=view)
+            self.addCleanup(ui.dispose)
+
+            gui.process_events()
+            editor, = ui.get_editors("play_button")
+            button = editor.control
+
+            self.assertEqual(get_button_text(button), "I'm a play button")
+
+            button_text_edit.play_button_label = "New Label"
+            self.assertEqual(get_button_text(button), "New Label")
+
+    @skip_if_null
+    def test_simple_button_editor(self):
+        self.check_button_text_update(simple_view)
+
+    @skip_if_null
+    def test_custom_button_editor(self):
+        self.check_button_text_update(custom_view)

--- a/traitsui/wx/button_editor.py
+++ b/traitsui/wx/button_editor.py
@@ -133,9 +133,11 @@ class CustomEditor(SimpleEditor):
         from pyface.image_button import ImageButton
 
         factory = self.factory
+        label = self.factory.label or self.item.get_label(self.ui)
+
         self._control = ImageButton(
             parent,
-            label=self.string_value(factory.label),
+            label=self.string_value(label),
             image=factory.image,
             style=factory.style,
             orientation=factory.orientation,
@@ -145,6 +147,8 @@ class CustomEditor(SimpleEditor):
         self.control = self._control.control
         self._control.on_trait_change(self.update_object, 'clicked',
                                       dispatch='ui')
+        self.sync_value(self.factory.label_value, 'label', 'from')
+
         self.set_tooltip()
 
     #-------------------------------------------------------------------------

--- a/traitsui/wx/button_editor.py
+++ b/traitsui/wx/button_editor.py
@@ -133,7 +133,10 @@ class CustomEditor(SimpleEditor):
         from pyface.image_button import ImageButton
 
         factory = self.factory
-        label = self.factory.label or self.item.get_label(self.ui)
+        if self.factory.label:
+            label = self.factory.label
+        else:
+            label = self.item.get_label(self.ui)
 
         self._control = ImageButton(
             parent,


### PR DESCRIPTION
Fix #355.

- Get label from editor factory or the UI label
- Synchronize button label