### PR TITLE
Fix the sizeHint() default for TreeItemDelegate

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1952,10 +1952,7 @@ class TreeItemDelegate(QtGui.QStyledItemDelegate):
 
         renderer = node.get_renderer(object, column=column)
         if renderer is None:
-            size = index.model().data(index, QtCore.Qt.SizeHintRole)
-            if size is None:
-                size = QtCore.QSize(1, 21)
-            return size
+            return super(TreeItemDelegate, self).sizeHint(option, index)
 
         size_context = (option, index)
         size = renderer.size(


### PR DESCRIPTION
The default implementation of `QStyledItemDelegate::sizeHint()` is exactly what Qt calls when no item delegate is set on a `QTreeView`.