### PR TITLE
BUG: Fix the signal connection.

### DIFF
--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -179,7 +179,7 @@ class CustomEditor(SimpleEditor):
         layout.setContentsMargins(0, 0, 0, 0)
 
         self._mapper = QtCore.QSignalMapper()
-        self._mapper.mapped.connect(self.update_object)
+        self._mapper.mapped[unicode].connect(self.update_object)
 
     #-------------------------------------------------------------------------
     #  Rebuilds the editor after its definition is modified:


### PR DESCRIPTION
When the signal connections were upgraded to the new style in #330,
some of them actually required the argument type specification to select
the correct C++ overload of the signal.

Ping @corranwebster 