### PR TITLE
FIX: Parse description and source code in Demos

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -100,6 +100,7 @@ dependencies = {
     "pip",
     "nose",
     "coverage",
+    "configobj",
 }
 
 extra_dependencies = {

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,4 +1,5 @@
 nose
+configobj
 coverage
 pygments
 numpy ; python_version >= '3.2'

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -29,4 +29,5 @@ __extras_require__ = {
     'pyqt': ['pyqt>=4.10', 'pygments'],
     'pyqt5': ['pyqt>=5', 'pygments'],
     'pyside': ['pyside>=1.2', 'pygments'],
+    'demo': ['configobj'],
 }

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -124,7 +124,13 @@ def parse_source(file_name):
             source_code = fh.read()
         return extract_docstring_from_source(source_code)
     except Exception:
-        return ('', '')
+        # Print an error message instead of failing silently.
+        # Ideally, the message would be output to the "log" tab.
+        import traceback
+        traceback_text = traceback.format_exc()
+        error_fmt = u"""Sorry, something went wrong.\n\n{}"""
+        error_msg = error_fmt.format(traceback_text)
+        return (error_msg, '')
 
 
 #-------------------------------------------------------------------------

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -29,7 +29,7 @@ import glob
 import token
 import tokenize
 import operator
-from io import BytesIO
+from io import StringIO, open
 from configobj import ConfigObj
 
 from traits.api import (HasTraits, HasPrivateTraits, Str, Instance, Property,
@@ -45,13 +45,6 @@ from os import listdir
 from os.path import (join, isdir, split, splitext, dirname, basename, abspath,
                      exists, isabs)
 
-
-# Tokenize's open handles source file encoding correctly in Python 3
-# otherwise just use builtin open on Python 2
-if sys.version_info.major >= 3:
-    src_open = tokenize.open
-else:
-    src_open = open
 
 #-------------------------------------------------------------------------
 #  Global data:
@@ -80,6 +73,11 @@ def user_name_for(name):
 def extract_docstring_from_source(source):
     """Return module docstring and source code from python source code.
 
+    Parameters
+    ----------
+    source : Str (Unicode)
+        Python source code.
+
     Returns
     -------
     docstring : str
@@ -88,7 +86,7 @@ def extract_docstring_from_source(source):
         The source code, sans docstring.
     """
     # Reset file and generate python tokens
-    f = BytesIO(source)
+    f = StringIO(source)
     python_tokens = tokenize.generate_tokens(f.readline)
 
     for ttype, tstring, tstart, tend, tline in python_tokens:
@@ -121,7 +119,7 @@ def parse_source(file_name):
         The source code, sans docstring.
     """
     try:
-        with src_open(file_name, 'r') as fh:
+        with open(file_name, 'r') as fh:
             source_code = fh.read()
         return extract_docstring_from_source(source_code)
     except Exception:
@@ -167,7 +165,7 @@ class DemoFileHandler(Handler):
         locals['__file__'] = df.path
         sys.modules['__main__'].__file__ = df.path
         try:
-            with src_open(df.path, 'r') as fp:
+            with open(df.path, 'r') as fp:
                 exec(compile(fp.read(), df.path, 'exec'), locals, locals)
             demo = self._get_object('modal_popup', locals)
             if demo is not None:
@@ -195,7 +193,7 @@ class DemoFileHandler(Handler):
 
     def execute_test(self, df, locals):
         """ Executes the file in df.path in the namespace of locals."""
-        with src_open(df.path, 'r') as fp:
+        with open(df.path, 'r') as fp:
             exec(compile(fp.read(), df.path, 'exec'), locals, locals)
 
     #-------------------------------------------------------------------------

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -29,7 +29,8 @@ import glob
 import token
 import tokenize
 import operator
-from io import StringIO, open
+from io import StringIO
+import io
 from configobj import ConfigObj
 
 from traits.api import (HasTraits, HasPrivateTraits, Str, Instance, Property,
@@ -119,7 +120,7 @@ def parse_source(file_name):
         The source code, sans docstring.
     """
     try:
-        with open(file_name, 'r') as fh:
+        with io.open(file_name, 'r', encoding='utf-8') as fh:
             source_code = fh.read()
         return extract_docstring_from_source(source_code)
     except Exception:
@@ -165,7 +166,7 @@ class DemoFileHandler(Handler):
         locals['__file__'] = df.path
         sys.modules['__main__'].__file__ = df.path
         try:
-            with open(df.path, 'r') as fp:
+            with io.open(df.path, 'r', encoding='utf-8') as fp:
                 exec(compile(fp.read(), df.path, 'exec'), locals, locals)
             demo = self._get_object('modal_popup', locals)
             if demo is not None:
@@ -193,7 +194,7 @@ class DemoFileHandler(Handler):
 
     def execute_test(self, df, locals):
         """ Executes the file in df.path in the namespace of locals."""
-        with open(df.path, 'r') as fp:
+        with io.open(df.path, 'r', encoding='utf-8') as fp:
             exec(compile(fp.read(), df.path, 'exec'), locals, locals)
 
     #-------------------------------------------------------------------------

--- a/traitsui/tests/test_extras.py
+++ b/traitsui/tests/test_extras.py
@@ -14,7 +14,7 @@ class TestDemo(TestCase):
         docstring, source = extract_docstring_from_source(source_code)
         self.assertEqual((u"", u""), (docstring, source))
 
-        source_code = u'''""" Module description """'''
+        source_code = u'''""" Module description """\nx=1\ny=2'''
         docstring, source = extract_docstring_from_source(source_code)
-        expected = (u' Module description ', '')
+        expected = (u' Module description ', 'x=1\ny=2')
         self.assertEqual(expected, (docstring, source))

--- a/traitsui/tests/test_extras.py
+++ b/traitsui/tests/test_extras.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from traitsui.extras.demo import extract_docstring_from_source
+
+
+class TestDemo(TestCase):
+
+    def test_extract_docstring_from_source(self):
+        source_code = b""
+        with self.assertRaises(TypeError):
+            docstring, source = extract_docstring_from_source(source_code)
+
+        source_code = u""
+        docstring, source = extract_docstring_from_source(source_code)
+        self.assertEqual((u"", u""), (docstring, source))
+
+        source_code = u'''""" Module description """'''
+        docstring, source = extract_docstring_from_source(source_code)
+        expected = (u' Module description ', '')
+        self.assertEqual(expected, (docstring, source))

--- a/traitsui/tests/test_extras.py
+++ b/traitsui/tests/test_extras.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from traitsui.extras.demo import extract_docstring_from_source
+from traitsui.extras.demo import extract_docstring_from_source, parse_source
 
 
 class TestDemo(TestCase):
@@ -18,3 +18,7 @@ class TestDemo(TestCase):
         docstring, source = extract_docstring_from_source(source_code)
         expected = (u' Module description ', 'x=1\ny=2')
         self.assertEqual(expected, (docstring, source))
+
+    def test_parse_source(self):
+        docstring, source = parse_source('non-existent-file.<>|:')
+        self.assertIn('Sorry, something went wrong.', docstring)


### PR DESCRIPTION
This fixes the docstring and source code parsing when loading demos in examples/demo/demo.py. It's never worked in Python because of an issue of bytes vs unicode what was silenced by a base `except`.

PR #484 introduced two new issues. It used `tokenize.open` on Python 3 and the regular `open` in Python 2, but they have different signatures; `tokenize.open` only takes a filename. This failed silently. And second it used `BytesIO`, where `tokenize.open` returns Unicode, which also failed silently.

This PR uses `io.open` and `StringIO` on both version.

All exceptions are still silently caught.