### PR TITLE
Fixes for Undo/Redo

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -369,8 +369,10 @@ class Editor(HasPrivateTraits):
                 self._update_editor, self.extended_name, remove=True)
             return
 
-        # Log the change that was made (as long as it is not for an event):
-        if object.base_trait(name).type != 'event':
+        # Log the change that was made (as long as the Item is not readonly
+        # or it is not for an event):
+        if (self.item.style != 'readonly'
+                and object.base_trait(name).type != 'event'):
             self.log_change(self.get_undo_item, object, name,
                             old_value, new_value)
 

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -125,8 +125,9 @@ class UndoItem(AbstractUndoItem):
         """
         try:
             setattr(self.object, self.name, self.old_value)
-        except:
-            pass
+        except Exception:
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
 
     #-------------------------------------------------------------------------
     #  Re-does the change:
@@ -137,8 +138,9 @@ class UndoItem(AbstractUndoItem):
         """
         try:
             setattr(self.object, self.name, self.new_value)
-        except:
-            pass
+        except Exception:
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
 
     #-------------------------------------------------------------------------
     #  Merges two undo items if possible:
@@ -164,6 +166,8 @@ class UndoItem(AbstractUndoItem):
                     # operation in a text editor):
                     n1 = len(v1)
                     n2 = len(v2)
+                    if abs(n1 - n2) > 1:
+                        return False
                     n = min(n1, n2)
                     i = 0
                     while (i < n) and (v1[i] == v2[i]):
@@ -197,7 +201,7 @@ class UndoItem(AbstractUndoItem):
                                     return False
                                 self.new_value = v2
                                 return True
-                        except:
+                        except Exception:
                             pass
 
                 elif t1 in NumericTypes:
@@ -251,8 +255,9 @@ class ListUndoItem(AbstractUndoItem):
         try:
             list = getattr(self.object, self.name)
             list[self.index: (self.index + len(self.added))] = self.removed
-        except:
-            pass
+        except Exception:
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
 
     #-------------------------------------------------------------------------
     #  Re-does the change:
@@ -264,8 +269,9 @@ class ListUndoItem(AbstractUndoItem):
         try:
             list = getattr(self.object, self.name)
             list[self.index: (self.index + len(self.removed))] = self.added
-        except:
-            pass
+        except Exception:
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
 
     #-------------------------------------------------------------------------
     #  Merges two undo items if possible:


### PR DESCRIPTION
Improve undo/redo exception handling.  Don't try to undo readonly items.  Short-circuit some expensive string comparisons.