### PR TITLE
For now, allow CI failures on pyside2 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,36 @@ matrix:
   include:
     - env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
     - env: RUNTIME=2.7 TOOLKITS="pyside2"
-    - env: RUNTIME=3.5 TOOLKITS="null pyqt pyqt5 pyside2"
-    - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
+    - env: RUNTIME=3.5 TOOLKITS="null pyqt pyqt5"
+    - env: RUNTIME=3.5 TOOLKITS="pyside2"
+    - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5"
+    - env: RUNTIME=3.6 TOOLKITS="pyside2"
     - os: osx
-      env: RUNTIME=2.7 TOOLKITS="null pyside pyqt pyside2"
+      env: RUNTIME=2.7 TOOLKITS="null pyside pyqt"
+    - os: osx
+      env: RUNTIME=2.7 TOOLKITS="pyside2"
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt wx"
     - os: osx
-      env: RUNTIME=3.5 TOOLKITS="null pyqt5 pyqt pyside2"
+      env: RUNTIME=3.5 TOOLKITS="null pyqt5 pyqt"
     - os: osx
-      env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyqt pyside2"
+      env: RUNTIME=3.5 TOOLKITS="pyside2"
+    - os: osx
+      env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyqt"
+    - os: osx
+      env: RUNTIME=3.6 TOOLKITS="pyside2"
   allow_failures:
+    - env: RUNTIME=2.7 TOOLKITS="pyside2"
+    - env: RUNTIME=3.5 TOOLKITS="pyside2"
+    - env: RUNTIME=3.6 TOOLKITS="pyside2"
+    - os: osx
+      env: RUNTIME=2.7 TOOLKITS="pyside2"
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt wx"
+    - os: osx
+      env: RUNTIME=3.5 TOOLKITS="pyside2"
+    - os: osx
+      env: RUNTIME=3.6 TOOLKITS="pyside2"
   fast_finish: true
 
 branches:


### PR DESCRIPTION
and create separate jobs for pyside2 on 2.7, 3.5 and 3.6, which can
be allowed to fail.

this is hopefully a temporary measure, reverted when a fix for the
pyside2 issues causing CI failure is discovered.