### PR TITLE
Remove an unused argument to wx.hook_events.

### DIFF
--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -389,8 +389,7 @@ class GUIToolkit(Toolkit):
     #  routed to the correct event handler:
     #-------------------------------------------------------------------------
 
-    def hook_events(self, ui, control, events=None, handler=None,
-                    drop_target=None):
+    def hook_events(self, ui, control, events=None, handler=None):
         """ Hooks all specified events for all controls in a UI so that they
             can be routed to the correct event handler.
         """
@@ -428,7 +427,7 @@ class GUIToolkit(Toolkit):
         control.PushEventHandler(event_handler)
 
         for child in control.GetChildren():
-            self.hook_events(ui, child, events, handler, drop_target)
+            self.hook_events(ui, child, events, handler)
 
     #-------------------------------------------------------------------------
     #  Routes a 'hooked' event to the correct handler method:


### PR DESCRIPTION
Drive-by cleanup: removes the unused `drop_target` argument to `GUIToolkit.hook_events` for the wx backend. This also makes the API consistent between the wx backend and the Qt backend.