### PR TITLE
Clean up of Python modernize

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,9 @@
 # serve to show the default value.
 
 from __future__ import absolute_import
-import sys, os
+
+from io import open
+import os
 
 base_path = os.path.dirname(__file__)
 
@@ -51,7 +53,7 @@ copyright = '2008-2018, Enthought'
 d = {}
 try:
     version_path = os.path.join(base_path, '..', '..', 'traitsui', '_version.py')
-    with open(version_path, 'rb') as fp:
+    with open(version_path, 'r', encoding='utf8') as fp:
         exec(compile(fp.read(), version_path, 'exec'), d)
     release = d['version']
     version = '.'.join(d['version'].split('.', 2)[:2])

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,6 @@
 
 from __future__ import absolute_import
 import sys, os
-from io import open
 
 base_path = os.path.dirname(__file__)
 
@@ -52,8 +51,8 @@ copyright = '2008-2018, Enthought'
 d = {}
 try:
     version_path = os.path.join(base_path, '..', '..', 'traitsui', '_version.py')
-    with open(version_path, 'r', encoding='utf8') as fp:
-        exec(fp.read(), d)
+    with open(version_path, 'rb') as fp:
+        exec(compile(fp.read(), version_path, 'exec'), d)
     release = d['version']
     version = '.'.join(d['version'].split('.', 2)[:2])
 

--- a/docs/source/tutorials/code_snippets/code_block1.py
+++ b/docs/source/tutorials/code_snippets/code_block1.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 from traits.api import *
 from traitsui.api import *
 

--- a/docs/source/tutorials/code_snippets/thread_example.py
+++ b/docs/source/tutorials/code_snippets/thread_example.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 from threading import Thread
 from time import sleep
 

--- a/examples/demo/Advanced/Apply_Revert_handler_demo.py
+++ b/examples/demo/Advanced/Apply_Revert_handler_demo.py
@@ -8,9 +8,8 @@ starting state (before any "Apply").
 Note that this does not automatically provide a full (multi-step incremental)
 Undo capability.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api import HasTraits, Str, List
 from traitsui.api import Item, View, Handler, HGroup, VGroup, TextEditor
 

--- a/examples/demo/Advanced/Auto_editable_readonly_table_cells.py
+++ b/examples/demo/Advanced/Auto_editable_readonly_table_cells.py
@@ -27,9 +27,8 @@ trait.
 
 #-- Imports --------------------------------------------------------------
 
-from __future__ import division
+from __future__ import absolute_import, division
 
-from __future__ import absolute_import
 from operator import attrgetter
 
 from traits.api \

--- a/examples/demo/Advanced/Auto_editable_readonly_table_cells.py
+++ b/examples/demo/Advanced/Auto_editable_readonly_table_cells.py
@@ -40,7 +40,6 @@ from traitsui.api \
 
 from traitsui.table_column \
     import ObjectColumn
-from six.moves import range
 
 #-- Integer Class --------------------------------------------------------
 

--- a/examples/demo/Advanced/Date_editor_demo.py
+++ b/examples/demo/Advanced/Date_editor_demo.py
@@ -4,9 +4,8 @@
 """
 A Traits UI editor that wraps a WX calendar panel.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api import HasTraits, Date, List, Str
 from traitsui.api import View, Item, DateEditor, Group
 

--- a/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
+++ b/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
@@ -56,7 +56,6 @@ Notes:
 from __future__ import absolute_import
 import logging
 import sys
-from six.moves import range
 logging.basicConfig(stream=sys.stderr)
 
 from random \

--- a/examples/demo/Advanced/HDF5_tree_demo.py
+++ b/examples/demo/Advanced/HDF5_tree_demo.py
@@ -6,9 +6,8 @@ In the demo, the path to the selected item is printed whenever the selection
 changes.  In order to run, a path to an existing HDF5 database must be given
 at the bottom of this file.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api import HasTraits, Str, List, Instance
 from traitsui.api import TreeEditor, TreeNode, View, Item, Group
 

--- a/examples/demo/Advanced/Multi_thread_demo.py
+++ b/examples/demo/Advanced/Multi_thread_demo.py
@@ -17,7 +17,6 @@ from threading import Thread
 from time import sleep
 from traits.api import HasTraits, Int, Button
 from traitsui.api import View, Item, VGroup
-from six.moves import range
 
 
 class ThreadDemo(HasTraits):

--- a/examples/demo/Advanced/Multi_thread_demo_2.py
+++ b/examples/demo/Advanced/Multi_thread_demo_2.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 from time import sleep
 from traits.api import HasTraits, Int, Button, List
 from traitsui.api import View, Item, ListEditor
-from six.moves import range
 
 #-- The Counter objects used to keep track of the current count ----------
 

--- a/examples/demo/Advanced/Property_List_demo.py
+++ b/examples/demo/Advanced/Property_List_demo.py
@@ -49,7 +49,6 @@ from traitsui.api \
 
 from traitsui.table_column \
     import ObjectColumn
-from six.moves import range
 
 #-- Person Class ---------------------------------------------------------
 

--- a/examples/demo/Advanced/Table_editor_with_live_search_and_cell_editor.py
+++ b/examples/demo/Advanced/Table_editor_with_live_search_and_cell_editor.py
@@ -403,7 +403,7 @@ class SourceFile(HasTraits):
     @property_depends_on('full_name')
     def _get_contents(self):
         try:
-            with open(self.full_name, 'rU') as fh:
+            with open(self.full_name, 'rU', encoding='utf8') as fh:
                 contents = fh.readlines()
                 return contents
         except Exception:

--- a/examples/demo/Advanced/Table_editor_with_progress_column.py
+++ b/examples/demo/Advanced/Table_editor_with_progress_column.py
@@ -5,7 +5,6 @@ from pyface.api import GUI
 from traits.api import Button, HasTraits, Instance, Int, List, Str
 from traitsui.api import ObjectColumn, TableEditor, UItem, View
 from traitsui.extras.progress_column import ProgressColumn
-from six.moves import range
 
 
 class Job(HasTraits):

--- a/examples/demo/Advanced/Tabular_editor_demo.py
+++ b/examples/demo/Advanced/Tabular_editor_demo.py
@@ -104,7 +104,6 @@ from traits.api import HasTraits, Str, Int, List, Instance, Property, \
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import View, Group, Item, TabularEditor
 from traitsui.tabular_adapter import TabularAdapter
-from six.moves import range
 
 #-- Person Class Definition ----------------------------------------------
 

--- a/examples/demo/Advanced/Time_editor_demo.py
+++ b/examples/demo/Advanced/Time_editor_demo.py
@@ -7,8 +7,8 @@ You can edit the time directly, or by using only the arrow keys (left & right
 to navigate, up & down to change).
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
 import datetime
 
 from traits.api import HasTraits, Time

--- a/examples/demo/Applications/Python_source_browser.py
+++ b/examples/demo/Applications/Python_source_browser.py
@@ -161,7 +161,7 @@ class PythonBrowser(HasPrivateTraits):
     def _file_info_changed(self, file_info):
         fh = None
         try:
-            fh = open(file_info.file_name, 'rU')
+            fh = open(file_info.file_name, 'rU', encoding='utf8')
             self.code = fh.read()
         except:
             pass

--- a/examples/demo/Standard_Editors/CSVListEditor_demo.py
+++ b/examples/demo/Standard_Editors/CSVListEditor_demo.py
@@ -5,9 +5,8 @@ This editor allows the user to enter a *single* line of input text, containing
 comma-separated values (or another separator may be specified). Your program
 specifies an element Trait type of Int, Float, Str, Enum, or Range.
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api import HasTraits, List, Int, Float, Enum, Range, Str, Button, \
     Property
 from traitsui.api import View, Item, Label, Heading, VGroup, HGroup, UItem, \

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
@@ -55,7 +55,7 @@ class LineCountInfo(MFileDialogModel):
             if getsize(self.file_name) > 10000000:
                 return 'File too big...'
 
-            fh = open(self.file_name, 'rU')
+            fh = open(self.file_name, 'rU', encoding='utf8')
             data = fh.read()
             fh.close()
         except:

--- a/examples/tutorials/doc_examples/examples/tree_editor.py
+++ b/examples/tutorials/doc_examples/examples/tree_editor.py
@@ -4,8 +4,8 @@
 # tree_editor.py -- Example of a tree editor
 
 #--[Imports]--------------------------------------------------------------
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 from traits.api \
     import HasTraits, Str, Regex, List, Instance
 from traitsui.api \

--- a/examples/tutorials/traitsui_4.0/deferred.py
+++ b/examples/tutorials/traitsui_4.0/deferred.py
@@ -37,7 +37,6 @@ number of screen updates.
 from __future__ import absolute_import
 from traits.api import *
 from traitsui.api import *
-from six.moves import range
 
 #--[Count Class]----------------------------------------------------------
 

--- a/examples/tutorials/traitsui_4.0/editors/tabular_editor/python_source_browser.py
+++ b/examples/tutorials/traitsui_4.0/editors/tabular_editor/python_source_browser.py
@@ -64,7 +64,6 @@ from traitsui.tabular_adapter \
 
 from pyface.image_resource \
     import ImageResource
-from io import open
 
 #--<Constants>------------------------------------------------------------
 

--- a/examples/tutorials/traitsui_4.0/editors/tabular_editor/sm_person_example.py
+++ b/examples/tutorials/traitsui_4.0/editors/tabular_editor/sm_person_example.py
@@ -69,7 +69,7 @@ from pyface.image_resource \
 
 # Necessary because of the dynamic way in which the demos are loaded:
 import traitsui.api
-from six.moves import range
+
 
 search_path = [join(dirname(traitsui.api.__file__),
                     'demo', 'Advanced')]

--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -26,8 +26,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import sys
 from operator import itemgetter
 import os

--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -192,12 +192,12 @@ MP3Template = """<html>
 #-------------------------------------------------------------------------
 
 
-def read_file(path, mode='rU'):
+def read_file(path, mode='rU', encoding='utf8'):
     """ Returns the contents of a specified text file (or None).
 
     """
     try:
-        with open(path, mode) as fh:
+        with open(path, mode, encoding=encoding) as fh:
             result = fh.read()
         return result
     except Exception:

--- a/integrationtests/styled_date_editor_test.py
+++ b/integrationtests/styled_date_editor_test.py
@@ -1,6 +1,5 @@
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from datetime import date
 
 from traits.etsconfig.api import ETSConfig

--- a/integrationtests/ui/check_list_editor_test.py
+++ b/integrationtests/ui/check_list_editor_test.py
@@ -15,9 +15,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api \
     import Enum, List
 

--- a/integrationtests/ui/check_list_editor_test2.py
+++ b/integrationtests/ui/check_list_editor_test2.py
@@ -15,9 +15,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api \
     import Enum, List, Str
 

--- a/integrationtests/ui/enum_dynamic_test.py
+++ b/integrationtests/ui/enum_dynamic_test.py
@@ -1,8 +1,8 @@
 #  Copyright (c) 2007, Enthought, Inc.
 #  License: BSD Style.
 
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
 from traits.api import *
 from traitsui.api import *
 

--- a/integrationtests/ui/instance_drag_test.py
+++ b/integrationtests/ui/instance_drag_test.py
@@ -16,9 +16,8 @@
 #-------------------------------------------------------------------------
 #  Imports:
 #-------------------------------------------------------------------------
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api \
     import HasTraits, Str, Regex, List, Instance
 

--- a/integrationtests/ui/instance_editor_test5.py
+++ b/integrationtests/ui/instance_editor_test5.py
@@ -1,8 +1,7 @@
 #  Copyright (c) 2007, Enthought, Inc.
 #  License: BSD Style.
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api import *
 from traitsui.api import *
 from traitsui.instance_choice \

--- a/integrationtests/ui/table_editor_focus_bug.py
+++ b/integrationtests/ui/table_editor_focus_bug.py
@@ -1,9 +1,8 @@
 #  Copyright (c) 2007, Enthought, Inc.
 #  License: BSD Style.
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api import HasTraits, Str, List
 from traitsui.api import Group, Item, TableEditor, View
 from traitsui.table_column \

--- a/integrationtests/ui/table_editor_test.py
+++ b/integrationtests/ui/table_editor_test.py
@@ -15,9 +15,8 @@
 #-------------------------------------------------------------------------
 #  Imports:
 #-------------------------------------------------------------------------
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api \
     import HasStrictTraits, Str, Int, Regex, List, Instance
 

--- a/integrationtests/ui/table_editor_test2.py
+++ b/integrationtests/ui/table_editor_test2.py
@@ -14,9 +14,8 @@
 #-------------------------------------------------------------------------
 #  Imports:
 #-------------------------------------------------------------------------
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api \
     import HasStrictTraits, Str, Int, Regex, List
 

--- a/integrationtests/ui/table_list_editor_test.py
+++ b/integrationtests/ui/table_list_editor_test.py
@@ -16,9 +16,8 @@
 #-------------------------------------------------------------------------
 #  Imports:
 #-------------------------------------------------------------------------
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api \
     import HasStrictTraits, List
 

--- a/integrationtests/ui/test_ui2.py
+++ b/integrationtests/ui/test_ui2.py
@@ -15,9 +15,8 @@
 #-------------------------------------------------------------------------
 #  Imports:
 #-------------------------------------------------------------------------
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 import wx
 
 from kiva.traits.kiva_font_trait \

--- a/integrationtests/ui/test_ui5.py
+++ b/integrationtests/ui/test_ui5.py
@@ -34,7 +34,6 @@ from traitsui.api \
 
 from traits.api \
     import Color, Font
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/integrationtests/ui/tree_editor_test.py
+++ b/integrationtests/ui/tree_editor_test.py
@@ -17,9 +17,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.api import HasTraits, Str, Regex, List, Instance
 from traitsui.api import TreeEditor, TreeNode, View, Item, VSplit, \
     HGroup, Handler, spring

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ if not is_released:
     if not IS_RELEASED:
         fullversion += '.dev{0}'.format(dev_num)
 
-    with open(filename, "wt", encoding='ascii') as fp:
+    with open(filename, "w", encoding='ascii') as fp:
         fp.write(template.format(version=VERSION,
                                  full_version=fullversion,
                                  git_revision=git_rev,

--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -40,7 +40,6 @@ from ..view import View
 from ..group import Group
 
 from ..item import Item
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  'ToolkitEditorFactory' class:

--- a/traitsui/editors/tuple_editor.py
+++ b/traitsui/editors/tuple_editor.py
@@ -38,7 +38,6 @@ from ..item import Item
 from ..editor_factory import EditorFactory
 
 from ..editor import Editor
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  'ToolkitEditorFactory' class:

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -29,7 +29,7 @@ import glob
 import token
 import tokenize
 import operator
-from io import StringIO
+from io import BytesIO
 from configobj import ConfigObj
 
 from traits.api import (HasTraits, HasPrivateTraits, Str, Instance, Property,
@@ -44,7 +44,7 @@ from os import listdir
 
 from os.path import (join, isdir, split, splitext, dirname, basename, abspath,
                      exists, isabs)
-from io import open
+
 
 #-------------------------------------------------------------------------
 #  Global data:
@@ -81,7 +81,7 @@ def extract_docstring_from_source(source):
         The source code, sans docstring.
     """
     # Reset file and generate python tokens
-    f = StringIO(source)
+    f = BytesIO(source)
     python_tokens = tokenize.generate_tokens(f.readline)
 
     for ttype, tstring, tstart, tend, tline in python_tokens:
@@ -114,10 +114,10 @@ def parse_source(file_name):
         The source code, sans docstring.
     """
     try:
-        fh = open(file_name, 'rb')
-        source_code = fh.read()
+        with open(file_name, 'rb') as fh:
+            source_code = fh.read()
         return extract_docstring_from_source(source_code)
-    except:
+    except Exception:
         return ('', '')
 
 
@@ -160,7 +160,7 @@ class DemoFileHandler(Handler):
         locals['__file__'] = df.path
         sys.modules['__main__'].__file__ = df.path
         try:
-            exec(compile(open(df.path).read(), df.path, 'exec'), locals, locals)
+            exec(compile(open(df.path, 'rb').read(), df.path, 'exec'), locals, locals)
             demo = self._get_object('modal_popup', locals)
             if demo is not None:
                 demo = ModalDemoButton(demo=demo)
@@ -187,7 +187,7 @@ class DemoFileHandler(Handler):
 
     def execute_test(self, df, locals):
         """ Executes the file in df.path in the namespace of locals."""
-        exec(compile(open(df.path).read(), df.path, 'exec'), locals, locals)
+        exec(compile(open(df.path, 'rb').read(), df.path, 'exec'), locals, locals)
 
     #-------------------------------------------------------------------------
     #  Closes the view:

--- a/traitsui/file_dialog.py
+++ b/traitsui/file_dialog.py
@@ -23,9 +23,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
-from __future__ import print_function
 from os import R_OK, W_OK, access, mkdir
 
 from os.path import (basename, dirname, exists, getatime, getctime, getmtime,

--- a/traitsui/file_dialog.py
+++ b/traitsui/file_dialog.py
@@ -74,7 +74,6 @@ from pyface.timer.api import do_later
 from .helper import commatize
 
 from .toolkit import toolkit
-from io import open
 
 #-------------------------------------------------------------------------
 #  Constants:
@@ -256,10 +255,9 @@ class TextInfo(MFileDialogModel):
             if getsize(self.file_name) > MAX_SIZE:
                 return 'File too big...'
 
-            fh = open(self.file_name, 'rb')
-            data = fh.read()
-            fh.close()
-        except:
+            with open(self.file_name, 'rb') as fh:
+                data = fh.read()
+        except Exception:
             return ''
 
         if (data.find('\x00') >= 0) or (data.find('\xFF') >= 0):

--- a/traitsui/helper.py
+++ b/traitsui/helper.py
@@ -31,7 +31,7 @@ from traits.api import BaseTraitHandler, CTrait, Enum, TraitError
 
 from .ui_traits import SequenceTypes
 import six
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -18,9 +18,8 @@ user interface toolkit.
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import division
+from __future__ import absolute_import, division
 
-from __future__ import absolute_import
 import logging
 
 from pyface.qt import QtCore, QtGui

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -40,7 +40,7 @@ from .editor_factory \
 from .editor \
     import EditorWithList
 import six
-from six.moves import range
+
 
 logger = logging.getLogger(__name__)
 

--- a/traitsui/qt4/color_editor.py
+++ b/traitsui/qt4/color_editor.py
@@ -33,7 +33,7 @@ from .editor_factory \
 from .editor \
     import Editor
 import six
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/qt4/color_editor.py
+++ b/traitsui/qt4/color_editor.py
@@ -13,13 +13,12 @@
 """ Defines the various color editors for the PyQt user interface toolkit.
 """
 
-from __future__ import division
+from __future__ import absolute_import, division
 
 #-------------------------------------------------------------------------
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import absolute_import
 from pyface.qt import QtCore, QtGui
 
 from traitsui.editors.color_editor \

--- a/traitsui/qt4/date_editor.py
+++ b/traitsui/qt4/date_editor.py
@@ -22,8 +22,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import datetime
 
 from pyface.qt import QtCore, QtGui

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -28,7 +28,6 @@ from traitsui.api \
 
 from .constants \
     import OKColor, ErrorColor
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  'Editor' class:

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -40,7 +40,6 @@ from traitsui.helper \
     import enum_values_changed
 from functools import reduce
 import six
-from six.moves import range
 
 
 # default formatting function (would import from string, but not in Python 3)

--- a/traitsui/qt4/extra/qt_view.py
+++ b/traitsui/qt4/extra/qt_view.py
@@ -25,7 +25,6 @@ from pyface.qt import QtGui
 # Enthought library imports.
 from traits.api import File, List, Str
 from traitsui.view import View
-from six.moves import range
 from io import open
 
 # Logger.

--- a/traitsui/qt4/extra/qt_view.py
+++ b/traitsui/qt4/extra/qt_view.py
@@ -60,7 +60,7 @@ class QtView(View):
 
         if self.style_sheet_path:
             try:
-                with open(self.style_sheet_path, 'r') as f:
+                with open(self.style_sheet_path, 'r', encoding='utf8') as f:
                     ui.control.setStyleSheet(f.read())
             except IOError:
                 logger.exception("Error loading Qt style sheet")

--- a/traitsui/qt4/extra/range_slider.py
+++ b/traitsui/qt4/extra/range_slider.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 from pyface.qt import QtGui, QtCore
 
 

--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -24,7 +24,6 @@ from traitsui.editors.file_editor import ToolkitEditorFactory
 from .text_editor import SimpleEditor as SimpleTextEditor
 from .helper import IconButton
 import six
-from six.moves import range
 
 
 is_qt5 = (QtCore.__version_info__[0] >= 5)

--- a/traitsui/qt4/history_editor.py
+++ b/traitsui/qt4/history_editor.py
@@ -28,7 +28,6 @@ from pyface.qt import QtGui
 
 from .editor import Editor
 import six
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  '_HistoryEditor' class:

--- a/traitsui/qt4/image_enum_editor.py
+++ b/traitsui/qt4/image_enum_editor.py
@@ -36,7 +36,7 @@ from .enum_editor import BaseEditor as BaseEnumEditor
 from .enum_editor import SimpleEditor as SimpleEnumEditor
 from .enum_editor import RadioEditor as CustomEnumEditor
 from .helper import pixmap_cache
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  'BaseImageEnumEditor' class:

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -34,7 +34,7 @@ from traitsui.editors.list_editor import ListItemProxy, \
 from .editor import Editor
 from .helper import IconButton
 from .menu import MakeMenu
-\
+
 #-------------------------------------------------------------------------
 #  'SimpleEditor' class:
 #-------------------------------------------------------------------------

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -34,8 +34,7 @@ from traitsui.editors.list_editor import ListItemProxy, \
 from .editor import Editor
 from .helper import IconButton
 from .menu import MakeMenu
-from six.moves import range
-
+\
 #-------------------------------------------------------------------------
 #  'SimpleEditor' class:
 #-------------------------------------------------------------------------

--- a/traitsui/qt4/list_str_model.py
+++ b/traitsui/qt4/list_str_model.py
@@ -22,9 +22,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
-from __future__ import absolute_import
 from pyface.qt import QtCore, QtGui
 
 from traitsui.ui_traits import SequenceTypes

--- a/traitsui/qt4/list_str_model.py
+++ b/traitsui/qt4/list_str_model.py
@@ -29,7 +29,6 @@ from pyface.qt import QtCore, QtGui
 
 from traitsui.ui_traits import SequenceTypes
 import six
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/qt4/menu.py
+++ b/traitsui/qt4/menu.py
@@ -46,8 +46,8 @@ A line beginning with a hyphen (-) is interpreted as a menu separator.
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import re
 
 from pyface.qt import QtGui

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -45,7 +45,6 @@ from .constants \
 from .helper \
     import IconButton
 import six
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  'BaseRangeEditor' class:

--- a/traitsui/qt4/set_editor.py
+++ b/traitsui/qt4/set_editor.py
@@ -35,7 +35,6 @@ from .editor \
 from traits.api \
     import Instance, Property
 import six
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  'SimpleEditor' class:

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -35,7 +35,6 @@ from traitsui.ui_traits import SequenceTypes
 from .editor import Editor
 from .table_model import TableModel, SortFilterTableModel
 import six
-from six.moves import range
 
 
 is_qt5 = QtCore.__version_info__ >= (5,)

--- a/traitsui/qt4/table_model.py
+++ b/traitsui/qt4/table_model.py
@@ -23,7 +23,6 @@ from traitsui.ui_traits import SequenceTypes
 
 from .clipboard import PyMimeData
 from six.moves import map
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/qt4/table_model.py
+++ b/traitsui/qt4/table_model.py
@@ -22,7 +22,6 @@ from pyface.qt import QtCore, QtGui
 from traitsui.ui_traits import SequenceTypes
 
 from .clipboard import PyMimeData
-from six.moves import map
 
 #-------------------------------------------------------------------------
 #  Constants:
@@ -270,7 +269,7 @@ class TableModel(QtCore.QAbstractTableModel):
         # this is a drag from a table model?
         data = mime_data.data(mime_type)
         if not data.isNull() and action == QtCore.Qt.MoveAction:
-            id_and_rows = list(map(int, str(data).split(' ')))
+            id_and_rows = [int(s) for s in data.data().decode('utf8').split(' ')]
             table_id = id_and_rows[0]
             # is it from ourself?
             if table_id == id(self):

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -38,7 +38,6 @@ from traitsui.tabular_adapter import TabularAdapter
 from .editor import Editor
 from .tabular_model import TabularModel
 import six
-from six.moves import range
 
 
 class HeaderEventFilter(QtCore.QObject):

--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -22,9 +22,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
-from __future__ import absolute_import
 from pyface.qt import QtCore, QtGui
 
 from traitsui.ui_traits import SequenceTypes

--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -24,13 +24,12 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import six
+
 from pyface.qt import QtCore, QtGui
 
 from traitsui.ui_traits import SequenceTypes
-
 from .clipboard import PyMimeData
-from six.moves import map
-import six
 
 #-------------------------------------------------------------------------
 #  Constants:
@@ -283,7 +282,7 @@ class TabularModel(QtCore.QAbstractTableModel):
         # this is a drag from a tabular model
         data = mime_data.data(tabular_mime_type)
         if not data.isNull() and action == QtCore.Qt.MoveAction:
-            id_and_rows = list(map(int, data.data().decode('utf8').split(' ')))
+            id_and_rows = [int(s) for s in data.data().decode('utf8').split(' ')]
             table_id = id_and_rows[0]
             # is it from ourself?
             if table_id == id(self):

--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -32,7 +32,6 @@ from traitsui.ui_traits import SequenceTypes
 from .clipboard import PyMimeData
 from six.moves import map
 import six
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/qt4/time_editor.py
+++ b/traitsui/qt4/time_editor.py
@@ -22,8 +22,8 @@
 #  Imports:
 #-------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import datetime
 
 from pyface.qt import QtCore, QtGui

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -44,7 +44,7 @@ from .clipboard import clipboard, PyMimeData
 from .editor import Editor
 from .helper import pixmap_cache
 import six
-from six.moves import range
+
 
 logger = logging.getLogger(__name__)
 

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -25,7 +25,6 @@ from traitsui.menu import Action
 from .constants import DefaultTitle
 from .editor import Editor
 from .helper import restore_window, save_window
-from six.moves import range
 
 
 class ButtonEditor(Editor):

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -45,7 +45,6 @@ from .ui_base \
 
 from .editor \
     import Editor
-from six.moves import range
 
 
 #-------------------------------------------------------------------------

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -13,8 +13,8 @@
 #
 #------------------------------------------------------------------------------
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import sys
 import traceback
 import inspect

--- a/traitsui/tests/editors/test_csv_editor.py
+++ b/traitsui/tests/editors/test_csv_editor.py
@@ -13,9 +13,8 @@
 #
 #------------------------------------------------------------------------------
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 import nose
 
 from traits.has_traits import HasTraits

--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -24,9 +24,8 @@ without de-focusing raises an AttributeError::
         self.value = self.control.GetValue()
     AttributeError: 'NoneType' object has no attribute 'GetValue'
 """
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.has_traits import HasTraits
 from traits.trait_types import Int
 from traitsui.item import Item

--- a/traitsui/tests/editors/test_range_editor_text.py
+++ b/traitsui/tests/editors/test_range_editor_text.py
@@ -19,9 +19,8 @@ Test case for bug (wx, Mac OS X)
 A RangeEditor in mode 'text' for an Int allows values out of range.
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from __future__ import absolute_import
 from traits.has_traits import HasTraits
 from traits.trait_types import Float, Int
 from traitsui.item import Item

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -7,7 +7,6 @@ from traitsui.api import Item, ObjectColumn, TableEditor, View
 from traitsui.tests._tools import (
     skip_if_not_qt4, press_ok_button,
     skip_if_null, store_exceptions_on_all_threads)
-from six.moves import range
 
 
 class ListItem(HasTraits):

--- a/traitsui/tests/test_actions.py
+++ b/traitsui/tests/test_actions.py
@@ -16,8 +16,8 @@
 """
 Test that menu and toolbar actions are triggered.
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import nose
 import pyface
 import unittest

--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -6,8 +6,7 @@
 #  under the conditions described in the aforementioned license.  The license
 #  is also available online at http://www.enthought.com/licenses/BSD.txt
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import,  print_function
 import nose
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 import nose
 import numpy as np
 from numpy.testing import assert_array_equal
-from six.moves import range
+
 
 try:
     from pandas import DataFrame

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -352,7 +352,7 @@ class UI(HasPrivateTraits):
 
         # Get the context 'object' (if available):
         if len(context) == 1:
-            object = list(context.values())[0]
+            object = next(context.values())
         else:
             object = context.get('object')
 
@@ -813,7 +813,7 @@ class UI(HasPrivateTraits):
                 if name != 'handler':
                     break
         elif n == 1:
-            name = list(context.keys())[0]
+            name = next(context.keys())
 
         value = context.get(name)
         if value is not None:

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -352,7 +352,7 @@ class UI(HasPrivateTraits):
 
         # Get the context 'object' (if available):
         if len(context) == 1:
-            object = next(context.values())
+            object = list(context.values())[0]
         else:
             object = context.get('object')
 
@@ -813,7 +813,7 @@ class UI(HasPrivateTraits):
                 if name != 'handler':
                     break
         elif n == 1:
-            name = next(context.keys())
+            name = list(context.keys())[0]
 
         value = context.get(name)
         if value is not None:

--- a/traitsui/ui_editors/array_view_editor.py
+++ b/traitsui/ui_editors/array_view_editor.py
@@ -31,7 +31,6 @@ from ..tabular_adapter import TabularAdapter
 from ..toolkit import toolkit_object
 
 from ..ui_editor import UIEditor
-from six.moves import range
 
 #-- Tabular Adapter Definition -------------------------------------------
 

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -30,7 +30,7 @@ import collections
 from traits.api import (Event, HasPrivateTraits, HasStrictTraits, HasTraits,
                         Instance, Int, List, Property, Str, Trait)
 import six
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -38,7 +38,7 @@ from traits.api import (Event, HasPrivateTraits, HasStrictTraits, HasTraits,
 #-------------------------------------------------------------------------
 
 NumericTypes = six.integer_types + (float, complex)
-SimpleTypes = six.string_types + NumericTypes + (bytes,)
+SimpleTypes = (six.text_type, bytes) + NumericTypes
 
 #-------------------------------------------------------------------------
 #  'AbstractUndoItem' class:

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -27,17 +27,18 @@ from __future__ import absolute_import
 
 import collections
 
+import six
+
 from traits.api import (Event, HasPrivateTraits, HasStrictTraits, HasTraits,
                         Instance, Int, List, Property, Str, Trait)
-import six
 
 
 #-------------------------------------------------------------------------
 #  Constants:
 #-------------------------------------------------------------------------
 
-NumericTypes = (int, int, float, complex)
-SimpleTypes = (str, six.text_type, int, int, float, complex)
+NumericTypes = six.integer_types + (float, complex)
+SimpleTypes = six.string_types + NumericTypes + (bytes,)
 
 #-------------------------------------------------------------------------
 #  'AbstractUndoItem' class:

--- a/traitsui/value_tree.py
+++ b/traitsui/value_tree.py
@@ -480,7 +480,7 @@ class FunctionNode(SingleValueTreeNodeObject):
     def format_value(self, value):
         """ Returns the formatted version of the value.
         """
-        return 'Function %s()' % (value.__code__.co_name)
+        return 'Function %s()' % (value.__name__)
 
 #---------------------------------------------------------------------------
 #  'MethodNode' class:
@@ -503,7 +503,7 @@ class MethodNode(MultiValueTreeNodeObject):
         return '%sound method %s.%s()' % (
             type,
             value.__self__.__class__.__name__,
-            value.__func__.__code__.co_name)
+            value.__func__.__name__)
 
     #-------------------------------------------------------------------------
     #  Returns whether or not the object has children:

--- a/traitsui/wx/check_list_editor.py
+++ b/traitsui/wx/check_list_editor.py
@@ -47,7 +47,6 @@ from .helper \
     import TraitsUIPanel
 from functools import reduce
 import six
-from six.moves import range
 
 logger = logging.getLogger(__name__)
 

--- a/traitsui/wx/code_editor.py
+++ b/traitsui/wx/code_editor.py
@@ -50,7 +50,6 @@ from .editor \
 
 from .constants \
     import OKColor, ErrorColor
-from six.moves import range
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/wx/date_editor.py
+++ b/traitsui/wx/date_editor.py
@@ -34,7 +34,6 @@ from traitsui.wx.editor import Editor
 from traitsui.wx.constants import WindowColor
 from traitsui.wx.text_editor \
     import ReadonlyEditor as TextReadonlyEditor
-from six.moves import range
 
 
 #------------------------------------------------------------------------------

--- a/traitsui/wx/date_editor.py
+++ b/traitsui/wx/date_editor.py
@@ -22,8 +22,8 @@ Future Work
 The class needs to be extend to provide the four basic editor types,
 Simple, Custom, Text, and ReadOnly.
 """
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import datetime
 
 import wx

--- a/traitsui/wx/dnd_editor.py
+++ b/traitsui/wx/dnd_editor.py
@@ -45,7 +45,6 @@ from traitsui.editors.dnd_editor \
 from pyface.wx.drag_and_drop \
     import PythonDropSource, PythonDropTarget, clipboard
 import six
-from io import open
 
 try:
     from apptools.io import File
@@ -223,15 +222,11 @@ class SimpleEditor(Editor):
     def _unpickle(self, file_name):
         """ Returns the unpickled version of a specified file (if possible).
         """
-        fh = None
-        try:
-            fh = open(file_name, 'rb')
-            object = load(fh)
-        except:
-            object = None
-
-        if fh is not None:
-            fh.close()
+        with open(file_name, 'rb') as fh:
+            try:
+                object = load(fh)
+            except Exception:
+                object = None
 
         return object
 

--- a/traitsui/wx/enum_editor.py
+++ b/traitsui/wx/enum_editor.py
@@ -44,7 +44,6 @@ from .constants \
 from .helper \
     import enum_values_changed, TraitsUIPanel, disconnect, disconnect_no_id
 from functools import reduce
-from six.moves import range
 
 
 # default formatting function (would import from string, but not in Python 3)

--- a/traitsui/wx/extra/windows/ie_html_editor.py
+++ b/traitsui/wx/extra/windows/ie_html_editor.py
@@ -27,7 +27,7 @@ import re
 import webbrowser
 
 import wx
-from io import open
+
 
 if wx.Platform == '__WXMSW__':
     # The new version of IEHTMLWindow (wx 2.8.8.0) is mostly compatible with
@@ -161,9 +161,8 @@ class _IEHTMLEditor(Editor):
 
         elif (value[:4] != 'http') or (value.find('://') < 0):
             try:
-                file = open(value, 'rb')
-                self.control.LoadStream(file)
-                file.close()
+                with open(value, 'rb') as file:
+                    self.control.LoadStream(file)
             except:
                 pass
 

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -50,7 +50,7 @@ from .constants \
 from .editor \
     import Editor
 import six
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/wx/image_slice.py
+++ b/traitsui/wx/image_slice.py
@@ -280,7 +280,7 @@ class ImageSlice(HasPrivateTraits):
             else:
                 matches = [(dy / 2, 1)]
         elif n > self.stretch_rows:
-            matches.sort(lambda l, r: cmp(r[1], l[1]))
+            matches.sort(key=lambda x: x[1])
             matches = matches[: self.stretch_rows]
 
         # Calculate and save the horizontal slice sizes:
@@ -309,7 +309,7 @@ class ImageSlice(HasPrivateTraits):
             else:
                 matches = [(dx / 2, 1)]
         elif n > self.stretch_columns:
-            matches.sort(lambda l, r: cmp(r[1], l[1]))
+            matches.sort(key=lambda x: x[1])
             matches = matches[: self.stretch_columns]
 
         # Calculate and save the vertical slice sizes:

--- a/traitsui/wx/image_slice.py
+++ b/traitsui/wx/image_slice.py
@@ -280,7 +280,7 @@ class ImageSlice(HasPrivateTraits):
             else:
                 matches = [(dy / 2, 1)]
         elif n > self.stretch_rows:
-            matches.sort(key=lambda x: x[1])
+            matches.sort(key=lambda x: x[1], reverse=True)
             matches = matches[: self.stretch_rows]
 
         # Calculate and save the horizontal slice sizes:
@@ -309,7 +309,7 @@ class ImageSlice(HasPrivateTraits):
             else:
                 matches = [(dx / 2, 1)]
         elif n > self.stretch_columns:
-            matches.sort(key=lambda x: x[1])
+            matches.sort(key=lambda x: x[1], reverse=True)
             matches = matches[: self.stretch_columns]
 
         # Calculate and save the vertical slice sizes:

--- a/traitsui/wx/image_slice.py
+++ b/traitsui/wx/image_slice.py
@@ -44,7 +44,7 @@ from .constants \
 
 from .constants import is_mac
 import traitsui.wx.constants
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  Recursively paint the parent's background if they have an associated image

--- a/traitsui/wx/list_editor.py
+++ b/traitsui/wx/list_editor.py
@@ -57,7 +57,7 @@ from .menu \
 from .image_control \
     import ImageControl
 import six
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  'SimpleEditor' class:

--- a/traitsui/wx/menu.py
+++ b/traitsui/wx/menu.py
@@ -49,8 +49,8 @@ A line beginning with a hyphen (-) is interpreted as a menu separator.
 #  Imports:
 #=========================================================================
 
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
 import wx
 import re
 import string

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -49,7 +49,7 @@ from .constants \
 
 from .helper \
     import TraitsUIPanel, Slider
-from six.moves import range
+
 
 if not hasattr(wx, 'wx.wxEVT_SCROLL_ENDSCROLL'):
     wxEVT_SCROLL_ENDSCROLL = wx.wxEVT_SCROLL_CHANGED

--- a/traitsui/wx/set_editor.py
+++ b/traitsui/wx/set_editor.py
@@ -42,7 +42,7 @@ from .editor \
 
 from .helper \
     import enum_values_changed, TraitsUIPanel
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  'SimpleEditor' class:

--- a/traitsui/wx/table_editor.py
+++ b/traitsui/wx/table_editor.py
@@ -70,7 +70,7 @@ from .table_model \
 
 from .helper import TraitsUIPanel
 from functools import reduce
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/wx/table_model.py
+++ b/traitsui/wx/table_model.py
@@ -54,7 +54,6 @@ from pyface.ui.wx.grid.trait_grid_cell_adapter \
 
 from pyface.timer.api \
     import do_later
-from six.moves import range
 
 
 logger = logging.getLogger(__name__)

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -63,7 +63,7 @@ from .constants \
 from .ui_base \
     import BaseDialog
 from .constants import is_mac
-from six.moves import range
+
 
 #-------------------------------------------------------------------------
 #  Constants:


### PR DESCRIPTION
Automated updating of code is rarely perfect.  This PR makes some manual improvements which reduce the use of six and/or simplify code.

Particular changes made:

- don't worry about `range` list creation with range under Python 2 in most cases.
- remove some old uses of `cmp`.  Fixes #485
- clean up `__future__` imports
- use list comprehensions instead of `list(map(...))` where it makes sense
- clean up a few uses of `six.string_types` and similar
- avoid `io.open` for binary reads (and use binary reads for code parsing/exec)
- use `next(...value())` instead `list(...value())[0]`
- use `fn.__name__` instead of `fn.__code__.co_name`