### PR TITLE
fix bug in update_object function

### DIFF
--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -99,6 +99,7 @@ class SimpleEditor(EditorWithList):
         self.values = valid_values = [x[0] for x in values]
         self.names = [x[1] for x in values]
 
+
         # Make sure the current value is still legal:
         modified = False
         cur_value = parse_value(self.value)
@@ -137,7 +138,7 @@ class SimpleEditor(EditorWithList):
     def update_object(self, text):
         """ Handles the user selecting a new value from the combo box.
         """
-        value = self.values[self.names.index(unicode(text))]
+        value = self.values[text]
         if not isinstance(self.value, basestring):
             value = [value]
         self.value = value


### PR DESCRIPTION
#378 fixed the exception thrown when choosing the values from the dropdown

We found that the text variable is ok to use instead of calling the index of the value.