### PR TITLE
Fix a few invalid escape sequences in docstrings.

### DIFF
--- a/traitsui/editors/color_editor.py
+++ b/traitsui/editors/color_editor.py
@@ -67,7 +67,7 @@ class ToolkitEditorFactory(EditorFactory):
 # in traitsui.<toolkit>.color_editor, and if none is found, the
 # ToolkitEditorFactory declared here is returned.
 def ColorEditor(*args, **traits):
-    """ Returns an instance of the toolkit-specific editor factory declared in
+    r""" Returns an instance of the toolkit-specific editor factory declared in
     traitsui.<toolkit>.color_editor. If such an editor factory
     cannot be located, an instance of the abstract ToolkitEditorFactory
     declared in traitsui.editors.color_editor is returned.

--- a/traitsui/editors/font_editor.py
+++ b/traitsui/editors/font_editor.py
@@ -44,7 +44,7 @@ class ToolkitEditorFactory(EditorFactory):
 # in traitsui.<toolkit>.font_editor, and if none is found, the
 # ToolkitEditorFactory declared here is returned.
 def FontEditor(*args, **traits):
-    """ Returns an instance of the toolkit-specific editor factory declared in
+    r""" Returns an instance of the toolkit-specific editor factory declared in
     traitsui.<toolkit>.font_editor. If such an editor factory
     cannot be located, an instance of the abstract ToolkitEditorFactory
     declared in traitsui.editors.font_editor is returned.

--- a/traitsui/editors/rgb_color_editor.py
+++ b/traitsui/editors/rgb_color_editor.py
@@ -47,7 +47,7 @@ class ToolkitEditorFactory(EditorFactory):
 
 
 def RGBColorEditor(*args, **traits):
-    """ Returns an instance of the toolkit-specific editor factory declared in
+    r""" Returns an instance of the toolkit-specific editor factory declared in
     traitsui.<toolkit>.rgb_color_editor. If such an editor factory
     cannot be located, an instance of the abstract ToolkitEditorFactory
     declared in traitsui.editors.rgb_color_editor is returned.


### PR DESCRIPTION
The following warnings came up in the test suite for another project:
```
/Users/travis/.edm/envs/traits-futures-py36-pyqt/lib/python3.6/site-packages/traitsui/editors/color_editor.py:80: DeprecationWarning: invalid escape sequence \*
  """
/Users/travis/.edm/envs/traits-futures-py36-pyqt/lib/python3.6/site-packages/traitsui/editors/font_editor.py:57: DeprecationWarning: invalid escape sequence \*
  """
/Users/travis/.edm/envs/traits-futures-py36-pyqt/lib/python3.6/site-packages/traitsui/editors/rgb_color_editor.py:60: DeprecationWarning: invalid escape sequence \*
  """
```
This PR fixes those invalid escape sequences.