### PR TITLE
Fix toolkit editor lookup

### DIFF
--- a/traitsui/editor_factory.py
+++ b/traitsui/editor_factory.py
@@ -183,20 +183,18 @@ class EditorFactory(HasPrivateTraits):
         """
         Returns the editor by name class_name in the backend package.
         """
-        editor_factory_classes = [factory_class for factory_class in cls.mro()
+        editor_factory_modules = [factory_class.__module__
+                                  for factory_class in cls.mro()
                                   if issubclass(factory_class, EditorFactory)]
-        for index in range(len(editor_factory_classes)):
+        for index, editor_module in enumerate(editor_factory_modules):
             try:
-                factory_class = editor_factory_classes[index]
-                editor_file_name = os.path.basename(
-                    sys.modules[factory_class.__module__].__file__)
-                object_ref = ':'.join([editor_file_name.split('.')[0],
-                                       class_name])
+                editor_module_name = editor_module.split('.')[-1]
+                object_ref = ':'.join([editor_module_name, class_name])
                 return toolkit_object(object_ref, True)
-            except Exception as e:
+            except RuntimeError as e:
                 msg = "Can't import toolkit_object '{}': {}"
                 logger.debug(msg.format(object_ref, e))
-                if index == len(editor_factory_classes) - 1:
+                if index == len(editor_factory_modules) - 1:
                     raise e
         return None
 

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -84,6 +84,13 @@ class SimpleEditor(Editor):
         self.control.clicked.connect(self.update_object)
         self.set_tooltip()
 
+    def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
+        if self.control is not None:
+            self.control.clicked.disconnect(self.update_object)
+        super(SimpleEditor, self).dispose()
+
     def _label_changed(self, label):
         self.control.setText(self.string_value(label))
 
@@ -105,6 +112,8 @@ class SimpleEditor(Editor):
         """ Handles the user clicking the button by setting the factory value
             on the object.
         """
+        if self.control is None:
+            return
         if self.selected_item != "":
             self.value = self.selected_item
         else:

--- a/traitsui/qt4/editor_factory.py
+++ b/traitsui/qt4/editor_factory.py
@@ -87,10 +87,6 @@ class TextEditor(Editor):
     """ Base class for text style editors, which displays an editable text
     field, containing a text representation of the object trait value.
     """
-    #-------------------------------------------------------------------------
-    #  Finishes initializing the editor by creating the underlying toolkit
-    #  widget:
-    #-------------------------------------------------------------------------
 
     def init(self, parent):
         """ Finishes initializing the editor by creating the underlying toolkit
@@ -100,13 +96,18 @@ class TextEditor(Editor):
         self.control.editingFinished.connect(self.update_object)
         self.set_tooltip()
 
-    #-------------------------------------------------------------------------
-    #  Handles the user changing the contents of the edit control:
-    #-------------------------------------------------------------------------
+    def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
+        if self.control is not None:
+            self.control.editingFinished.disconnect(self.update_object)
+        super(TextEditor, self).dispose()
 
     def update_object(self):
         """ Handles the user changing the contents of the edit control.
         """
+        if self.control is None:
+            return
         try:
             self.value = unicode(self.control.text())
         except TraitError as excp:

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -15,6 +15,13 @@ class ButtonTextEdit(HasTraits):
 
     play_button_label = Unicode("I'm a play button")
 
+    traits_view = View(
+        Item('play_button', style='simple'),
+        Item('play_button', style='custom'),
+        Item('play_button', style='readonly'),
+        Item('play_button', style='text'),
+    )
+
 
 simple_view = View(
     UItem(
@@ -64,6 +71,16 @@ class TestButtonEditor(unittest.TestCase):
 
             button_text_edit.play_button_label = "New Label"
             self.assertEqual(get_button_text(button), "New Label")
+
+    @skip_if_null
+    def test_styles(self):
+        # simple smoke test of buttons
+        gui = GUI()
+        button_text_edit = ButtonTextEdit()
+        with store_exceptions_on_all_threads():
+            ui = button_text_edit.edit_traits()
+            self.addCleanup(ui.dispose)
+            gui.process_events()
 
     @skip_if_null
     def test_simple_button_editor(self):

--- a/traitsui/toolkit.py
+++ b/traitsui/toolkit.py
@@ -51,7 +51,8 @@ def toolkit_object(name, raise_exceptions=False):
     ---------
     name : str
         The relative module path and the object name separated by a colon.
-
+    raise_exceptions : bool
+        Whether or not to raise an exception if the name cannot be imported.
 
     Raises
     ------
@@ -59,16 +60,20 @@ def toolkit_object(name, raise_exceptions=False):
         If no working toolkit is found.
     RuntimeError
         If no ETSConfig.toolkit is set but the toolkit cannot be loaded for
-        some reason.
+        some reason.  This is also raised if raise_exceptions is True the
+        backend does not implement the desired object.
     """
     global _toolkit
-    try:
-        if _toolkit is None:
-            toolkit()
-        return _toolkit(name)
-    except Exception as exc:
-        if raise_exceptions:
-            raise
+
+    if _toolkit is None:
+        toolkit()
+    obj = _toolkit(name)
+
+    if raise_exceptions and obj.__name__ == 'Unimplemented':
+        raise RuntimeError("Can't import {} for backend {}".format(
+            repr(name), _toolkit.toolkit))
+
+    return obj
 
 
 def toolkit(*toolkits):


### PR DESCRIPTION
The previous changes to toolkit lookup broke lookup of editor backends in the case where the editor of a particular style is not implemented in the same module as the editor factory.