### PR TITLE
Add extras require to setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,16 @@ matrix:
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt wx"
     - os: osx
-      env: RUNTIME=3.5 TOOLKITS="null pyqt pyqt5"
+      env: RUNTIME=3.5 TOOLKITS="null pyqt5"
     - os: osx
-      env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5"
+      env: RUNTIME=3.6 TOOLKITS="null pyqt5"
   allow_failures:
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt wx"
+    - os: osx
+      env: RUNTIME=3.5 TOOLKITS="pyqt"
+    - os: osx
+      env: RUNTIME=3.6 TOOLKITS="pyqt"
   fast_finish: true
 
 branches:

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ if not is_released:
 
 if __name__ == "__main__":
     write_version_py()
-    from traitsui import __version__, __requires__
+    from traitsui import __version__, __requires__, __extras_require__
 
     def additional_commands():
         try:
@@ -135,6 +135,7 @@ if __name__ == "__main__":
         url='https://docs.enthought.com/traitsui',
         download_url='https://github.com/enthought/traitsui',
         install_requires=__requires__,
+        extras_require=__extras_require__,
         license='BSD',
         maintainer='ETS Developers',
         maintainer_email='enthought-dev@enthought.com',

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -23,3 +23,9 @@ __requires__ = [
     'traits',
     'pyface',
 ]
+__extras_require__ = {
+    'wx': ['wxpython>=2.8.10', 'numpy'],
+    'pyqt': ['pyqt>=4.10', 'pygments'],
+    'pyqt5': ['pyqt>=5', 'pygments'],
+    'pyside': ['pyside>=1.2', 'pygments'],
+}


### PR DESCRIPTION
This adds an `extras_require` entry to the `setup.py` file which permits installation of backend packages via setup.py and/or pip.