### PR TITLE
Removing duplicate 'wx.' in reference to CB_READONLY

### DIFF
--- a/traitsui/wx/color_editor.py
+++ b/traitsui/wx/color_editor.py
@@ -151,7 +151,7 @@ class SimpleColorEditor(BaseSimpleEditor):
 
         self.control = ColorComboBox(parent, -
                                      1, current_color_name, wx.Point(0, 0), wx.Size(40, -
-                                                                                    1), self.choices, style=wx.wx.CB_READONLY)
+                                                                                    1), self.choices, style=wx.CB_READONLY)
 
         self.control.Bind(wx.EVT_COMBOBOX, self.color_selected)
         return


### PR DESCRIPTION
Removing duplicate 'wx.' in reference to CB_READONLY