### PR TITLE
TabularEditor: don't raise when failing to find `None`.

### DIFF
--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -353,8 +353,10 @@ class TabularEditor(Editor):
             try:
                 selected_row = self.value.index(new)
             except Exception as e:
-                from traitsui.api import raise_to_debug
-                raise_to_debug()
+                # It's not exceptional for new to be None
+                if new is not None:
+                    from traitsui.api import raise_to_debug
+                    raise_to_debug()
             else:
                 self._selected_row_changed(selected_row)
 


### PR DESCRIPTION
It's normal for the TabularEditor's `selected` trait to be `None`, both at initialization time and when the current selection is cleared. Don't propagate an error in that case.

Fixes #366.