### PR TITLE
Fix Qt widget state saving for Python 3

### DIFF
--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -360,7 +360,7 @@ class TableEditor(Editor, BaseTableEditor):
         prefs = {}
         header = self.table_view.horizontalHeader()
         if header is not None:
-            prefs['column_state'] = str(header.saveState())
+            prefs['column_state'] = header.saveState().data()
         return prefs
 
     #-------------------------------------------------------------------------

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1669,7 +1669,7 @@ class SimpleEditor(Editor):
 
             self.control.restoreState(structure)
         header = self._tree.header()
-        self.setExpandsOnDoubleClick(self.factory.expands_on_dclick)
+        self.control.setExpandsOnDoubleClick(self.factory.expands_on_dclick)
 
         if header is not None and 'column_state' in prefs:
             header.restoreState(prefs['column_state'])

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1683,10 +1683,10 @@ class SimpleEditor(Editor):
         """
         prefs = {}
         if isinstance(self.control, QtGui.QSplitter):
-            prefs['structure'] = str(self.control.saveState())
+            prefs['structure'] = self.control.saveState().data()
         header = self._tree.header()
         if header is not None:
-            prefs['column_state'] = str(header.saveState())
+            prefs['column_state'] = header.saveState().data()
 
         return prefs
 

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1194,7 +1194,7 @@ class SplitterGroupEditor(GroupEditor):
     def save_prefs(self):
         """ Returns any user preference information associated with the editor.
         """
-        return {'structure': str(self.splitter.saveState())}
+        return {'structure': self.splitter.saveState().data()}
 
 
 class TabbedFoldGroupEditor(GroupEditor):

--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -81,3 +81,12 @@ def test_tree_editor_listeners_with_shown_root():
 @skip_if_null
 def test_tree_editor_listeners_with_hidden_root():
     _test_tree_editor_releases_listeners(hide_root=True)
+
+
+@skip_if_null
+def test_smoke_save_restore_prefs():
+        bogus = Bogus(bogus_list=[Bogus()])
+        tree_editor_view = BogusTreeView(bogus=bogus)
+        ui = tree_editor_view.edit_traits()
+        prefs = ui.get_prefs()
+        ui.set_prefs(prefs)


### PR DESCRIPTION
The conversion of `QBytes` to something that the TraitsUI preferences (really, widget-state) saving machinery can deal with was not made Python-3-safe. I stuck a quick smoke test in for the `TreeEditor` (which caused the report enthought/mayavi#576 bug), but there were a few other problematic editors that I fixed (untested).

Fixes enthought/mayavi#576