### PR TITLE
Use tooltip metadata optionally instead of desc.

### DIFF
--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -106,11 +106,13 @@ class Editor(UIEditor):
         """
         desc = self.description
         if desc == '':
-            desc = self.object.base_trait(self.name).desc
+            desc = self.object.base_trait(self.name).tooltip
             if desc is None:
-                return False
+                desc = self.object.base_trait(self.name).desc
+                if desc is None:
+                    return False
 
-            desc = 'Specifies ' + desc
+                desc = 'Specifies ' + desc
 
         if control is None:
             control = self.control

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1101,8 +1101,9 @@ class _GroupPanel(object):
         label text.
 
         We also set the help on the QLabel control (from item.help) and the
-        tooltip (it item.desc exists; we add "Specifies " at the start of the
-        item.desc string, if item.tooltip exists we just use it as is).
+        tooltip (if the ``tooltip`` metadata on the edited trait exists, then
+        it will be used as-is; otherwise, if the ``desc`` metadata exists, the
+        string "Specifies " will be prepended to the start of ``desc``).
 
         Parameters
         ----------

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -832,7 +832,9 @@ class _GroupPanel(object):
             # Otherwise, it must be a trait Item:
             object = eval(item.object_, globals(), ui.context)
             trait = object.base_trait(name)
-            desc = trait.desc or ''
+            desc = trait.tooltip
+            if desc is None:
+                desc = 'Specifies ' + trait.desc if trait.desc else ''
 
             # Get the editor factory associated with the Item:
             editor_factory = item.editor
@@ -1098,9 +1100,9 @@ class _GroupPanel(object):
         we append a suffix (by default a colon ':') at the end of the
         label text.
 
-        We also set the help on the QLabel control (from item.help) and
-        the tooltip (it item.desc exists; we add "Specifies " at the start
-        of the item.desc string).
+        We also set the help on the QLabel control (from item.help) and the
+        tooltip (it item.desc exists; we add "Specifies " at the start of the
+        item.desc string, if item.tooltip exists we just use it as is).
 
         Parameters
         ----------
@@ -1117,6 +1119,7 @@ class _GroupPanel(object):
         -------
         label_control : QLabel
             The control for the label
+
         """
 
         label = item.get_label(ui)
@@ -1139,10 +1142,8 @@ class _GroupPanel(object):
         #wx.EVT_LEFT_UP( control, show_help_popup )
         label_control.help = item.get_help(ui)
 
-        # FIXME: do people rely on traitsui adding 'Specifies ' to the start
-        # of every tooltip? It's not flexible at all
         if desc != '':
-            label_control.setToolTip('Specifies ' + desc)
+            label_control.setToolTip(desc)
 
         return label_control
 

--- a/traitsui/wx/editor.py
+++ b/traitsui/wx/editor.py
@@ -115,11 +115,13 @@ class Editor(UIEditor):
         """
         desc = self.description
         if desc == '':
-            desc = self.object.base_trait(self.name).desc
+            desc = self.object.base_trait(self.name).tooltip
             if desc is None:
-                return False
+                desc = self.object.base_trait(self.name).desc
+                if desc is None:
+                    return False
 
-            desc = 'Specifies ' + desc
+                desc = 'Specifies ' + desc
 
         if control is None:
             control = self.control

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -885,7 +885,10 @@ class FillPanel(object):
             # Otherwise, it must be a trait Item:
             object = eval(item.object_, globals(), ui.context)
             trait = object.base_trait(name)
-            desc = trait.desc or ''
+            desc = trait.tooltip
+            if desc is None:
+                desc = 'Specifies ' + trait.desc if trait.desc else ''
+
             label = None
 
             # If we are displaying labels on the left, add the label to the
@@ -1091,7 +1094,7 @@ class FillPanel(object):
                   pad_side, self.label_pad)
 
         if desc != '':
-            control.SetToolTipString('Specifies ' + desc)
+            control.SetToolTipString(desc)
 
         return control
 


### PR DESCRIPTION
This implements the suggestion in #472.  If a `tooltip` metadata
attribute exists for a trait, it is used as is for the tooltip,
otherwise the original behavior of using the `'Specifies' + item.desc`
is used.