### PR TITLE
Fix: df editor typos

### DIFF
--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -427,9 +427,9 @@ def test_data_frame_editor_with_update_refresh():
 def test_data_frame_editor_with_refresh():
     class DataFrameViewer(HasTraits):
         data = Instance(DataFrame)
-        df_updated = Event
+        df_refreshed = Event
         view = View(
-            Item('data', editor=DataFrameEditor())
+            Item('data', editor=DataFrameEditor(refresh="df_refreshed"))
         )
 
     df = DataFrame(DATA, index=['one', 'two', 'three', 'four'],
@@ -437,5 +437,5 @@ def test_data_frame_editor_with_refresh():
     viewer = DataFrameViewer(data=df)
     with store_exceptions_on_all_threads():
         ui = viewer.edit_traits()
-        viewer.df_updated = True
+        viewer.df_refreshed = True
         ui.dispose()

--- a/traitsui/ui_editors/data_frame_editor.py
+++ b/traitsui/ui_editors/data_frame_editor.py
@@ -183,7 +183,7 @@ class _DataFrameEditor(UIEditor):
                     selected=self._target_name(self.factory.selected),
                     selected_row=self._target_name(self.factory.selected_row),
                     selectable=self.factory.selectable,
-                    activated=self._target_name(self.factory.selected),
+                    activated=self._target_name(self.factory.activated),
                     activated_row=self._target_name(self.factory.activated_row),  # noqa
                     clicked=self._target_name(self.factory.clicked),
                     dclicked=self._target_name(self.factory.dclicked),


### PR DESCRIPTION
Corrects 2 copy-pasta typos, in the `DataFrameEditor` and its test suite.