### PR TITLE
Cleanup: Fix a broken try/finally pattern in a test.

### DIFF
--- a/traitsui/tests/test_tuple_editor.py
+++ b/traitsui/tests/test_tuple_editor.py
@@ -40,13 +40,12 @@ class TestTupleEditor(UnittestTools, unittest.TestCase):
     def test_value_update(self):
         # Regression test for #179
         model = DummyModel()
+        ui = model.edit_traits()
         try:
-            ui = model.edit_traits()
             with self.assertTraitChanges(model, 'data', count=1):
                 model.data = (3, 4.6, 'nono')
         finally:
-            if ui is not None:
-                ui.dispose()
+            ui.dispose()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A drive-by cleanup: in the original code, if `model.edit_traits()` fails, a `NameError` for `ui` will be raised in the `finally` clause, obscuring (or replacing, in Python 2) the original traceback.

Also removes the unnecessary `ui is not None` check: `ui` will either be a `UI` object, or undefined.