### PR TITLE
Check old value only non event/spring objects

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -143,14 +143,14 @@ class Editor(HasPrivateTraits):
         """
         HasPrivateTraits.__init__(self, **traits)
         try:
-            self.old_value = getattr(self.object, self.name)
-        except AttributeError:
-            ctrait = self.object.base_trait(self.name)
+            ctrait = self.object.trait(self.name)
             if ctrait.type == 'event' or self.name == 'spring':
                 # Getting the attribute will fail for 'Event' traits:
                 self.old_value = Undefined
             else:
-                raise
+                self.old_value = getattr( self.object, self.name )
+        except AttributeError:
+            raise
 
         # Synchronize the application invalid state status with the editor's:
         self.sync_value(self.factory.invalid, 'invalid', 'from')


### PR DESCRIPTION
I have a test script: 
```from traits.api import HasTraits, Button
from traitsui.api import View, Item
class Parent(HasTraits):
    def __init__(self):
        self.add_trait('say_hello', Button(
            get=self._say_hello_fired,
            set=self._say_hello_fired
            )
                       )
    def extra(self, *args, **kwargs):
        pass
    def _say_hello_fired(self):
        print("hello")
        return self.extra
    def default_traits_view(self):
        return View(
                Item('say_hello',
                     show_label=False),
                )
parent = Parent()
# parent.configure_traits()
parent.say_hello()
```
I want to enable both scripting and GUI control with minimal source code changes. In the example above I want both the button in the GUI when configure_traits is uncommented and then separately the parent.say_hello() method call to work.
This works, however, I get an erroneous call on init to say_hello in the GUI side because in [Editor.__init__ editor.py](https://github.com/enthought/traitsui/blob/512d24196e43f374dd5f7de5f127585eed6e0a85/traitsui/editor.py#L145)
```
...
try:
    self.old_value = getattr( self.object, self.name )
except AttributeError:
    ctrait = self.object.trait(self.name)
    if ctrait.type == 'event' or self.name == 'spring':
        # Getting the attribute will fail for 'Event' traits:
        self.old_value = Undefined
    else:
        raise
...
```
The check if it is an event happens after it checks for old value.
Can this be changed with out screwing things up?:
```
try:
    ctrait = self.object.trait(self.name)
    if ctrait.type == 'event' or self.name == 'spring':
        # Getting the attribute will fail for 'Event' traits:
        self.old_value = Undefined
    else:
        self.old_value = getattr( self.object, self.name )
except AttributeError:
        raise
```