### PR TITLE
[WIP] IPyWidgets Backend for TraitsUI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,10 @@ if __name__ == "__main__":
                 'wx = traitsui.wx:toolkit',
                 'qt = traitsui.qt4:toolkit',
                 'null = traitsui.null:toolkit',
+                'ipywidgets = traitsui.ipywidgets:toolkit',
+            ],
+            'pyface.toolkits': [
+                'ipywidgets = traitsui.ipywidgets:toolkit',
             ],
         },
         platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],

--- a/traitsui/api.py
+++ b/traitsui/api.py
@@ -117,7 +117,7 @@ from .menu import (
     RevertAction,
     RevertButton,
     Separator,
-    StandardMenuBar,
+    #StandardMenuBar,
     ToolBar,
     UndoAction,
     UndoButton)

--- a/traitsui/base_panel.py
+++ b/traitsui/base_panel.py
@@ -13,7 +13,6 @@
 
 from pyface.action.api import ActionController
 from traits.api import Any, Instance
-from traitsui.menu import Action
 
 
 # Set of all predefined system button names:
@@ -59,6 +58,8 @@ class BasePanel(ActionController):
     def coerce_button(self, action):
         """ Coerces a string to an Action if necessary.
         """
+        from traitsui.menu import Action
+
         if isinstance(action, basestring):
             return Action(
                 name=action,

--- a/traitsui/ipywidgets/TestIPyWidgets.ipynb
+++ b/traitsui/ipywidgets/TestIPyWidgets.ipynb
@@ -15,22 +15,11 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(<code object <module> at 0x108ea8810, file \"<string>\", line 1>, {'object': <__main__.TestObj object at 0x109137468>, 'handler': <traitsui.handler.Handler object at 0x109137200>})\n",
-      "<__main__.TestObj object at 0x109137468>\n",
-      "(<code object <module> at 0x108ea8810, file \"<string>\", line 1>, {'object': <__main__.TestObj object at 0x109137468>, 'handler': <traitsui.handler.Handler object at 0x109137200>})\n",
-      "<__main__.TestObj object at 0x109137468>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from traits.api import HasTraits, Unicode, Bool\n",
+    "from traits.api import HasTraits, Unicode, Bool, Int\n",
     "\n",
-    "from traitsui.group import VGroup\n",
+    "from traitsui.group import VGroup, Tabbed, VFold, VGrid\n",
     "from traitsui.item import Item\n",
     "from traitsui.view import View\n",
     "from traitsui.ui import UI\n",
@@ -38,30 +27,25 @@
     "class TestObj(HasTraits):\n",
     "    text = Unicode\n",
     "    boolean = Bool\n",
+    "    integer = Int\n",
     "\n",
     "test_obj = TestObj()\n",
     "    \n",
     "test_view = View(\n",
-    "    VGroup(\n",
-    "        Item(name='', label='test'),\n",
-    "        Item('text'),\n",
-    "        Item('boolean'),\n",
-    "        show_labels=False,\n",
+    "    Tabbed(\n",
+    "        VGroup(\n",
+    "            Item(label='test'),\n",
+    "            Item('text'),\n",
+    "            label=\"Tab 1\",\n",
+    "        ),\n",
+    "        VGroup(\n",
+    "            Item('boolean'),\n",
+    "            Item('integer'),\n",
+    "            label=\"Tab 2\"\n",
+    "        ),\n",
     "    ),\n",
-    "    kind='panel'\n",
     ")\n",
-    "#test_view.edit_traits(context={'object': test_obj}, kind='live')\n",
-    "ui = test_obj.edit_traits(view=test_view, kind='live')\n",
-    "\n",
-    "#ui = test_view.ui(context={'object': test_obj}, kind='live')\n",
-    "\n",
-    "# ui = UI(view=test_view,\n",
-    "#     context={},\n",
-    "#     handler=default_handler(),\n",
-    "#     view_elements=None,\n",
-    "#     title=test_view.title,\n",
-    "#     id='',\n",
-    "#     scrollable=False)\n"
+    "ui = test_obj.edit_traits(view=test_view, kind='live')\n"
    ]
   },
   {
@@ -70,14 +54,31 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tab(children=(GridBox(children=(Label(value='test'), Label(value=''), Label(value='Text:'), Text(value='')), layout=Layout(grid_template_columns='auto auto')), GridBox(children=(Label(value='Boolean:'), Checkbox(value=False), Label(value='Integer:'), Text(value='0')), layout=Layout(grid_template_columns='auto auto'))), _titles={'0': 'Tab 1', '1': 'Tab 2'})\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ui.control)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "50f1263c423e4725bfd662574c9895fc",
+       "model_id": "ad6fbfa88e5d47088de44c5fb1d77511",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(Label(value='test'), Text(value=''), Checkbox(value=False)))"
+       "Tab(children=(GridBox(children=(Label(value='test'), Label(value=''), Label(value='Text:'), Text(value='')), l…"
       ]
      },
      "metadata": {},
@@ -89,12 +90,36 @@
     "#from traitsui.ipywidgets.ui_panel import panel\n",
     "\n",
     "t = ui.control\n",
-    "display(t)"
+    "t"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d861bee9d0db4fff9da86ce049d860c2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Tab(children=(GridBox(children=(Label(value='test'), Label(value=''), Label(value='Text:'), Text(value='')), l…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "test_obj.configure_traits(view=test_view, kind='live')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -103,7 +128,7 @@
        "''"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -114,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -132,7 +157,7 @@
        "False"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -143,11 +168,74 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_obj.integer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_obj.integer = 100"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "test_obj.boolean = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5ca16f2ce9a747f1ac13b2e41bf034e5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(Button(layout=Layout(height='auto', width='auto'), style=ButtonStyle(button_color='darkseagr…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ipywidgets import GridBox, Button, ButtonStyle, Layout\n",
+    "gb = GridBox(children=[Button(layout=Layout(width='auto', height='auto'),\n",
+    "                         style=ButtonStyle(button_color='darkseagreen')) for i in range(9)\n",
+    "                 ],\n",
+    "        layout=Layout(\n",
+    "            width='50%',\n",
+    "            grid_template_columns='100px 50px 100px',\n",
+    "            grid_template_rows='80px auto 80px',\n",
+    "            grid_gap='5px 10px')\n",
+    "       )\n",
+    "display(gb)"
    ]
   },
   {
@@ -174,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/traitsui/ipywidgets/TestIPyWidgets.ipynb
+++ b/traitsui/ipywidgets/TestIPyWidgets.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from traits.etsconfig.api import ETSConfig\n",
+    "\n",
+    "ETSConfig.toolkit = 'ipywidgets'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(<code object <module> at 0x108ea8810, file \"<string>\", line 1>, {'object': <__main__.TestObj object at 0x109137468>, 'handler': <traitsui.handler.Handler object at 0x109137200>})\n",
+      "<__main__.TestObj object at 0x109137468>\n",
+      "(<code object <module> at 0x108ea8810, file \"<string>\", line 1>, {'object': <__main__.TestObj object at 0x109137468>, 'handler': <traitsui.handler.Handler object at 0x109137200>})\n",
+      "<__main__.TestObj object at 0x109137468>\n"
+     ]
+    }
+   ],
+   "source": [
+    "from traits.api import HasTraits, Unicode, Bool\n",
+    "\n",
+    "from traitsui.group import VGroup\n",
+    "from traitsui.item import Item\n",
+    "from traitsui.view import View\n",
+    "from traitsui.ui import UI\n",
+    "\n",
+    "class TestObj(HasTraits):\n",
+    "    text = Unicode\n",
+    "    boolean = Bool\n",
+    "\n",
+    "test_obj = TestObj()\n",
+    "    \n",
+    "test_view = View(\n",
+    "    VGroup(\n",
+    "        Item(name='', label='test'),\n",
+    "        Item('text'),\n",
+    "        Item('boolean'),\n",
+    "        show_labels=False,\n",
+    "    ),\n",
+    "    kind='panel'\n",
+    ")\n",
+    "#test_view.edit_traits(context={'object': test_obj}, kind='live')\n",
+    "ui = test_obj.edit_traits(view=test_view, kind='live')\n",
+    "\n",
+    "#ui = test_view.ui(context={'object': test_obj}, kind='live')\n",
+    "\n",
+    "# ui = UI(view=test_view,\n",
+    "#     context={},\n",
+    "#     handler=default_handler(),\n",
+    "#     view_elements=None,\n",
+    "#     title=test_view.title,\n",
+    "#     id='',\n",
+    "#     scrollable=False)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "50f1263c423e4725bfd662574c9895fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Label(value='test'), Text(value=''), Checkbox(value=False)))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.display import display\n",
+    "#from traitsui.ipywidgets.ui_panel import panel\n",
+    "\n",
+    "t = ui.control\n",
+    "display(t)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_obj.text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_obj.text = \"Other way\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_obj.boolean"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_obj.boolean = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/traitsui/ipywidgets/__init__.py
+++ b/traitsui/ipywidgets/__init__.py
@@ -1,0 +1,5 @@
+
+from .toolkit import GUIToolkit
+
+# Reference to the GUIToolkit object for IPyWidgets.
+toolkit = GUIToolkit('traitsui', 'ipywidgets', 'traitsui.ipywidgets')

--- a/traitsui/ipywidgets/boolean_editor.py
+++ b/traitsui/ipywidgets/boolean_editor.py
@@ -19,13 +19,13 @@ class SimpleEditor(Editor):
             widget.
         """
         self.control = widgets.Checkbox(value=True, description='')
-        self.control.stateChanged.connect(self.update_object)
+        self.control.observe(self.update_object, 'value')
         self.set_tooltip()
 
-    def update_object(self, state):
+    def update_object(self, event=None):
         """ Handles the user clicking the checkbox.
         """
-        self.value = bool(state)
+        self.value = bool(self.control.value)
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the

--- a/traitsui/ipywidgets/boolean_editor.py
+++ b/traitsui/ipywidgets/boolean_editor.py
@@ -1,0 +1,52 @@
+""" Defines the various Boolean editors for the PyQt user interface toolkit.
+"""
+
+import ipywidgets as widgets
+
+from editor import Editor
+
+# This needs to be imported in here for use by the editor factory for boolean
+# editors (declared in traitsui). The editor factory's text_editor
+# method will use the TextEditor in the ui.
+from text_editor import SimpleEditor as TextEditor
+
+
+class SimpleEditor(Editor):
+    """ Simple style of editor for Boolean values, which displays a check box.
+    """
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        self.control = widgets.Checkbox(value=True, description='')
+        self.control.stateChanged.connect(self.update_object)
+        self.set_tooltip()
+
+    def update_object(self, state):
+        """ Handles the user clicking the checkbox.
+        """
+        self.value = bool(state)
+
+    def update_editor(self):
+        """ Updates the editor when the object trait changes externally to the
+            editor.
+        """
+        self.control.value = self.value
+
+
+class ReadonlyEditor(Editor):
+    """ Read-only style of editor for Boolean values, which displays static text
+    of either "True" or "False".
+    """
+
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        self.control = widgets.Valid(value=self.value, readout='')
+
+    def update_editor(self):
+        """ Updates the editor when the object trait changes externally to the
+            editor.
+        """
+        self.control.value = self.value

--- a/traitsui/ipywidgets/constants.py
+++ b/traitsui/ipywidgets/constants.py
@@ -1,0 +1,31 @@
+""" Defines constants used by the ipywidgets implementation of the various text
+editors and text editor factories.
+"""
+
+#  import ipywidgets as widgets
+
+# Default dialog title
+DefaultTitle = 'Edit properties'
+
+# Color of valid input
+OKColor = ''
+
+# Color to highlight input errors
+ErrorColor = 'danger'
+
+# Color for background of read-only fields
+ReadonlyColor = ''  # QtGui.QColor(244, 243, 238)
+
+# Color for background of fields where objects can be dropped
+DropColor = ''   # QtGui.QColor(215, 242, 255)
+
+# Color for an editable field
+EditableColor = ''  # _palette.color(QtGui.QPalette.Base)
+
+# Color for background of windows (like dialog background color)
+WindowColor = ''  # _palette.color(QtGui.QPalette.Window)
+
+# Screen size values:
+
+screen_dx = ''
+screen_dy = ''

--- a/traitsui/ipywidgets/editor.py
+++ b/traitsui/ipywidgets/editor.py
@@ -1,0 +1,257 @@
+""" Defines the base class for ipywidgets editors.
+"""
+from __future__ import print_function
+
+from traits.api import HasTraits, Instance, Str, Callable
+
+from traitsui.api import Editor as UIEditor
+
+from constants import OKColor, ErrorColor
+
+
+class Editor(UIEditor):
+    """ Base class for ipywidgets editors for Traits-based UIs.
+    """
+
+    def clear_layout(self):
+        """ Delete the contents of a control's layout.
+        """
+        # FIXME?
+        pass
+
+    def _control_changed(self, control):
+        """ Handles the **control** trait being set.
+        """
+        # FIXME: Check we actually make use of this.
+        if control is not None:
+            control._editor = self
+
+    def set_focus(self):
+        """ Assigns focus to the editor's underlying toolkit widget.
+        """
+        # FIXME?
+        pass
+
+    def update_editor(self):
+        """ Updates the editor when the object trait changes externally to the
+            editor.
+        """
+        new_value = self.value
+        if self.control.value != new_value:
+            self.control.value = new_value
+
+    def error(self, excp):
+        """ Handles an error that occurs while setting the object's trait value.
+        """
+        # Make sure the control is a widget rather than a layout.
+        # FIXME?
+        print(self.control, self.description, 'value error', str(excp))
+
+    def set_tooltip(self, control=None):
+        """ Sets the tooltip for a specified control.
+        """
+        desc = self.description
+        if desc == '':
+            desc = self.object.base_trait(self.name).desc
+            if desc is None:
+                return False
+
+            desc = 'Specifies ' + desc
+
+        if control is None:
+            control = self.control
+
+        if hasattr(control, 'tooltip'):
+            control.tooltip = desc
+
+        return True
+
+    def _enabled_changed(self, enabled):
+        """Handles the **enabled** state of the editor being changed.
+        """
+        if self.control is not None:
+            self._enabled_changed_helper(self.control, enabled)
+        if self.label_control is not None:
+            self.label_control.disabled = not enabled
+
+    def _enabled_changed_helper(self, control, enabled):
+        """A helper that allows the control to be a layout and recursively
+           manages all its widgets.
+        """
+        if hasattr(control, 'disabled'):
+            control.disabled = not enabled
+        elif hasattr(control, 'children'):
+            for child in control.children:
+                child.disabled = not enabled
+
+    def _visible_changed(self, visible):
+        """Handles the **visible** state of the editor being changed.
+        """
+        visibility = 'visible' if visible else 'hidden'
+        if self.label_control is not None:
+            self.label_control.layout.visibility = visibility
+        if self.control is None:
+            # We are being called after the editor has already gone away.
+            return
+
+        self._visible_changed_helper(self.control, visibility)
+
+    def _visible_changed_helper(self, control, visibility):
+        """A helper that allows the control to be a layout and recursively
+           manages all its widgets.
+        """
+        if hasattr(control, 'layout'):
+            control.layout.visibility = visibility
+        if hasattr(control, 'children'):
+            for child in control.children:
+                self._visible_changed_helper(child, visibility)
+
+    def get_error_control(self):
+        """ Returns the editor's control for indicating error status.
+        """
+        return self.control
+
+    def in_error_state(self):
+        """ Returns whether or not the editor is in an error state.
+        """
+        return False
+
+    def set_error_state(self, state=None, control=None):
+        """ Sets the editor's current error state.
+        """
+        if state is None:
+            state = self.invalid
+        state = state or self.in_error_state()
+
+        if control is None:
+            control = self.get_error_control()
+
+        if not isinstance(control, list):
+            control = [control]
+
+        for item in control:
+            if item is None:
+                continue
+
+            if state:
+                color = ErrorColor
+            else:
+                color = OKColor
+
+            try:
+                if hasattr(item, 'box_style'):
+                    item.box_style = color
+            # FIXME!
+            except Exception:
+                pass
+
+    def _invalid_changed(self, state):
+        """ Handles the editor's invalid state changing.
+        """
+        self.set_error_state()
+
+    def eval_when(self, condition, object, trait):
+        """ Evaluates a condition within a defined context, and sets a
+        specified object trait based on the result, which is assumed to be a
+        Boolean.
+        """
+        if condition != '':
+            value = True
+            try:
+                if not eval(condition, globals(), self._menu_context):
+                    value = False
+            except:
+                from traitsui.api import raise_to_debug
+                raise_to_debug()
+            setattr(object, trait, value)
+
+
+class EditorWithList(Editor):
+    """ Editor for an object that contains a list.
+    """
+    # Object containing the list being monitored
+    list_object = Instance(HasTraits)
+
+    # Name of the monitored trait
+    list_name = Str
+
+    # Function used to evaluate the current list object value:
+    list_value = Callable
+
+    def init(self, parent):
+        """ Initializes the object.
+        """
+        factory = self.factory
+        name = factory.name
+        if name != '':
+            self.list_object, self.list_name, self.list_value = \
+                self.parse_extended_name(name)
+        else:
+            self.list_object, self.list_name = factory, 'values'
+            self.list_value = lambda: factory.values
+
+        self.list_object.on_trait_change(self._list_updated,
+                                         self.list_name, dispatch='ui')
+        self.list_object.on_trait_change(
+            self._list_updated,
+            self.list_name + '_items',
+            dispatch='ui')
+
+        self._list_updated()
+
+    def dispose(self):
+        """ Disconnects the listeners set up by the constructor.
+        """
+        self.list_object.on_trait_change(self._list_updated,
+                                         self.list_name, remove=True)
+        self.list_object.on_trait_change(
+            self._list_updated,
+            self.list_name + '_items',
+            remove=True)
+
+        super(EditorWithList, self).dispose()
+
+    def _list_updated(self):
+        """ Handles the monitored trait being updated.
+        """
+        self.list_updated(self.list_value())
+
+    def list_updated(self, values):
+        """ Handles the monitored list being updated.
+        """
+        raise NotImplementedError
+
+
+class EditorFromView(Editor):
+    """ An editor generated from a View object.
+    """
+
+    def init(self, parent):
+        """ Initializes the object.
+        """
+        self._ui = ui = self.init_ui(parent)
+        if ui.history is None:
+            ui.history = self.ui.history
+
+        self.control = ui.control
+
+    def init_ui(self, parent):
+        """ Creates and returns the traits UI defined by this editor.
+            (Must be overridden by a subclass).
+        """
+        raise NotImplementedError
+
+    def update_editor(self):
+        """ Updates the editor when the object trait changes externally to the
+            editor.
+        """
+        # Normally nothing needs to be done here, since it should all be
+        # handled by the editor's internally created traits UI:
+        pass
+
+    def dispose(self):
+        """ Disposes of the editor.
+        """
+        self._ui.dispose()
+
+        super(EditorFromView, self).dispose()

--- a/traitsui/ipywidgets/text_editor.py
+++ b/traitsui/ipywidgets/text_editor.py
@@ -63,11 +63,13 @@ class SimpleEditor(Editor):
             # updated.
             control.continous_update = False
 
+        control.observe(self.update_object, 'value')
+
         self.control = control
         self.set_error_state(False)
         self.set_tooltip()
 
-    def update_object(self):
+    def update_object(self, event=None):
         """ Handles the user entering input data in the edit control.
         """
         if (not self._no_update) and (self.control is not None):

--- a/traitsui/ipywidgets/text_editor.py
+++ b/traitsui/ipywidgets/text_editor.py
@@ -1,0 +1,154 @@
+""" Defines the various text editors for the ipywidgets user interface toolkit.
+"""
+
+import ipywidgets as widgets
+
+from traits.api import TraitError
+
+# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
+# compatibility. The class has been moved to the
+# traitsui.editors.text_editor file.
+from traitsui.editors.text_editor import evaluate_trait, ToolkitEditorFactory
+
+from editor import Editor
+
+# FIXME
+#  from editor_factory import ReadonlyEditor as BaseReadonlyEditor
+
+from constants import OKColor
+
+
+class SimpleEditor(Editor):
+    """ Simple style text editor, which displays a text field.
+    """
+
+    # Flag for window styles:
+    base_style = widgets.Text
+
+    # Background color when input is OK:
+    ok_color = OKColor
+
+    # *** Trait definitions ***
+    # Function used to evaluate textual user input:
+    evaluate = evaluate_trait
+
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        factory = self.factory
+        wtype = self.base_style
+        self.evaluate = factory.evaluate
+        self.sync_value(factory.evaluate_name, 'evaluate', 'from')
+
+        if not factory.multi_line or factory.is_grid_cell:
+            wtype = widgets.Text
+
+        if factory.password:
+            wtype = widgets.Password
+
+        multi_line = (wtype is not widgets.Text)
+        if multi_line:
+            self.scrollable = True
+
+        control = wtype(value=self.str_value, description='')
+
+        if factory.read_only:
+            control.disabled = True
+
+        if factory.auto_set and not factory.is_grid_cell:
+            control.continous_update = True
+        else:
+            # Assume enter_set is set, otherwise the value will never get
+            # updated.
+            control.continous_update = False
+
+        self.control = control
+        self.set_error_state(False)
+        self.set_tooltip()
+
+    def update_object(self):
+        """ Handles the user entering input data in the edit control.
+        """
+        if (not self._no_update) and (self.control is not None):
+            try:
+                self.value = self._get_user_value()
+
+                if self._error is not None:
+                    self._error = None
+                    self.ui.errors -= 1
+
+                self.set_error_state(False)
+
+            except TraitError as excp:
+                pass
+
+    def update_editor(self):
+        """ Updates the editor when the object trait changes externally to the
+            editor.
+        """
+        user_value = self._get_user_value()
+        try:
+            unequal = bool(user_value != self.value)
+        except ValueError:
+            # This might be a numpy array.
+            unequal = True
+
+        if unequal:
+            self._no_update = True
+            self.control.value = self.str_value
+            self._no_update = False
+
+        if self._error is not None:
+            self._error = None
+            self.ui.errors -= 1
+            self.set_error_state(False)
+
+    def _get_user_value(self):
+        """ Gets the actual value corresponding to what the user typed.
+        """
+        value = self.control.value
+
+        try:
+            value = self.evaluate(value)
+        except:
+            pass
+
+        try:
+            ret = self.factory.mapping.get(value, value)
+        except TypeError:
+            # The value is probably not hashable.
+            ret = value
+
+        return ret
+
+    def error(self, excp):
+        """ Handles an error that occurs while setting the object's trait value.
+        """
+        if self._error is None:
+            self._error = True
+            self.ui.errors += 1
+
+        self.set_error_state(True)
+
+    def in_error_state(self):
+        """ Returns whether or not the editor is in an error state.
+        """
+        return (self.invalid or self._error)
+
+
+class CustomEditor(SimpleEditor):
+    """ Custom style of text editor, which displays a multi-line text field.
+    """
+
+    base_style = widgets.Textarea
+
+
+class ReadonlyEditor(SimpleEditor):
+    """ Read-only style of text editor, which displays a read-only text field.
+    """
+
+    def init(self, parent):
+        super(ReadonlyEditor, self).init(parent)
+
+        self.control.disabled = True

--- a/traitsui/ipywidgets/toolkit.py
+++ b/traitsui/ipywidgets/toolkit.py
@@ -5,6 +5,7 @@ from traits.trait_notifiers import set_ui_handler
 from pyface.base_toolkit import Toolkit as PyfaceToolkit
 from traitsui.toolkit import Toolkit
 
+from IPython.display import display
 import ipywidgets
 
 
@@ -18,6 +19,7 @@ def ui_handler(handler, *args, **kwds):
     """ Handles UI notification handler requests that occur on a thread other
         than the UI thread.
     """
+    # XXX should really have some sort of queue based system
     handler(*args, **kwds)
 
 set_ui_handler(ui_handler)
@@ -33,6 +35,51 @@ class GUIToolkit(Toolkit):
     def ui_live(self, ui, parent):
         from .ui_panel import ui_panel
         ui_panel(ui, parent)
+
+    def view_application(self, context, view, kind=None, handler=None,
+                         id='', scrollable=None, args=None):
+        """ Creates a PyQt modal dialog user interface that
+            runs as a complete application, using information from the
+            specified View object.
+
+        Parameters
+        ----------
+        context : object or dictionary
+            A single object or a dictionary of string/object pairs, whose trait
+            attributes are to be edited. If not specified, the current object is
+            used.
+        view : view or string
+            A View object that defines a user interface for editing trait
+            attribute values.
+        kind : string
+            The type of user interface window to create. See the
+            **traitsui.view.kind_trait** trait for values and
+            their meanings. If *kind* is unspecified or None, the **kind**
+            attribute of the View object is used.
+        handler : Handler object
+            A handler object used for event handling in the dialog box. If
+            None, the default handler for Traits UI is used.
+        id : string
+            A unique ID for persisting preferences about this user interface,
+            such as size and position. If not specified, no user preferences
+            are saved.
+        scrollable : Boolean
+            Indicates whether the dialog box should be scrollable. When set to
+            True, scroll bars appear on the dialog box if it is not large enough
+            to display all of the items in the view at one time.
+
+        """
+        ui = view.ui(
+            context,
+            kind=kind,
+            handler=handler,
+            id=id,
+            scrollable=scrollable,
+            args=args
+        )
+        display(ui.control)
+        # XXX ideally this would spawn a web server that has enough support of
+        # IPyWidgets to interface
 
     def rebuild_ui(self, ui):
         """ Rebuilds a UI after a change to the content of the UI.

--- a/traitsui/ipywidgets/toolkit.py
+++ b/traitsui/ipywidgets/toolkit.py
@@ -1,0 +1,14 @@
+from traitsui.toolkit import assert_toolkit_import
+assert_toolkit_import(['ipywidgets'])
+
+from traitsui.toolkit import Toolkit
+
+import ipywidgets
+
+
+class GUIToolkit(Toolkit):
+    """ Implementation class for ipywidgets toolkit """
+
+    def ui_panel(self, ui, parent):
+        from .ui_panel import ui_panel
+        ui_panel(ui, parent)

--- a/traitsui/ipywidgets/toolkit.py
+++ b/traitsui/ipywidgets/toolkit.py
@@ -1,9 +1,26 @@
 from traitsui.toolkit import assert_toolkit_import
 assert_toolkit_import(['ipywidgets'])
 
+from traits.trait_notifiers import set_ui_handler
+from pyface.base_toolkit import Toolkit as PyfaceToolkit
 from traitsui.toolkit import Toolkit
 
 import ipywidgets
+
+
+toolkit = PyfaceToolkit(
+    'pyface',
+    'ipywidgets',
+    'traitsui.ipywidgets'
+)
+
+def ui_handler(handler, *args, **kwds):
+    """ Handles UI notification handler requests that occur on a thread other
+        than the UI thread.
+    """
+    handler(*args, **kwds)
+
+set_ui_handler(ui_handler)
 
 
 class GUIToolkit(Toolkit):
@@ -12,3 +29,44 @@ class GUIToolkit(Toolkit):
     def ui_panel(self, ui, parent):
         from .ui_panel import ui_panel
         ui_panel(ui, parent)
+
+    def ui_live(self, ui, parent):
+        from .ui_panel import ui_panel
+        ui_panel(ui, parent)
+
+    def rebuild_ui(self, ui):
+        """ Rebuilds a UI after a change to the content of the UI.
+        """
+        if ui.control is not None:
+            ui.recycle()
+            ui.info.ui = ui
+        ui.rebuild(ui, ui.parent)
+
+    def constants(self):
+        """ Returns a dictionary of useful constants.
+
+            Currently, the dictionary should have the following key/value pairs:
+
+            - 'WindowColor': the standard window background color in the toolkit
+              specific color format.
+        """
+        return {'WindowColor': None}
+
+
+    def color_trait(self, *args, **traits):
+        #import color_trait as ct
+        #return ct.PyQtColor(*args, **traits)
+        from traits.api import Unicode
+        return Unicode
+
+    def rgb_color_trait(self, *args, **traits):
+        #import rgb_color_trait as rgbct
+        #return rgbct.RGBColor(*args, **traits)
+        from traits.api import Unicode
+        return Unicode
+
+    def font_trait(self, *args, **traits):
+        #import font_trait as ft
+        #return ft.PyQtFont(*args, **traits)
+        from traits.api import Unicode
+        return Unicode

--- a/traitsui/ipywidgets/ui_panel.py
+++ b/traitsui/ipywidgets/ui_panel.py
@@ -1,0 +1,96 @@
+from traitsui.base_panel import BasePanel
+from traitsui.group import Group
+
+import ipywidgets
+
+
+def ui_panel(ui, parent):
+    _ui_panel_for(ui, parent, False)
+
+
+def ui_subpanel(ui, parent):
+    _ui_panel_for(ui, parent, True)
+
+
+def _ui_panel_for(ui, parent, is_subpanel):
+    ui.control = control = Panel(ui, parent, is_subpanel).control
+
+
+class Panel(BasePanel):
+
+    def __init__(self, ui, parent, is_subpanel):
+        self.ui = ui
+        history = ui.history
+        view = ui.view
+
+        # Reset any existing history listeners.
+        if history is not None:
+            history.on_trait_change(self._on_undoable, 'undoable', remove=True)
+            history.on_trait_change(self._on_redoable, 'redoable', remove=True)
+            history.on_trait_change(self._on_revertable, 'undoable',
+                                    remove=True)
+
+        # no buttons for now
+
+        self.control = panel(ui)
+
+
+def panel(ui):
+    ui.info.bind_context()
+
+    content = ui._grousp
+    n_groups = len(content)
+
+    if n_groups == 0:
+        panel = None
+    elif n_groups == 1:
+        panel = GroupPanel(content[0], ui).control
+    elif n_groups > 1:
+        panel = ipywidgets.Tab()
+        _fill_panel(panel, content, ui)
+        panel.ui = ui
+
+    # not handling scrollable for now
+
+    return panel
+
+
+def _fill_panel(panel, content, ui, item_handler=None):
+    """ Fill a page-based container panel with content. """
+
+    active = 0
+
+    for index, item in enumeratex(content):
+        page_name = item.get_label(ui)
+        if page_name == "":
+            page_name = "Page {}".format(index)
+
+        if isinstance(item, Group):
+            if item.selected:
+                active = index
+
+            gp = GroupPanel(item, ui, suppress_label=True)
+            page = gp.control
+            sub_page = gp.sub_control
+
+            if isinstance(sub_page, type(panel)) and len(sub_page.children) == 1:
+                new = sub_page.children[0]
+            else:
+                new = page
+
+        else:
+            new = item_handler(item)
+
+        panel.children.append(new)
+        panel.set_title(index, page_name)
+
+    panel.selected_index = active
+
+
+class GroupPanel(object):
+
+    def __init__(self, group, ui, suppress_label=False):
+        content = group.get_content()
+
+        self.group = group
+        self.ui = ui

--- a/traitsui/ipywidgets/ui_panel.py
+++ b/traitsui/ipywidgets/ui_panel.py
@@ -1,7 +1,12 @@
+import re
+
 from traitsui.base_panel import BasePanel
 from traitsui.group import Group
 
 import ipywidgets
+
+# Pattern of all digits
+all_digits = re.compile(r'\d+')
 
 
 def ui_panel(ui, parent):
@@ -38,7 +43,7 @@ class Panel(BasePanel):
 def panel(ui):
     ui.info.bind_context()
 
-    content = ui._grousp
+    content = ui._groups
     n_groups = len(content)
 
     if n_groups == 0:
@@ -60,7 +65,7 @@ def _fill_panel(panel, content, ui, item_handler=None):
 
     active = 0
 
-    for index, item in enumeratex(content):
+    for index, item in enumerate(content):
         page_name = item.get_label(ui)
         if page_name == "":
             page_name = "Page {}".format(index)
@@ -81,7 +86,7 @@ def _fill_panel(panel, content, ui, item_handler=None):
         else:
             new = item_handler(item)
 
-        panel.children.append(new)
+        panel.children += (new,)
         panel.set_title(index, page_name)
 
     panel.selected_index = active
@@ -94,3 +99,242 @@ class GroupPanel(object):
 
         self.group = group
         self.ui = ui
+
+        outer = sub = inner = None
+        if group.label != "":
+            if group.orientation == 'horizontal':
+                outer = inner = ipywidgets.HBox()
+            else:
+                outer = inner = ipywidgets.VBox()
+            inner.children += (ipywidgets.Label(value=group.label),)
+
+        if len(content) == 0:
+            pass
+        elif group.layout == 'tabbed':
+            sub = ipywidgets.Tab()
+            _fill_panel(sub, content, self.ui, self._add_page_item)
+            if outer is None:
+                outer = sub
+            else:
+                inner.children += (sub,)
+            editor = PagedGroupEditor(container=sub, control=sub, ui=ui)
+            self._setup_editor(group, editor)
+        elif group.layout == 'fold':
+            sub = ipywidgets.Accordion()
+            _fill_panel(sub, content, self.ui, self._add_page_item)
+            if outer is None:
+                outer = sub
+            else:
+                inner.children += (sub,)
+            editor = PagedGroupEditor(container=sub, control=sub, ui=ui)
+            self._setup_editor(group, editor)
+        elif group.layout in {'split', 'flow'}:
+            raise NotImplementedError("IPyWidgets backend does not have Split or Flow")
+        else:
+            if isinstance(content[0], Group):
+                layout = self._add_groups(content, inner)
+            else:
+                layout = self._add_items(content, inner)
+
+            if outer is None:
+                outer = layout
+            elif layout is not inner:
+                inner.children += (layout,)
+
+        self.control = outer
+        self.sub_control = sub
+
+    def _setup_editor(self, group, editor):
+        if group.id != '':
+            self.ui.info.bind(group.id, editor)
+        if group.visible_when != '':
+            self.ui.info.bind(group.visible_when, editor)
+        if group.enabled_when != '':
+            self.ui.info.bind(group.enabled_when, editor)
+
+    def _add_page_item(self, item, layout):
+        """Adds a single Item to a page based panel.
+        """
+        layout.children += (item,)
+
+    def _add_groups(self, content, outer):
+        if outer is None:
+            if self.group.orientation == 'horizontal':
+                outer = ipywidgets.HBox()
+            else:
+                outer = ipywidgets.VBox()
+
+        for subgroup in content:
+            panel = GroupPanel(subgroup, self.ui).control
+
+            if panel is not None:
+                outer.children += (panel,)
+            else:
+                # add some space
+                outer.children += (ipywidgets.Label(value=' '),)
+
+        return outer
+
+    def _add_items(self, content, outer=None):
+        ui = self.ui
+        info = ui.info
+        handler = ui.handler
+
+        group = self.group
+        show_left = group.show_left
+        columns = group.columns
+
+        show_labels = any(item.show_label for item in content)
+
+        if show_labels or columns > 1:
+            if self.group.orientation == 'horizontal':
+                inner = ipywidgets.HBox()
+            else:
+                inner = ipywidgets.VBox()
+            #inner = ipywidgets.GridBox()
+            if outer is None:
+                outer = inner
+            else:
+                outer.children += (inner,)
+
+            row = 0
+
+        else:
+            if self.group.orientation == 'horizontal':
+                outer = ipywidgets.HBox()
+            else:
+                outer = ipywidgets.VBox()
+            inner = outer
+            row = -1
+            show_left = None
+
+        col = -1
+        for item in content:
+            col += 1
+            if row > 0 and col > columns:
+                col = 0
+                row += 1
+
+            name = item.name
+            if name == '':
+                label = item.label
+                if label != "":
+                    label = ipywidgets.Label(value=label)
+                    self._add_widget(inner, label, row, col, show_labels)
+                continue
+
+            if name == '_':
+                # separator
+                # XXX do nothing for now
+                continue
+
+            if name == ' ':
+                name = '5'
+
+            if all_digits.match(name):
+                # spacer
+                # XXX do nothing for now
+                continue
+
+            # XXX can we avoid evals for dots?
+            print(item.object_, ui.context)
+            obj = eval(item.object_, globals(), ui.context)
+            print(obj)
+            trait = obj.base_trait(name)
+            desc = trait.desc if trait.desc is not None else ''
+
+            editor_factory = item.editor
+            if editor_factory is None:
+                editor_factory = trait.get_editor().trait_set(
+                    **item.editor_args)
+
+                if editor_factory is None:
+                    # FIXME grab from traitsui.editors instead
+                    from .text_editor import ToolkitEditorFactory
+                    editor_factory = ToolkitEditorFactory()
+
+                if item.format_func is not None:
+                    editor_factory.format_func = item.format_func
+
+                if item.format_str != '':
+                    editor_factory.format_str = item.format_str
+
+                if item.invalid != '':
+                    editor_factory.invalid = item.invalid
+
+            factory_method = getattr(editor_factory, item.style + '_editor')
+            editor = factory_method(
+                ui, obj, name, item.tooltip, None
+            ).trait_set(item=item, object_name=item.object)
+
+            # Tell the editor to actually build the editing widget.  Note that
+            # "inner" is a layout.  This shouldn't matter as individual editors
+            # shouldn't be using it as a parent anyway.  The important thing is
+            # that it is not None (otherwise the main TraitsUI code can change
+            # the "kind" of the created UI object).
+            editor.prepare(inner)
+            control = editor.control
+
+            editor.enabled = editor_factory.enabled
+            if item.show_label:
+                label = self._create_label(item, ui, desc)
+                self._add_widget(inner, label, row, col, show_labels,
+                                 show_left)
+            else:
+                label = None
+
+            editor.label_control = label
+
+            self._add_widget(inner, control, row, col, show_labels)
+
+            # bind to the UIinfo
+            id = item.id or name
+            info.bind(id, editor, item.id)
+
+            # add to the list of editors
+            ui._editors.append(editor)
+
+            # handler may want to know when the editor is defined
+            defined = getattr(handler, id + '_defined', None)
+            if defined is not None:
+                ui.add_defined(defined)
+
+            # add visible_when and enabled_when hooks
+            if item.visible_when != '':
+                ui.add_visible(item.visible_when, editor)
+            if item.enabled_when != '':
+                ui.add_enabled(item.enabled_when, editor)
+
+        return outer
+
+    def _add_widget(self, layout, w, row, column, show_labels,
+                    label_alignment='left'):
+        #print(layout)
+        if row < 0:
+            # we have an HBox or VBox
+            layout.children += (w,)
+        else:
+            if self.group.orientation == 'vertical':
+                row, column = column, row
+
+            if show_labels:
+                column *= 2
+
+# if __name__ == '__main__':
+#     from traitsui.api import VGroup, Item, View, UI, default_handler
+#
+#     test_view = View(
+#         VGroup(
+#             Item(name='', label='test'),
+#             show_labels=False,
+#         ),
+#     )
+#     ui = UI(view=test_view,
+#         context={},
+#         handler=default_handler(),
+#         view_elements=None,
+#         title=test_view.title,
+#         id='',
+#         scrollable=False)
+#
+#     #print(panel(ui))

--- a/traitsui/item.py
+++ b/traitsui/item.py
@@ -312,6 +312,20 @@ class Item(ViewSubElement):
         return ((name == '') or (name == '_') or
                 (all_digits.match(name) is not None))
 
+    def is_label(self):
+        return not self.name and self.label
+
+    def is_separator(self):
+        return self.name == '_'
+
+    def get_spacing(self):
+        if self.name == ' ':
+            return 5
+        elif all_digits.match(self.name):
+            return int(self.name)
+        else:
+            return None
+
     #-------------------------------------------------------------------------
     #  Gets the help text associated with the Item in a specified UI:
     #-------------------------------------------------------------------------

--- a/traitsui/menu.py
+++ b/traitsui/menu.py
@@ -124,16 +124,16 @@ HelpAction = Action(
 )
 
 #: The standard Traits UI menu bar
-StandardMenuBar = MenuBar(
-    Menu(CloseAction,
-         name='File'),
-    Menu(UndoAction,
-         RedoAction,
-         RevertAction,
-         name='Edit'),
-    Menu(HelpAction,
-         name='Help')
-)
+# StandardMenuBar = MenuBar(
+#     Menu(CloseAction,
+#          name='File'),
+#     Menu(UndoAction,
+#          RedoAction,
+#          RevertAction,
+#          name='Edit'),
+#     Menu(HelpAction,
+#          name='Help')
+# )
 
 #-------------------------------------------------------------------------
 #  Standard buttons (i.e. actions):

--- a/traitsui/qt4/color_trait.py
+++ b/traitsui/qt4/color_trait.py
@@ -28,7 +28,7 @@ from traits.api \
 
 
 def convert_to_color(object, name, value):
-    """ Converts a number into a QColor object.
+    """ Converts a number into a CSV color string.
     """
     # Try the toolkit agnostic format.
     try:

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -705,9 +705,7 @@ class _GroupPanel(object):
         columns = group.columns
 
         # See if a label is needed.
-        show_labels = False
-        for item in content:
-            show_labels |= item.show_label
+        show_labels = any(item.show_label for item in content)
 
         # See if a grid layout is needed.
         if show_labels or columns > 1:


### PR DESCRIPTION
Highly experimental, to the point that it possible should live in its own project, but it can live here for now.  To get it to work currently:

- create a new EDM environment
- install the pre-release ipywidgets with `pip install ipywidgets --pre`
- install traitsui and dependencies with `edm install traitsui`
- remove the EDM installed traitsui with `pip uninstall traitsui`
- install this branch with `python setup.py install`

If you are working on this you will need to `python setup.py install` after each change you make.  This sucks, but currently no better option.

Things that still need to be done:

- [ ] build out a bunch of editors
- [ ] toolkit specific color and font traits
- [ ] support for embedding in ipywidgets UIs (_may_ work already, but untested)
- [ ] check various ways of configuring views
- [ ] clean up the `ui_panel.py` code