### PR TITLE
Avoid PyQt 4.12-1 build

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -102,7 +102,7 @@ dependencies = {
 }
 
 extra_dependencies = {
-    'pyside': {'pyside'},
+    'pyside': {'pyside < 4.12'},  # FIXME: build of 4.12-1 appears to be bad
     'pyqt': {'pyqt'},
     # XXX once pyqt5 is available in EDM, we will want it here
     'pyqt5': set(),

--- a/etstool.py
+++ b/etstool.py
@@ -102,8 +102,8 @@ dependencies = {
 }
 
 extra_dependencies = {
-    'pyside': {'pyside < 4.12'},  # FIXME: build of 4.12-1 appears to be bad
-    'pyqt': {'pyqt'},
+    'pyside': {'pyside'},
+    'pyqt': {'pyqt < 4.12'},  # FIXME: build of 4.12-1 appears to be bad
     # XXX once pyqt5 is available in EDM, we will want it here
     'pyqt5': set(),
     'wx': {'wxpython'},

--- a/etstool.py
+++ b/etstool.py
@@ -103,7 +103,7 @@ dependencies = {
 
 extra_dependencies = {
     'pyside': {'pyside'},
-    'pyqt': {'pyqt < 4.12'},  # FIXME: build of 4.12-1 appears to be bad
+    'pyqt': {'pyqt<4.12'},  # FIXME: build of 4.12-1 appears to be bad
     # XXX once pyqt5 is available in EDM, we will want it here
     'pyqt5': set(),
     'wx': {'wxpython'},


### PR DESCRIPTION
Current build of pyqt appears to be bad on windows.  Temporary downgrade for CI system.