### PR TITLE
Fix crash when creating view of TabularEditor with no columns

### DIFF
--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -634,7 +634,12 @@ class _TableView(QtGui.QTableView):
             # we make a reasonable guess based on the minimum size hint and the font
             # of the first row.
             size = vheader.minimumSectionSize()
-            font = editor.adapter.get_font(editor.object, editor.name, 0)
+
+            # Check if any columns have been added, and use their font, otherwise
+            # use the default font
+            font = None
+            if 0 in editor.adapter.column_map:
+                font = editor.adapter.get_font(editor.object, editor.name, 0)
             if font is not None:
                 size = max(
                     size, QtGui.QFontMetrics(

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -372,7 +372,9 @@ class TabularAdapter(HasPrivateTraits):
         font object should be returned. Note that all columns for the specified
         table row will use the font value returned.
         """
-        return self._result_for('get_font', object, trait, row, column)
+        if column in self.column_map:
+            return self._result_for('get_font', object, trait, row, column)
+        return None
 
     def get_text_color(self, object, trait, row, column=0):
         """ Returns the text color to use for a specified row or cell.
@@ -688,12 +690,8 @@ class TabularAdapter(HasPrivateTraits):
 
     def _result_for(self, name, object, trait, row, column, value=None):
         """ Returns/Sets the value of the specified *name* attribute for the
-        specified *object.trait[row].column* item, or None if the requested
-        column cannot be found in self.column_map.
-
+            specified *object.trait[row].column* item.
         """
-        if column not in self.column_map:
-            return None
         self.object = object
         self.name = trait
         self.row = row

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -688,8 +688,12 @@ class TabularAdapter(HasPrivateTraits):
 
     def _result_for(self, name, object, trait, row, column, value=None):
         """ Returns/Sets the value of the specified *name* attribute for the
-            specified *object.trait[row].column* item.
+        specified *object.trait[row].column* item, or None if the requested
+        column cannot be found in self.column_map.
+
         """
+        if column not in self.column_map:
+            return None
         self.object = object
         self.name = trait
         self.row = row

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -372,9 +372,7 @@ class TabularAdapter(HasPrivateTraits):
         font object should be returned. Note that all columns for the specified
         table row will use the font value returned.
         """
-        if column in self.column_map:
-            return self._result_for('get_font', object, trait, row, column)
-        return None
+        return self._result_for('get_font', object, trait, row, column)
 
     def get_text_color(self, object, trait, row, column=0):
         """ Returns the text color to use for a specified row or cell.


### PR DESCRIPTION
This PR aims to fix #520 by returning None any time a `View` tries to get the properties of a non-existent column in `TabularAdapter`.

I can't spot any unintended consequences of this, but as it seems that `get_font` is the main culprit here, this change could be applied at that level instead if that makes more sense.