### PR TITLE
Use trait instead of hardcoding checklist values

### DIFF
--- a/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
+++ b/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
@@ -28,7 +28,12 @@ class CheckListEditorDemo(HasTraits):
     values = List(Str, ['None'])
 
     # Specify the strings to be displayed in the checklist:
-    checklist = List(editor=CheckListEditor(
+    checklist_static = List(editor=CheckListEditor(
+        values=['one', 'two', 'three', 'four', 'five', 'six'],
+        cols=2))
+
+    # Specify the strings to be displayed in the checklist:
+    checklist_dynamic = List(editor=CheckListEditor(
         name='values',
         cols=2))
 
@@ -36,11 +41,18 @@ class CheckListEditorDemo(HasTraits):
     checklist_group = Group(
         '10',  # insert vertical space
         Label('The custom style lets you select items from a checklist:'),
-        UItem('checklist', style='custom'),
+        UItem('checklist_static', style='custom'),
         '10', '_', '10',  # a horizontal line with 10 empty pixels above and below
         Label('The readonly style shows you which items are selected, '
               'as a Python list:'),
-        UItem('checklist', style='readonly'),
+        UItem('checklist_static', style='readonly'),
+        '10',  # insert vertical space
+        Label('The custom style lets you select items from a checklist:'),
+        UItem('checklist_dynamic', style='custom'),
+        '10', '_', '10',  # a horizontal line with 10 empty pixels above and below
+        Label('The readonly style shows you which items are selected, '
+              'as a Python list:'),
+        UItem('checklist_dynamic', style='readonly'),
     )
 
     traits_view = View(
@@ -52,7 +64,7 @@ class CheckListEditorDemo(HasTraits):
 
 
 # Create the demo:
-values=['one', 'two', 'three', 'four', 'five', 'six']
+values=['1', '2', '3', '4', '5', '6']
 demo = CheckListEditorDemo(values=values)
 
 # Run the demo (if invoked from the command line):

--- a/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
+++ b/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
@@ -18,17 +18,18 @@ We do *not* demonstrate two styles which are not as useful for this editor:
     drop-down widget.
 """
 
-from traits.api import HasTraits, List
+from traits.api import HasTraits, List, Str
 from traitsui.api import UItem, Group, View, CheckListEditor, Label
 
 
 class CheckListEditorDemo(HasTraits):
     """ Define the main CheckListEditor simple demo class. """
 
+    values = List(Str, ['None'])
+
     # Specify the strings to be displayed in the checklist:
     checklist = List(editor=CheckListEditor(
-        values=['one', 'two', 'three', 'four',
-                'five', 'six'],
+        name='values',
         cols=2))
 
     # CheckListEditor display with two columns:
@@ -49,8 +50,10 @@ class CheckListEditorDemo(HasTraits):
         resizable=True
     )
 
+
 # Create the demo:
-demo = CheckListEditorDemo()
+values=['one', 'two', 'three', 'four', 'five', 'six']
+demo = CheckListEditorDemo(values=values)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':


### PR DESCRIPTION
Personally, this was what I was looking for and I am assuming that
this is what people would want to do after coming across this example
i.e. to be able to dynamically update the checklist values

```
modified:   examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
```