### PR TITLE
Scroll to column implementation.

### DIFF
--- a/traitsui/editors/tabular_editor.py
+++ b/traitsui/editors/tabular_editor.py
@@ -114,6 +114,10 @@ class TabularEditor(BasicEditorFactory):
     # trigger a scroll-to command. The data is an integer giving the row.
     scroll_to_row = Str
 
+    # The optional extended name of the Event trait that should be used to
+    # trigger a scroll-to command. The data is an integer giving the column.
+    scroll_to_column = Str
+
     # Controls behavior of scroll to row
     scroll_to_row_hint = Enum("center", "top", "bottom", "visible")
 

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -443,7 +443,10 @@ class TabularEditor(Editor):
         """
         scroll_hint = self.scroll_to_row_hint_map.get(
             self.factory.scroll_to_row_hint, self.control.PositionAtCenter)
-        self.control.scrollTo(self.model.index(0, column), scroll_hint)
+        self.control.scrollTo(
+            self.model.index(self.activated_row, column),
+            scroll_hint
+        )
 
     #-- Table Control Event Handlers -----------------------------------------
 

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -101,6 +101,9 @@ class TabularEditor(Editor):
     # The event triggering scrolling.
     scroll_to_row = Event(Int)
 
+    # The event triggering scrolling.
+    scroll_to_column = Event(Int)
+
     # Is the tabular editor scrollable? This value overrides the default.
     scrollable = True
 
@@ -180,6 +183,8 @@ class TabularEditor(Editor):
             'column_right_clicked',
             'to')
         self.sync_value(factory.scroll_to_row, 'scroll_to_row', 'from',
+                        is_event=True)
+        self.sync_value(factory.scroll_to_column, 'scroll_to_column', 'from',
                         is_event=True)
 
         # Connect other signals as necessary
@@ -432,6 +437,14 @@ class TabularEditor(Editor):
         scroll_hint = self.scroll_to_row_hint_map.get(
             self.factory.scroll_to_row_hint, self.control.PositionAtCenter)
         self.control.scrollTo(self.model.index(row, 0), scroll_hint)
+
+    def _scroll_to_column_changed(self, column):
+        """ Scroll to the given column.
+        """
+        import ipdb; ipdb.set_trace()
+        scroll_hint = self.scroll_to_row_hint_map.get(
+            self.factory.scroll_to_row_hint, self.control.PositionAtCenter)
+        self.control.scrollTo(self.model.index(0, column), scroll_hint)
 
     #-- Table Control Event Handlers -----------------------------------------
 

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -441,7 +441,6 @@ class TabularEditor(Editor):
     def _scroll_to_column_changed(self, column):
         """ Scroll to the given column.
         """
-        import ipdb; ipdb.set_trace()
         scroll_hint = self.scroll_to_row_hint_map.get(
             self.factory.scroll_to_row_hint, self.control.PositionAtCenter)
         self.control.scrollTo(self.model.index(0, column), scroll_hint)


### PR DESCRIPTION
This change allows scrolling to the column index (nearly identical to scroll_to_row). Corran, I couldnt find any tests for tabular_editor, but if I did miss it please let me know and I will add one asap for scroll_to_column. 

In the near future, I'll send you another PR to populate a selected_column property similar to selected_row, but this one would be useful for our project now.