### PR TITLE
HTTPS not enabled for external github pages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
             """.splitlines() if len(c.strip()) > 0],
         description='traitsui: traits-capable user interfaces',
         long_description=open('README.rst').read(),
-        url='https://docs.enthought.com/traitsui',
+        url='http://docs.enthought.com/traitsui',
         download_url='https://github.com/enthought/traitsui',
         install_requires=__requires__,
         extras_require=__extras_require__,


### PR DESCRIPTION
Have to use HTTP.  This may not be long-term sustainable (Chrome and Firefox are deprecating HTTP) and we may need to host some sort of project page ourselves.