### PR TITLE
BUG: allow argumentless call to _ModalDialog.close()

### DIFF
--- a/traitsui/qt4/ui_modal.py
+++ b/traitsui/qt4/ui_modal.py
@@ -165,7 +165,7 @@ class _ModalDialog(BaseDialog):
 
         self.add_contents(panel(ui), bbox)
 
-    def close(self, rc):
+    def close(self, rc=True):
         """Close the dialog and set the given return code.
         """
         super(_ModalDialog, self).close(rc)


### PR DESCRIPTION
`CloseAction` invokes `Handler._on_close()` which eventually invokes the `close()` method (without arguments) on one of these toolkit objects that provides the flavor of dialog that was requested. [Most have a default value](https://github.com/enthought/traitsui/blob/master/traitsui/qt4/ui_live.py#L205) for the return code, but the Qt implementation of the modal dialog did not. The [wx version of the modal dialog](https://github.com/enthought/traitsui/blob/master/traitsui/wx/ui_modal.py#L240) also provides the default value.

I would add a test except that it appears to be frightfully difficult to test modal dialogs in a test suite. Manual testing confirms that it does what one expects it to do, however.