### PR TITLE
Add `scroll_to_row` functionality to DataFrameEditor

### DIFF
--- a/traitsui/ui_editors/data_frame_editor.py
+++ b/traitsui/ui_editors/data_frame_editor.py
@@ -190,7 +190,7 @@ class _DataFrameEditor(UIEditor):
                     clicked=self._target_name(self.factory.clicked),
                     dclicked=self._target_name(self.factory.dclicked),
                     scroll_to_row=self._target_name(self.factory.scroll_to_row),  # noqa
-                    scroll_to_row_hint=self._target_name(self.factory.scroll_to_row_hint),  # noqa
+                    scroll_to_row_hint=self.factory.scroll_to_row_hint,
                     right_clicked=self._target_name(self.factory.right_clicked),  # noqa
                     right_dclicked=self._target_name(self.factory.right_dclicked),  # noqa
                     column_clicked=self._target_name(self.factory.column_clicked),  # noqa

--- a/traitsui/ui_editors/data_frame_editor.py
+++ b/traitsui/ui_editors/data_frame_editor.py
@@ -189,6 +189,8 @@ class _DataFrameEditor(UIEditor):
                     activated_row=self._target_name(self.factory.activated_row),  # noqa
                     clicked=self._target_name(self.factory.clicked),
                     dclicked=self._target_name(self.factory.dclicked),
+                    scroll_to_row=self._target_name(self.factory.scroll_to_row),  # noqa
+                    scroll_to_row_hint=self._target_name(self.factory.scroll_to_row_hint),  # noqa
                     right_clicked=self._target_name(self.factory.right_clicked),  # noqa
                     right_dclicked=self._target_name(self.factory.right_dclicked),  # noqa
                     column_clicked=self._target_name(self.factory.column_clicked),  # noqa
@@ -297,6 +299,13 @@ class DataFrameEditor(BasicEditorFactory):
     # The optional extended name of the trait to synchronize left double click
     # data with. The data is a TabularEditorEvent:
     dclicked = Str
+
+    # The optional extended name of the Event trait that should be used to
+    # trigger a scroll-to command. The data is an integer giving the row.
+    scroll_to_row = Str
+
+    # Controls behavior of scroll to row
+    scroll_to_row_hint = Enum("center", "top", "bottom", "visible")
 
     # The optional extended name of the trait to synchronize right click data
     # with. The data is a TabularEditorEvent:

--- a/traitsui/ui_editors/data_frame_editor.py
+++ b/traitsui/ui_editors/data_frame_editor.py
@@ -191,6 +191,7 @@ class _DataFrameEditor(UIEditor):
                     dclicked=self._target_name(self.factory.dclicked),
                     scroll_to_row=self._target_name(self.factory.scroll_to_row),  # noqa
                     scroll_to_row_hint=self.factory.scroll_to_row_hint,
+                    scroll_to_column=self._target_name(self.factory.scroll_to_column),  # noqa
                     right_clicked=self._target_name(self.factory.right_clicked),  # noqa
                     right_dclicked=self._target_name(self.factory.right_dclicked),  # noqa
                     column_clicked=self._target_name(self.factory.column_clicked),  # noqa
@@ -306,6 +307,10 @@ class DataFrameEditor(BasicEditorFactory):
 
     # Controls behavior of scroll to row
     scroll_to_row_hint = Enum("center", "top", "bottom", "visible")
+
+    # The optional extended name of the Event trait that should be used to
+    # trigger a scroll-to command. The data is an integer giving the column.
+    scroll_to_column = Str
 
     # The optional extended name of the trait to synchronize right click data
     # with. The data is a TabularEditorEvent:


### PR DESCRIPTION
Realized that this feature was missing from the DataFrameEditor, despite mirroring (most of) the other functionality provided by the TabularEditor. Turned out to be easy, as least for the environment I'm running in. I wasn't sure if this was left out originally for backend-specific reasons, but figured I'd open a PR to start the conversation.