### PR TITLE
Make Qt TextEditor the same as SimpleEditor for TextEditor factory.

### DIFF
--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -248,3 +248,11 @@ class ReadonlyEditor(BaseReadonlyEditor):
             new_value = '*' * len(new_value)
 
         self.control.setText(new_value)
+
+
+#-------------------------------------------------------------------------
+#  'TextEditor' class:
+#-------------------------------------------------------------------------
+
+# Same as SimpleEditor for a text editor.
+TextEditor = SimpleEditor


### PR DESCRIPTION
This matches the behaviour of the Wx backend and fixes a bug where passwords would not be obscured when using `style='text`' in the Qt backend.

Fixes #10.