### PR TITLE
Remove use of traits._py2to3 module

### DIFF
--- a/traitsui/group.py
+++ b/traitsui/group.py
@@ -36,6 +36,8 @@ from .include import Include
 
 from .ui_traits import SequenceTypes, ContainerDelegate, Orientation, Layout
 
+from .util import str_find
+
 from .dock_window_theme import dock_window_theme, DockWindowTheme
 import six
 
@@ -364,7 +366,7 @@ class Group(ViewSubElement):
         self.show_labels = show_labels
 
         # Parse all of the punctuation based sub-string options:
-        value = self._split('id', value, ':', str.find, 0, 1)
+        value = self._split('id', value, ':', str_find, 0, 1)
         if value != '':
             self.object = value
 

--- a/traitsui/group.py
+++ b/traitsui/group.py
@@ -28,8 +28,6 @@ from __future__ import absolute_import
 from traits.api import (Bool, Delegate, Float, Instance, List, Property, Range,
                         ReadOnly, Str, TraitError, cached_property)
 
-import traits._py2to3 as _py2to3
-
 from .view_element import ViewSubElement
 
 from .item import Item
@@ -366,7 +364,7 @@ class Group(ViewSubElement):
         self.show_labels = show_labels
 
         # Parse all of the punctuation based sub-string options:
-        value = self._split('id', value, ':', _py2to3.str_find, 0, 1)
+        value = self._split('id', value, ':', str.find, 0, 1)
         if value != '':
             self.object = value
 

--- a/traitsui/item.py
+++ b/traitsui/item.py
@@ -31,7 +31,6 @@ from traits.api import (Bool, Callable, Constant, Delegate, Float, Instance,
                         Range, Str, Undefined, Dict,)
 
 from traits.trait_base import user_name_for
-import traits._py2to3 as _py2to3
 
 from .view_element import ViewSubElement
 
@@ -285,8 +284,8 @@ class Item(ViewSubElement):
         value = self._parse_tooltip(value)
         value = self._option(value, '#', 'resizable', True)
         value = self._option(value, '^', 'emphasized', True)
-        value = self._split('id', value, ':', _py2to3.str_find, 0, 1)
-        value = self._split('object', value, '.', _py2to3.str_rfind, 0, 1)
+        value = self._split('id', value, ':', str.find, 0, 1)
+        value = self._split('object', value, '.', str.rfind, 0, 1)
 
         if value != '':
             self.name = value

--- a/traitsui/item.py
+++ b/traitsui/item.py
@@ -36,6 +36,8 @@ from .view_element import ViewSubElement
 
 from .ui_traits import ContainerDelegate, EditorStyle
 
+from .util import str_find, str_rfind
+
 from .editor_factory import EditorFactory
 import six
 
@@ -284,8 +286,8 @@ class Item(ViewSubElement):
         value = self._parse_tooltip(value)
         value = self._option(value, '#', 'resizable', True)
         value = self._option(value, '^', 'emphasized', True)
-        value = self._split('id', value, ':', str.find, 0, 1)
-        value = self._split('object', value, '.', str.rfind, 0, 1)
+        value = self._split('id', value, ':', str_find, 0, 1)
+        value = self._split('object', value, '.', str_rfind, 0, 1)
 
         if value != '':
             self.name = value

--- a/traitsui/util.py
+++ b/traitsui/util.py
@@ -1,0 +1,23 @@
+#  Copyright (c) 2019, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+#  Author: Poruri Sai Rahul
+#  Date:   Feb 2019
+
+import six
+
+if six.PY2:
+    import string
+
+    str_find = string.find
+    str_rfind = string.rfind
+else:
+    str_find = str.find
+    str_rfind = str.rfind

--- a/traitsui/view_element.py
+++ b/traitsui/view_element.py
@@ -32,6 +32,8 @@ from traits.api import HasPrivateTraits, Trait, Bool
 from .ui_traits import (AnObject, DockStyle, EditorStyle, ExportType,
                         HelpId, Image)
 
+from .util import str_rfind
+
 #-------------------------------------------------------------------------
 #  Constants:
 #-------------------------------------------------------------------------
@@ -176,7 +178,7 @@ class ViewSubElement(ViewElement):
         value = self._option(value, '@', 'style', 'custom')
         value = self._option(value, '*', 'style', 'text')
         value = self._option(value, '~', 'style', 'readonly')
-        value = self._split('style', value, ';', str.rfind, 1, 0)
+        value = self._split('style', value, ';', str_rfind, 1, 0)
 
         return value
 

--- a/traitsui/view_element.py
+++ b/traitsui/view_element.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import
 import re
 
 from traits.api import HasPrivateTraits, Trait, Bool
-import traits._py2to3 as _py2to3
 
 from .ui_traits import (AnObject, DockStyle, EditorStyle, ExportType,
                         HelpId, Image)
@@ -177,7 +176,7 @@ class ViewSubElement(ViewElement):
         value = self._option(value, '@', 'style', 'custom')
         value = self._option(value, '*', 'style', 'text')
         value = self._option(value, '~', 'style', 'readonly')
-        value = self._split('style', value, ';', _py2to3.str_rfind, 1, 0)
+        value = self._split('style', value, ';', str.rfind, 1, 0)
 
         return value
 


### PR DESCRIPTION
because all version of python we support have str.find, we don't need to use the private module.

note that str_find and str_rfind are being removed from the private module in traits. see https://github.com/enthought/traits/pull/449