### PR TITLE
Maintenance branch TreeNodeObject fix

### DIFF
--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -1892,11 +1892,11 @@ class TreeNodeObject(HasPrivateTraits):
         """
         label = node.label
         if label[:1] != '=':
-            memo = ('label', label, object, listener)
+            memo = ('label', label, node, listener)
             if not remove:
                 def wrapped_listener(target, name, new):
                     """ Ensure listener gets called with correct object. """
-                    return listener(object, name, new)
+                    return listener(node, name, new)
 
                 self._listener_cache[memo] = wrapped_listener
             else:

--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -1742,6 +1742,9 @@ class TreeNodeObject(HasPrivateTraits):
     """ Represents the object that corresponds to a tree node.
     """
 
+    #: A cache for listeners that need to keep state.
+    _listener_cache = Dict
+
     #-------------------------------------------------------------------------
     #  Returns whether chidren of this object are allowed or not:
     #-------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #556 on 6.1 maintenance branch.

This is just #557 rebased.