### PR TITLE
Allow colors to be used as icons for qt TreeEditor nodes

### DIFF
--- a/examples/demo/Extras/Tree_editor_with_TreeNodeRenderer.py
+++ b/examples/demo/Extras/Tree_editor_with_TreeNodeRenderer.py
@@ -18,12 +18,13 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-from random import choice
+from random import choice, uniform
+import colorsys
 
 import numpy as np
 
 from pyface.qt import QtCore, QtGui
-from traits.api import Array, Float, HasTraits, Instance, Int, List, Unicode
+from traits.api import Array, Float, HasTraits, Instance, Int, List, RGBColor, Unicode
 
 from traitsui.api import TreeEditor, TreeNode, UItem, View
 from traitsui.tree_node_renderer import AbstractTreeNodeRenderer
@@ -37,8 +38,14 @@ class MyDataElement(HasTraits):
     #: A random walk to plot.
     data = Array
 
+    #: A color to show as an icon.
+    color = RGBColor
+
     def _data_default(self):
         return np.random.standard_normal((1000,)).cumsum()
+
+    def _color_default(self):
+        return colorsys.hsv_to_rgb(uniform(0.0, 1.0), 1.0, 1.0)
 
 
 class MyData(HasTraits):
@@ -125,6 +132,9 @@ class SparklineTreeNode(TreeNode):
             return self.sparkline_renderer
         else:
             return self.word_wrap_renderer
+
+    def get_icon(self, object, is_expanded):
+        return object.color
 
 
 class SparklineTreeView(HasTraits):

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -591,14 +591,33 @@ class SimpleEditor(Editor):
         elif isinstance(icon_name, ImageResource):
             image_resource = icon_name
 
+        elif isinstance(icon_name, tuple):
+            if max(icon_name) <= 1.0:
+                # rgb(a) color tuple between 0.0 and 1.0
+                color = QtGui.QColor.fromRgbF(*icon_name)
+            else:
+                # rgb(a) color tuple between 0 and 255
+                color = QtGui.QColor.fromRgb(*icon_name)
+            return self._icon_from_color(color)
+
+        elif isinstance(icon_name, QtGui.QColor):
+            return self._icon_from_color(icon_name)
+
         else:
             raise ValueError(
-                "Icon value must be a string or IImageResource instance: " +
+                "Icon value must be a string or color or color tuple or " +
+                "IImageResource instance: " +
                 "given {!r}".format(icon_name)
             )
 
         file_name = image_resource.absolute_path
         return QtGui.QIcon(pixmap_cache(file_name))
+
+    def _icon_from_color(self, color):
+        """ Create a square icon filled with the given color. """
+        pixmap = QtGui.QPixmap(self._tree.iconSize())
+        pixmap.fill(color)
+        return QtGui.QIcon(pixmap)
 
     #-------------------------------------------------------------------------
     #  Adds the event listeners for a specified object:


### PR DESCRIPTION
No corresponding work done for wx backend, however.

Values can be tuples or a value held in a `Color` or `RGBColor` trait.

<img width="512" alt="screen shot 2019-02-25 at 1 00 58 pm" src="https://user-images.githubusercontent.com/600761/53339159-6f7f3600-38fd-11e9-9f1d-d99cf004de53.png">
