### PR TITLE
Improve TraitsUI Action handling

### DIFF
--- a/docs/source/traitsui_user_manual/handler.rst
+++ b/docs/source/traitsui_user_manual/handler.rst
@@ -15,12 +15,12 @@ GUI events, i.e., for events that are generated through or by the program
 interface. Such events can require changes to one or more model objects (e.g.,
 because a data value has been updated) or manipulation of the interface itself
 (e.g., window closure, dynamic interface behavior). In TraitsUI, such actions
-are performed by a Handler object. 
+are performed by a Handler object.
 
 In the preceding examples in this guide, the Handler object has been implicit:
 TraitsUI provides a default Handler that takes care of a common set of GUI
 events including window initialization and closure, data value updates, and
-button press events for the standard TraitsUI window buttons (see 
+button press events for the standard TraitsUI window buttons (see
 :ref:`command-buttons-the-buttons-attribute`).
 
 This chapter explains the features of the TraitsUI Handler, and shows how to
@@ -45,14 +45,14 @@ means of the UIInfo object.
 
 Whenever TraitsUI creates a window or panel from a View, a UIInfo object is
 created to act as the Handler's reference to that window and to the objects
-whose :term:`trait attribute`\ s are displayed in it. Each entry in the View's 
-context (see :ref:`the-view-context`) becomes an attribute of the UIInfo 
-object. [12]_ For example, the UIInfo object created in 
-:ref:`Example 7 <example-7-using-a-multi-object-view-with-a-context>` 
+whose :term:`trait attribute`\ s are displayed in it. Each entry in the View's
+context (see :ref:`the-view-context`) becomes an attribute of the UIInfo
+object. [12]_ For example, the UIInfo object created in
+:ref:`Example 7 <example-7-using-a-multi-object-view-with-a-context>`
 has attributes **h1** and **h2** whose values are the objects **house1** and
 **house2** respectively. In :ref:`Example 1 <example-1-using-configure-traits>`
-through 
-:ref:`Example 6 <example-6-defining-multiple-view-objects-in-a-hastraits-class>`, 
+through
+:ref:`Example 6 <example-6-defining-multiple-view-objects-in-a-hastraits-class>`,
 the created UIInfo object has an attribute **object** whose value is the object
 **sam**.
 
@@ -81,8 +81,8 @@ Binding a Singleton Handler to a View
 
 To associate a given custom Handler with all windows produced from a given View,
 assign an instance of the custom Handler class to the View's **handler**
-attribute. The result of this technique, as shown in 
-:ref:`Example 9 <example-9-using-a-handler-that-reacts-to-trait-changes>`, is 
+attribute. The result of this technique, as shown in
+:ref:`Example 9 <example-9-using-a-handler-that-reacts-to-trait-changes>`, is
 that the window created by the View object is automatically controlled by the
 specified handler instance.
 
@@ -131,9 +131,9 @@ application.
 Both ModelView and Controller extend the Handler class by adding the following
 trait attributes:
 
-- **model**: The model object for which this handler defines a view and 
+- **model**: The model object for which this handler defines a view and
   controller.
-- **info**: The UIInfo object associated with the actual user interface window 
+- **info**: The UIInfo object associated with the actual user interface window
   or panel for the model object.
 
 The **model** attribute provides convenient access to the model object
@@ -223,12 +223,12 @@ are called.
 
 1. A UIInfo object is created
 2. The Handler's init_info() method is called. Override this method if the
-   handler needs access to viewable traits on the UIInfo object whose values 
+   handler needs access to viewable traits on the UIInfo object whose values
    are properties that depend on items in the context being edited.
 3. The UI object is created, and generates the actual window.
 4. The init() method is called. Override this method if you need to initialize
-   or customize the window. 
-   
+   or customize the window.
+
 .. TODO: Add a non-trivial example here.
 
 5. The position() method is called. Override this method to modify the position
@@ -278,6 +278,11 @@ are called.
 |                           |                          |global help handler,   |
 |                           |                          |for this window.       |
 +---------------------------+--------------------------+-----------------------+
+|perform(info, action,      |The user clicks a button  |To change the way that |
+|event)                     |or toolbar item, or       |actions are handled,   |
+|                           |selects a menu item.      |eg. to pass more info  |
+|                           |                          |to a method.           |
++---------------------------+--------------------------+-----------------------+
 
 .. _reacting-to-trait-changes:
 
@@ -303,30 +308,30 @@ have been replaced by underscores. For example, for a method to handle changes
 on the **salary** attribute of the object whose context key is 'object' (the
 default object), the method name should be object_salary_changed().
 
-By contrast, a subclass of Handler for 
-:ref:`Example 7 <example-7-using-a-multi-object-view-with-a-context>` might 
+By contrast, a subclass of Handler for
+:ref:`Example 7 <example-7-using-a-multi-object-view-with-a-context>` might
 include a method called h2_price_changed() to be called whenever the price of
-the second house is edited. 
+the second house is edited.
 
 .. note:: These methods are called on window creation.
 
-   User interface notification methods are called when the window is first 
-   created. 
+   User interface notification methods are called when the window is first
+   created.
 
 To differentiate between code that should be executed when the window is first
 initialized and code that should be executed when the trait actually changes,
-use the **initialized** attribute of the UIInfo object (i.e., of the *info* 
+use the **initialized** attribute of the UIInfo object (i.e., of the *info*
 argument)::
 
     def object_foo_changed(self, info):
-    
+
         if not info.initialized:
-            #code to be executed only when the window is 
+            #code to be executed only when the window is
             #created
         else:
-            #code to be executed only when 'foo' changes after    
+            #code to be executed only when 'foo' changes after
             #window initialization}
-    
+
         #code to be executed in either case
 
 The following script, which annotates its window's title with an asterisk ('*')
@@ -339,43 +344,43 @@ overridden setattr() method and user interface notification method.
 
 ::
 
-    # handler_override.py -- Example of a Handler that overrides 
-    #                        setattr(), and that has a user interface 
+    # handler_override.py -- Example of a Handler that overrides
+    #                        setattr(), and that has a user interface
     #                        notification method
-    
+
     from traits.api import HasTraits, Bool
     from traitsui.api import View, Handler
-    
+
     class TC_Handler(Handler):
-    
+
         def setattr(self, info, object, name, value):
             Handler.setattr(self, info, object, name, value)
             info.object._updated = True
-    
+
         def object__updated_changed(self, info):
             if info.initialized:
                 info.ui.title += "*"
-    
+
     class TestClass(HasTraits):
         b1 = Bool
         b2 = Bool
         b3 = Bool
         _updated = Bool(False)
-    
-    view1 = View('b1', 'b2', 'b3', 
-                 title="Alter Title", 
+
+    view1 = View('b1', 'b2', 'b3',
+                 title="Alter Title",
                  handler=TC_Handler(),
                  buttons = ['OK', 'Cancel'])
-    
+
     tc = TestClass()
     tc.configure_traits(view=view1)
 
 .. image:: images/alter_title_before.png
    :alt: Dialog box with empty checkboxes and a title of "Alter Title"
-   
+
 .. figure:: images/alter_title_after.png
    :alt: Dialog box with one filled checkbox and a title of "Alter Title*"
-     
+
    Figure 7: Before and after views of Example 9
 
 .. _implementing-custom-window-commands:
@@ -403,7 +408,7 @@ the logic for the window. To create the action:
    UIInfo object.
 #. Create an Action instance using the name of the new method, e.g.::
 
-        recalc = Action(name = "Recalculate", 
+        recalc = Action(name = "Recalculate",
                         action = "do_recalc")
 
 .. _custom-command-buttons:
@@ -445,7 +450,7 @@ following code::
            menubar = MenuBar(
               Menu( my_action,
                     name = 'My Special Menu')))
-                    
+
 .. _toolbars:
 
 Toolbars
@@ -462,13 +467,13 @@ except that toolbars do not contain menus; they directly contain actions.
    is used::
 
     From pyface.api import ImageResource
-    
-    recalc = Action(name = "Recalculate", 
+
+    recalc = Action(name = "Recalculate",
                     action = "do_recalc",
                     toolip = "Recalculate the results",
                     image = ImageResource("recalc.png"))
 
-2. If the View does not already include a ToolBar, create one and assign it to 
+2. If the View does not already include a ToolBar, create one and assign it to
    the View's **toolbar** attribute.
 3. Add the Action to the ToolBar.
 
@@ -477,16 +482,14 @@ created, as in the following code::
 
     View ( #view contents,
            # ...,
-           toolbar = ToolBar( my_action))
+           toolbar = ToolBar(my_action))
 
 .. rubric:: Footnotes
 
-.. [11] Except those implemented via the **enabled_when**, **visible_when**, 
-   and **defined_when** attributes of Items and Groups. 
-   
-.. [12] Other attributes of the UIInfo object include a UI object and any 
-   *trait editors* contained in the window (see 
-   :ref:`introduction-to-trait-editor-factories` and 
-   :ref:`the-predefined-trait-editor-factories`).   
-   
+.. [11] Except those implemented via the **enabled_when**, **visible_when**,
+   and **defined_when** attributes of Items and Groups.
 
+.. [12] Other attributes of the UIInfo object include a UI object and any
+   *trait editors* contained in the window (see
+   :ref:`introduction-to-trait-editor-factories` and
+   :ref:`the-predefined-trait-editor-factories`).

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -106,26 +106,18 @@ class ButtonEditor(Editor):
     #-------------------------------------------------------------------------
 
     def __init__(self, **traits):
-        self.set(**traits)
+        # XXX Why does this need to be an Editor subclass? -- CJW
+        HasPrivateTraits.__init__(self, **traits)
 
     #-------------------------------------------------------------------------
     #  Handles the associated button being clicked:
     #-------------------------------------------------------------------------
 
-    def perform(self):
-        """Handles the associated button being clicked."""
-        self.ui.do_undoable(self._perform, None)
-
-    def _perform(self, event):
-        method_name = self.action.action
-        if method_name == '':
-            method_name = '_%s_clicked' % self.action.name.lower()
-
-        method = getattr(self.ui.handler, method_name, None)
-        if method is not None:
-            method(self.ui.info)
-        else:
-            self.action.perform(event)
+    def perform(self, event):
+        """ Handles the associated button being clicked.
+        """
+        handler = self.ui.handler
+        self.ui.do_undoable(handler.perform, self.ui.info, self.action, event)
 
 
 class BasePanel(object):
@@ -136,33 +128,11 @@ class BasePanel(object):
     #  Performs the action described by a specified Action object:
     #-------------------------------------------------------------------------
 
-    def perform(self, action):
+    def perform(self, action, event):
         """ Performs the action described by a specified Action object.
         """
-        self.ui.do_undoable(self._perform, action)
-
-    def _perform(self, action):
-        method = getattr(self.ui.handler, action.action, None)
-        if method is not None:
-            method(self.ui.info)
-        else:
-            # TODO extract to common superclass for wx and qt4
-
-            # cf. commit cdf76eb5965c0184114c4674e06b28beee04af36
-            # (July 28, 2008, dmorrill) that fixes this issue for the
-            # wx backend
-
-            # look for the method in the context of the handler
-            context = self.ui.context
-            for item in PerformHandlers:
-                handler = context.get(item, None)
-                if handler is not None:
-                    method = getattr(handler, action.action, None)
-                    if method is not None:
-                        method()
-                        break
-            else:
-                action.perform()
+        handler = self.ui.handler
+        self.ui.do_undoable(handler.perform, self.ui.info, action, event)
 
     #-------------------------------------------------------------------------
     #  Check to see if a specified 'system' button is in the buttons list, and

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -43,9 +43,6 @@ from helper \
 # List of all predefined system button names:
 SystemButtons = ['Undo', 'Redo', 'Apply', 'Revert', 'OK', 'Cancel', 'Help']
 
-# List of alternative context items that might handle an Action 'perform':
-PerformHandlers = ('object', 'model')
-
 
 def default_icon():
     from pyface.image_resource import ImageResource

--- a/traitsui/tests/test_handler.py
+++ b/traitsui/tests/test_handler.py
@@ -1,0 +1,279 @@
+#
+#  Copyright (c) 2017, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Author: Corran Webster
+#  Date:   Aug 2017
+#
+
+from unittest import TestCase
+
+from pyface.action.api import ActionEvent
+from traits.api import HasTraits, Bool
+from traitsui.api import (
+    Action, CloseAction, Handler, HelpAction, RedoAction, RevertAction, UI,
+    UndoAction
+)
+
+
+class PyfaceAction(Action):
+
+    name = 'Test Action'
+
+    performed = Bool
+
+    def perform(self, event):
+        self.performed = True
+
+
+class TraitsUIAction(Action):
+
+    name = 'Test Action'
+
+    performed = Bool
+
+    def perform(self):
+        self.performed = True
+
+
+class SampleHandler(Handler):
+
+    action_performed = Bool
+
+    info_action_performed = Bool
+
+    click_performed = Bool
+
+    undo_performed = Bool
+
+    redo_performed = Bool
+
+    revert_performed = Bool
+
+    apply_performed = Bool
+
+    close_performed = Bool
+
+    help_performed = Bool
+
+    def action_handler(self):
+        self.action_performed = True
+
+    def info_action_handler(self, info):
+        self.info_action_performed = True
+
+    def revert(self, info):
+        self.revert_perfomed = True
+
+    def apply(self, info):
+        self.apply_perfomed = True
+
+    def show_help(self, info, control=None):
+        self.help_performed = True
+
+    def _action_clicked(self):
+        self.click_performed = True
+
+    def _on_undo(self, info):
+        super(SampleHandler, self)._on_undo(info)
+        self.undo_performed = True
+
+    def _on_redo(self, info):
+        super(SampleHandler, self)._on_redo(info)
+        self.redo_performed = True
+
+    def _on_revert(self, info):
+        super(SampleHandler, self)._on_revert(info)
+        self.revert_performed = True
+
+    def _on_close(self, info):
+        super(SampleHandler, self)._on_close(info)
+        self.close_performed = True
+
+
+class SampleObject(HasTraits):
+
+    object_action_performed = Bool
+
+    action_performed = Bool
+
+    info_action_performed = Bool
+
+    click_performed = Bool
+
+    def object_action_handler(self):
+        self.object_action_performed = True
+
+    def action_handler(self):
+        self.action_performed = True
+
+    def info_action_handler(self, info):
+        self.info_action_performed = True
+
+    def _action_click(self):
+        self.click_performed = True
+
+
+class TestHandler(TestCase):
+
+    def test_perform_pyface_action(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = PyfaceAction()
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(action.performed)
+
+    def test_perform_traitsui_action(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = TraitsUIAction()
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(action.performed)
+        self.assertFalse(handler.action_performed)
+        self.assertFalse(handler.info_action_performed)
+        self.assertFalse(handler.click_performed)
+        self.assertFalse(object.action_performed)
+        self.assertFalse(object.info_action_performed)
+        self.assertFalse(object.click_performed)
+
+    def test_perform_action_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = TraitsUIAction(name='action', action='action_handler')
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.action_performed)
+        self.assertFalse(handler.info_action_performed)
+        self.assertFalse(handler.click_performed)
+        self.assertFalse(object.action_performed)
+        self.assertFalse(object.info_action_performed)
+        self.assertFalse(object.click_performed)
+        self.assertFalse(action.performed)
+
+    def test_perform_info_action_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = TraitsUIAction(name='action', action='info_action_handler')
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.info_action_performed)
+        self.assertFalse(handler.action_performed)
+        self.assertFalse(handler.click_performed)
+        self.assertFalse(object.action_performed)
+        self.assertFalse(object.info_action_performed)
+        self.assertFalse(object.click_performed)
+        self.assertFalse(action.performed)
+
+    def test_perform_click_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = TraitsUIAction(name='action', action='')
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.click_performed)
+        self.assertFalse(handler.action_performed)
+        self.assertFalse(handler.info_action_performed)
+        self.assertFalse(object.action_performed)
+        self.assertFalse(object.info_action_performed)
+        self.assertFalse(object.click_performed)
+        self.assertFalse(action.performed)
+
+    def test_perform_object_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = TraitsUIAction(name='action', action='object_action_handler')
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(object.object_action_performed)
+        self.assertFalse(action.performed)
+
+    def test_undo_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = UndoAction
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.undo_performed)
+
+    def test_redo_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = RedoAction
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.redo_performed)
+
+    def test_revert_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = RevertAction
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.revert_performed)
+
+    def test_close_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = CloseAction
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.close_performed)
+
+    def test_help_handler(self):
+        object = SampleObject()
+        handler = SampleHandler()
+        action = HelpAction
+        event = ActionEvent()
+        ui = UI(handler=handler, context={'object': object})
+        info = ui.info
+
+        handler.perform(info, action, event)
+
+        self.assertTrue(handler.help_performed)

--- a/traitsui/wx/ui_base.py
+++ b/traitsui/wx/ui_base.py
@@ -102,7 +102,8 @@ class ButtonEditor(Editor):
     #-------------------------------------------------------------------------
 
     def __init__(self, **traits):
-        self.set(**traits)
+        # XXX Why does this need to be an Editor subclass? -- CJW
+        HasPrivateTraits.__init__(self, **traits)
 
     #-------------------------------------------------------------------------
     #  Handles the associated button being clicked:
@@ -111,17 +112,9 @@ class ButtonEditor(Editor):
     def perform(self, event):
         """ Handles the associated button being clicked.
         """
-        self.ui.do_undoable(self._perform, event)
+        handler = self.ui.handler
+        self.ui.do_undoable(handler.perform, self.ui.info, self.action, event)
 
-    def _perform(self, event):
-        method_name = self.action.action
-        if method_name == '':
-            method_name = '_%s_clicked' % (self.action.name.lower())
-        method = getattr(self.ui.handler, method_name, None)
-        if method is not None:
-            method(self.ui.info)
-        else:
-            self.action.perform(event)
 
 #-------------------------------------------------------------------------
 #  'BaseDialog' class:
@@ -279,26 +272,11 @@ class BaseDialog(object):
     #  Performs the action described by a specified Action object:
     #-------------------------------------------------------------------------
 
-    def perform(self, action):
+    def perform(self, action, event):
         """ Performs the action described by a specified Action object.
         """
-        self.ui.do_undoable(self._perform, action)
-
-    def _perform(self, action):
-        method = getattr(self.ui.handler, action.action, None)
-        if method is not None:
-            method(self.ui.info)
-        else:
-            context = self.ui.context
-            for item in PerformHandlers:
-                handler = context.get(item, None)
-                if handler is not None:
-                    method = getattr(handler, action.action, None)
-                    if method is not None:
-                        method()
-                        break
-            else:
-                action.perform()
+        handler = self.ui.handler
+        self.ui.do_undoable(handler.perform, self.ui.info, action, event)
 
     #-------------------------------------------------------------------------
     #  Check to see if a specified 'system' button is in the buttons list, and

--- a/traitsui/wx/ui_base.py
+++ b/traitsui/wx/ui_base.py
@@ -44,9 +44,6 @@ from editor \
 # List of all predefined system button names:
 SystemButtons = ['Undo', 'Redo', 'Apply', 'Revert', 'OK', 'Cancel', 'Help']
 
-# List of alternative context items that might handle an Action 'perform':
-PerformHandlers = ('object', 'model')
-
 #-------------------------------------------------------------------------
 #  'RadioGroup' class:
 #-------------------------------------------------------------------------


### PR DESCRIPTION
This adds a `perform` method to the base `Handler` class and shifts the common `Action` perform dispatch logic out of the toolkit `BaseDialog` classes.

This should be largely backwards compatible: obviously any existing user `Handler` subclass with a `perform` will have a problem, and there are some subtle differences in what methods will be checked (eg. `_<action.name>_clicked` can be called for menu toolbar items and in addition to buttons, if `action.action` is not defined).

Fixes #383 and a TODO left open in #56.

Also cleans up a couple of other issues (eg. `ui_base.ButtonEditor` was not correctly initialised)