### PR TITLE
Update Travis CI configuration to be compatible with Ubuntu Xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: generic
-sudo: false
+dist: xenial
+services:
+  - xvfb
 
 env:
   global:
@@ -34,8 +36,6 @@ cache:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
-  - export DISPLAY=:99.0
-  - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage


### PR DESCRIPTION
Fix framebuffer configuration for compatibility with Ubuntu Xenial.

Also remove the deprecated "sudo: false".

refs:
- https://docs.travis-ci.com/user/gui-and-headless-browsers
- https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
- https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration