### PR TITLE
BUG: Use an existing omnipresent trait for the spring dummy.

### DIFF
--- a/traitsui/item.py
+++ b/traitsui/item.py
@@ -552,7 +552,11 @@ class Spring(Item):
     #-------------------------------------------------------------------------
 
     # Name of the trait the item is editing
-    name = 'spring'
+    # Just a dummy trait that exists on all HasTraits objects. It's an Event,
+    # so it won't cause Traits UI to add any synchronization, and because it
+    # already exists, it won't force the addition of a new trait with a bogus
+    # name.
+    name = 'trait_modified'
 
     # Should a label be displayed?
     show_label = Bool(False)

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -20,10 +20,10 @@ Test cases for the UI object.
 from __future__ import absolute_import
 import nose
 
-from traits.has_traits import HasTraits
+from traits.has_traits import HasTraits, HasStrictTraits
 from traits.trait_types import Str, Int
 import traitsui
-from traitsui.item import Item
+from traitsui.item import Item, spring
 from traitsui.view import View
 
 from traitsui.tests._tools import *
@@ -39,6 +39,17 @@ class FooDialog(HasTraits):
         Item('my_int'),
         Item('my_str'),
         buttons=['OK']
+    )
+
+
+class DisallowNewTraits(HasStrictTraits):
+    """ Make sure no extra traits are added.
+    """
+    x = Int(10)
+
+    traits_view = View(
+        Item('x'),
+        spring,
     )
 
 
@@ -191,3 +202,11 @@ def test_destroy_after_ok_qt():
 
     nose.tools.assert_is_none(ui.control)
     nose.tools.assert_equal(control.deleteLater._n_calls, 1)
+
+
+def test_no_spring_trait():
+    obj = DisallowNewTraits()
+    ui = obj.edit_traits()
+    ui.dispose()
+
+    nose.tools.assert_true('spring' not in obj.traits())

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -204,6 +204,7 @@ def test_destroy_after_ok_qt():
     nose.tools.assert_equal(control.deleteLater._n_calls, 1)
 
 
+@skip_if_null
 def test_no_spring_trait():
     obj = DisallowNewTraits()
     ui = obj.edit_traits()


### PR DESCRIPTION
Fixes #514

Regardless of any underlying issues that we might want to also fix in Traits itself, this is likely a good idea.