### PR TITLE
Better toolkit handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,8 +144,8 @@ if __name__ == "__main__":
         entry_points = {
             'traitsui.toolkits': [
                 'qt4 = traitsui.qt4:toolkit',
-                'qt = traitsui.qt4:toolkit',
                 'wx = traitsui.wx:toolkit',
+                'qt = traitsui.qt4:toolkit',
                 'null = traitsui.null:toolkit',
             ],
         },

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,14 @@ if __name__ == "__main__":
         package_data=dict(traitsui=['image/library/*.zip', 'images/*',
                                     'wx/images/*', 'qt4/images/*']),
         packages=find_packages(),
+        entry_points = {
+            'traitsui.toolkits': [
+                'qt4 = traitsui.qt4:toolkit',
+                'qt = traitsui.qt4:toolkit',
+                'wx = traitsui.wx:toolkit',
+                'null = traitsui.null:toolkit',
+            ],
+        },
         platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
         zip_safe=False,
         use_2to3=True,

--- a/traitsui/null/__init__.py
+++ b/traitsui/null/__init__.py
@@ -28,4 +28,4 @@
 from __future__ import absolute_import
 
 from . import toolkit
-toolkit = toolkit.GUIToolkit('traitsui', 'null', 'traitsui.qt4')
+toolkit = toolkit.GUIToolkit('traitsui', 'null', 'traitsui.null')

--- a/traitsui/null/__init__.py
+++ b/traitsui/null/__init__.py
@@ -28,4 +28,4 @@
 from __future__ import absolute_import
 
 from . import toolkit
-toolkit = toolkit.GUIToolkit()
+toolkit = toolkit.GUIToolkit('traitsui', 'null', 'traitsui.qt4')

--- a/traitsui/qt4/__init__.py
+++ b/traitsui/qt4/__init__.py
@@ -24,5 +24,5 @@ import pyface.qt
 
 import toolkit
 
-# Reference to the GUIToolkit object for PyQt.
-toolkit = toolkit.GUIToolkit()
+# Reference to the GUIToolkit object for Qt.
+toolkit = toolkit.GUIToolkit('traitsui', 'qt4', 'traitsui.qt4')

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -19,26 +19,17 @@ the PyQt user interface toolkit.
 
 # Make sure that importing from this backend is OK:
 from traitsui.toolkit import assert_toolkit_import
-assert_toolkit_import('qt4')
+assert_toolkit_import(['qt4', 'qt'])
 
-from pyface.qt import QtCore, QtGui, qt_api
-
-if qt_api == 'pyqt':
-    # Check the version numbers are late enough:
-    if QtCore.QT_VERSION < 0x040200:
-        raise RuntimeError("Need Qt v4.2 or higher, but got v%s" %
-                           QtCore.QT_VERSION_STR)
-
-# Make sure a QApplication object is created early:
-import sys
-if QtGui.QApplication.startingUp():
-    _app = QtGui.QApplication(sys.argv)
+# Ensure that we can import Pyface backend.  This starts App as a side-effect.
+from pyface.toolkit import toolkit_object as pyface_toolkit
+_app = pyface_toolkit('init:_app')
 
 from traits.trait_notifiers import set_ui_handler
+from pyface.qt import QtCore, QtGui
 
 from traitsui.toolkit import Toolkit
-
-from constants import screen_dx, screen_dy
+from .constants import screen_dx, screen_dy
 
 #-------------------------------------------------------------------------
 #  Handles UI notification handler requests that occur on a thread other than

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -26,7 +26,7 @@ from pyface.toolkit import toolkit_object as pyface_toolkit
 _app = pyface_toolkit('init:_app')
 
 from traits.trait_notifiers import set_ui_handler
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtCore, QtGui, qt_api
 
 from traitsui.toolkit import Toolkit
 from .constants import screen_dx, screen_dy

--- a/traitsui/tests/test_toolkit.py
+++ b/traitsui/tests/test_toolkit.py
@@ -45,7 +45,8 @@ class TestToolkit(unittest.TestCase):
             # try to import a non-existent toolkit
             tk = traitsui.toolkit.toolkit('nosuchtoolkit')
 
-            # should fail, and give us 'null'
-            self.assertEqual(ETSConfig.toolkit, 'null')
-            from traitsui.null import toolkit
-            self.assertIs(tk, toolkit)
+            # should fail, and give us a standard toolkit, but don't know which
+            # exactly we get what depends on what is installed in test
+            # environment
+            self.assertTrue(ETSConfig.toolkit in {'null', 'qt4', 'wx'})
+            self.assertTrue(tk.toolkit in {'null', 'qt4', 'wx'})

--- a/traitsui/tests/test_toolkit.py
+++ b/traitsui/tests/test_toolkit.py
@@ -48,5 +48,5 @@ class TestToolkit(unittest.TestCase):
             # should fail, and give us a standard toolkit, but don't know which
             # exactly we get what depends on what is installed in test
             # environment
-            self.assertTrue(ETSConfig.toolkit in {'null', 'qt4', 'wx'})
-            self.assertTrue(tk.toolkit in {'null', 'qt4', 'wx'})
+            self.assertTrue(ETSConfig.toolkit in {'null', 'qt4', 'wx', 'qt'})
+            self.assertTrue(tk.toolkit in {'null', 'qt4', 'wx', 'qt'})

--- a/traitsui/toolkit.py
+++ b/traitsui/toolkit.py
@@ -82,10 +82,6 @@ except AttributeError:
             raise
 
 
-def _import_toolkit(name):
-    return __import__(name, globals=globals(), level=1).toolkit
-
-
 def assert_toolkit_import(names):
     """ Raise an error if a toolkit with the given name should not be allowed
     to be imported.

--- a/traitsui/toolkit.py
+++ b/traitsui/toolkit.py
@@ -140,61 +140,61 @@ except:
     }
     default_priorities = lambda plugin: TOOLKIT_PRIORITIES.get(plugin.name, 0)
 
-def find_toolkit(entry_point, toolkits=None, priorities=default_priorities):
-    """ Find a toolkit that works.
+    def find_toolkit(entry_point, toolkits=None, priorities=default_priorities):
+        """ Find a toolkit that works.
 
-    If ETSConfig is set, then attempt to find a matching toolkit.  Otherwise
-    try every plugin for the entry_point until one works.  The ordering of the
-    plugins is supplied via the priorities function which should be suitable
-    for use as a sorting key function.
+        If ETSConfig is set, then attempt to find a matching toolkit.  Otherwise
+        try every plugin for the entry_point until one works.  The ordering of the
+        plugins is supplied via the priorities function which should be suitable
+        for use as a sorting key function.
 
-    Parameters
-    ----------
-    entry_point : str
-        The name of the entry point that holds our toolkits.
-    toolkits : collection of strings
-        Only consider toolkits which match the given strings, ignore other
-        ones.
-    priorities : callable
-        A callable function that returns an priority for each plugin.
+        Parameters
+        ----------
+        entry_point : str
+            The name of the entry point that holds our toolkits.
+        toolkits : collection of strings
+            Only consider toolkits which match the given strings, ignore other
+            ones.
+        priorities : callable
+            A callable function that returns an priority for each plugin.
 
-    Returns
-    -------
-    toolkit : Toolkit instance
-        A callable object that implements the Toolkit interface.
+        Returns
+        -------
+        toolkit : Toolkit instance
+            A callable object that implements the Toolkit interface.
 
-    Raises
-    ------
-    TraitError
-        If no working toolkit is found.
-    RuntimeError
-        If no ETSConfig.toolkit is set but the toolkit cannot be loaded for
-        some reason.
-    """
-    if ETSConfig.toolkit:
-        return import_toolkit(ETSConfig.toolkit, entry_point)
+        Raises
+        ------
+        TraitError
+            If no working toolkit is found.
+        RuntimeError
+            If no ETSConfig.toolkit is set but the toolkit cannot be loaded for
+            some reason.
+        """
+        if ETSConfig.toolkit:
+            return import_toolkit(ETSConfig.toolkit, entry_point)
 
-    entry_points = [
-        plugin for plugin in pkg_resources.iter_entry_points(entry_point)
-        if toolkits is None or plugin.name in toolkits
-    ]
-    for plugin in sorted(entry_points, key=priorities):
-        if plugin.name not in toolkits:
-            continue
-        try:
-            with ETSConfig.provisional_toolkit(plugin.name):
-                toolkit = plugin.load()
-                return toolkit
-        except (ImportError, AttributeError) as exc:
-            msg = "Could not load %s plugin %r from %r"
-            logger.info(msg, entry_point, plugin.name, plugin.module_name)
-            logger.debug(exc, exc_info=True)
+        entry_points = [
+            plugin for plugin in pkg_resources.iter_entry_points(entry_point)
+            if toolkits is None or plugin.name in toolkits
+        ]
+        for plugin in sorted(entry_points, key=priorities):
+            if plugin.name not in toolkits:
+                continue
+            try:
+                with ETSConfig.provisional_toolkit(plugin.name):
+                    toolkit = plugin.load()
+                    return toolkit
+            except (ImportError, AttributeError) as exc:
+                msg = "Could not load %s plugin %r from %r"
+                logger.info(msg, entry_point, plugin.name, plugin.module_name)
+                logger.debug(exc, exc_info=True)
 
-    # if all else fails, try to import the null toolkit.
-    with ETSConfig.provisional_toolkit('null'):
-        return import_toolkit('null', entry_point)
+        # if all else fails, try to import the null toolkit.
+        with ETSConfig.provisional_toolkit('null'):
+            return import_toolkit('null', entry_point)
 
-    raise TraitError("Could not import any {} toolkit.".format(entry_point))
+        raise TraitError("Could not import any {} toolkit.".format(entry_point))
 
 
 def assert_toolkit_import(names):

--- a/traitsui/toolkit.py
+++ b/traitsui/toolkit.py
@@ -154,8 +154,11 @@ def toolkit(*toolkits):
         _toolkit = import_toolkit(ETSConfig.toolkit)
         return _toolkit
 
+    if not toolkits:
+        toolkits = ('qt4', 'wx')
+
     # Try known toolkits first.
-    for toolkit_name in ('qt4', 'wx'):
+    for toolkit_name in toolkits:
         try:
             with provisional_toolkit(toolkit_name):
                 _toolkit = _import_toolkit(toolkit_name)

--- a/traitsui/toolkit.py
+++ b/traitsui/toolkit.py
@@ -157,7 +157,7 @@ def toolkit(*toolkits):
     for toolkit_name in toolkits:
         try:
             with provisional_toolkit(toolkit_name):
-                _toolkit = _import_toolkit(toolkit_name)
+                _toolkit = import_toolkit(toolkit_name)
                 return _toolkit
         except (AttributeError, ImportError) as exc:
             # import failed, reset toolkit to none, log error and try again
@@ -182,7 +182,7 @@ def toolkit(*toolkits):
     # Try using the null toolkit and printing a warning
     try:
         with provisional_toolkit('null'):
-            _toolkit = _import_toolkit('null')
+            _toolkit = import_toolkit('null')
             import warnings
             msg = (
                 "Unable to import the '{0}' backend for traits UI; " +

--- a/traitsui/wx/__init__.py
+++ b/traitsui/wx/__init__.py
@@ -26,4 +26,4 @@
 import toolkit
 
 # Reference to the GUIToolkit object for wxPython
-toolkit = toolkit.GUIToolkit('traitsui', 'wx', 'traitsui.qt4')
+toolkit = toolkit.GUIToolkit('traitsui', 'wx', 'traitsui.wx')

--- a/traitsui/wx/__init__.py
+++ b/traitsui/wx/__init__.py
@@ -26,4 +26,4 @@
 import toolkit
 
 # Reference to the GUIToolkit object for wxPython
-toolkit = toolkit.GUIToolkit()
+toolkit = toolkit.GUIToolkit('traitsui', 'wx', 'traitsui.qt4')

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -25,40 +25,27 @@
 
 # Make sure that importimg from this backend is OK:
 from traitsui.toolkit import assert_toolkit_import
-assert_toolkit_import('wx')
+assert_toolkit_import(['wx'])
 
 import wx
 
-# Make sure a wx.App object is created early:
-_app = wx.GetApp()
-if _app is None:
-    _app = wx.App(redirect=False)
+# Ensure that we can import Pyface backend.  This starts App as a side-effect.
+from pyface.toolkit import toolkit_object as pyface_toolkit
+_app = pyface_toolkit('init:_app')
 
-from traits.api \
-    import HasPrivateTraits, Instance, Property, Category, cached_property
-
-from traits.trait_notifiers \
-    import set_ui_handler
+from traits.api import (
+    HasPrivateTraits, Instance, Property, Category, cached_property
+)
+from traits.trait_notifiers import set_ui_handler
+from pyface.wx.drag_and_drop import PythonDropTarget
 
 from traitsui.theme import Theme
+from traitsui.ui import UI
+from traitsui.dock_window_theme import DockWindowTheme
+from traitsui.toolkit import Toolkit
 
-from traitsui.ui \
-    import UI
-
-from traitsui.dock_window_theme \
-    import DockWindowTheme
-
-from traitsui.toolkit \
-    import Toolkit
-
-from pyface.wx.drag_and_drop \
-    import PythonDropTarget
-
-from constants \
-    import WindowColor, screen_dx, screen_dy
-
-from helper \
-    import position_window
+from .constants import WindowColor, screen_dx, screen_dy
+from .helper import position_window
 
 #-------------------------------------------------------------------------
 #  Constants:


### PR DESCRIPTION
This PR does a few things:

- allows adding new toolkits via `pkg_resources` entrypoints.
- leans on the pyface toolkit mechanisms where practical, reducing duplicated code
- allows `qt` as a synonym for `qt4`.