### PR TITLE
Add tests for actions bound to buttons

### DIFF
--- a/traitsui/tests/test_actions.py
+++ b/traitsui/tests/test_actions.py
@@ -64,7 +64,7 @@ class DialogWithToolbar(HasTraits):
         Item('action_successful', style='readonly'),
         menubar=menubar,
         toolbar=toolbar,
-        buttons=['OK']
+        buttons=[TestAction, 'OK']
     )
 
 
@@ -92,6 +92,14 @@ def _qt_trigger_action(container_class, ui):
     toolbar = ui.control.findChild(container_class)
     action = toolbar.actions()[0]
     action.trigger()
+
+
+def _qt_click_button(ui):
+    from pyface.qt.QtGui import QDialogButtonBox
+    bbox = ui.control.findChild(QDialogButtonBox)
+    button = bbox.buttons()[1]
+    print(button.text())
+    button.click()
 
 
 @skip_if_not_qt4
@@ -124,6 +132,18 @@ def test_qt_menu_action():
     _test_actions(qt_trigger_menu_action)
 
 
+@skip_if_not_qt4
+def test_qt_button_action():
+    # Behavior: when clicking on a button action, the corresponding function
+    # should be executed
+
+    # Bug: in the Qt4 backend, a
+    # TypeError: perform() takes exactly 2 arguments (1 given) was raised
+    # instead
+
+    _test_actions(_qt_click_button)
+
+
 # ----- wx tests
 
 @skip_if_not_wx
@@ -148,6 +168,28 @@ def test_wx_toolbar_action():
         toolbar.ProcessEvent(click_event)
 
     _test_actions(_wx_trigger_toolbar_action)
+
+@skip_if_not_wx
+def test_wx_button_action():
+    # Behavior: when clicking on a button action, the corresponding function
+    # should be executed
+
+    import wx
+
+    def _wx_trigger_button_action(ui):
+        # long road to get at the Id of the toolbar button
+        button_sizer = ui.control.GetSizer().GetChildren()[2].GetSizer()
+        button = button_sizer.GetChildren()[0].GetWindow()
+
+        control_id = button.GetId()
+
+        # build event that clicks the button
+        click_event = wx.CommandEvent(wx.wxEVT_COMMAND_BUTTON_CLICKED, control_id)
+
+        # send the event to the toolbar
+        ui.control.ProcessEvent(click_event)
+
+    _test_actions(_wx_trigger_button_action)
 
 
 # TODO: I couldn't find a way to press menu items programmatically for wx


### PR DESCRIPTION
Fixes a gap in #393 and #384 