### PR TITLE
Fix modal view application

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -114,6 +114,10 @@ extra_dependencies = {
     'null': set()
 }
 
+runtime_dependencies = {
+    '2.7': {'mock'},
+}
+
 environment_vars = {
     'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
@@ -139,7 +143,10 @@ def install(runtime, toolkit, environment):
     """
     parameters = get_parameters(runtime, toolkit, environment)
     packages = ' '.join(
-        dependencies | extra_dependencies.get(toolkit, set()))
+        dependencies
+        | extra_dependencies.get(toolkit, set())
+        | runtime_dependencies.get(runtime, set())
+    )
     # edm commands to setup the development environment
     commands = [
         "edm environments create {environment} --force --version={runtime}",

--- a/traitsui/qt4/view_application.py
+++ b/traitsui/qt4/view_application.py
@@ -126,9 +126,10 @@ class ViewApplication(object):
             try:
                 from etsdevtools.developer.helper.fbi import enable_fbi
                 enable_fbi()
-            except:
+            except Exception:
                 pass
 
+        # this will block for modal dialogs, but not non-modals
         self.ui = self.view.ui(self.context,
                                kind=self.kind,
                                handler=self.handler,
@@ -136,4 +137,6 @@ class ViewApplication(object):
                                scrollable=self.scrollable,
                                args=self.args)
 
-        start_event_loop_qt4()
+        # only non-modal UIs need to have an event loop started for them
+        if kind not in {'modal', 'livemodal'}:
+            start_event_loop_qt4()

--- a/traitsui/tests/test_view_application.py
+++ b/traitsui/tests/test_view_application.py
@@ -20,6 +20,10 @@ from ._tools import is_current_backend_qt4
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
+if no_gui_test_assistant:
+    class GuiTestAssistant(object):
+        pass
+
 
 class SimpleModel(HasTraits):
     cell = Int

--- a/traitsui/tests/test_view_application.py
+++ b/traitsui/tests/test_view_application.py
@@ -1,0 +1,227 @@
+#  Copyright (c) 2019, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+
+from __future__ import absolute_import
+import unittest
+
+from pyface.timer.api import CallbackTimer
+from pyface.toolkit import toolkit_object
+from traits.api import HasTraits, Instance, Int
+from traitsui.api import Handler, Item, UIInfo, View, toolkit
+
+from ._tools import is_current_backend_qt4
+
+# get the pyface GUI test assistant and Modal dialog tester
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
+
+class SimpleModel(HasTraits):
+    cell = Int
+
+
+class ClosableHandler(Handler):
+
+    info = Instance(UIInfo)
+
+    def init(self, info):
+        self.info = info
+        return True
+
+    def test_close(self):
+        self.info.ui.dispose()
+
+
+simple_view = View(
+    Item('cell'),
+    title="Enter IDs and conditions",
+    buttons=['OK', 'Cancel']
+)
+
+
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestViewApplication(GuiTestAssistant, unittest.TestCase):
+
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+        self.model = SimpleModel()
+        self.handler = ClosableHandler()
+        self.event_loop_timeout = False
+        self.closed = False
+
+        if is_current_backend_qt4():
+            if len(self.qt_app.topLevelWidgets()) > 0:
+                with self.event_loop_with_timeout(repeat=5):
+                    self.gui.invoke_later(self.qt_app.closeAllWindows)
+
+    def view_application(self, kind, button=None):
+        if button is None:
+            self.gui.invoke_later(self.close_dialog)
+        else:
+            self.gui.invoke_later(self.click_button, text=button)
+
+        timer = CallbackTimer.single_shot(
+            callback=self.stop_event_loop,
+            interval=1.0
+        )
+        try:
+            self.result = toolkit().view_application(
+                context=self.model,
+                view=simple_view,
+                kind=kind,
+                handler=self.handler,
+            )
+        finally:
+            timer.stop()
+
+    def view_application_event_loop(self, kind):
+        with self.event_loop_until_condition(lambda: self.closed):
+            self.gui.invoke_later(
+                toolkit().view_application,
+                context=self.model,
+                view=simple_view,
+                kind=kind,
+                handler=self.handler,
+            )
+            self.gui.invoke_after(100, self.close_dialog)
+
+    def close_dialog(self):
+        if is_current_backend_qt4():
+            self.handler.info.ui.control.close()
+            self.closed = True
+        else:
+            raise NotImplementedError("Can't close current backend")
+
+    def click_button(self, text):
+        if is_current_backend_qt4():
+            from pyface.qt.QtGui import QPushButton
+            from pyface.ui.qt4.util.testing import find_qt_widget
+
+            button = find_qt_widget(
+                self.handler.info.ui.control,
+                QPushButton,
+                lambda widget: widget.text() == text,
+            )
+            if button is None:
+                raise RuntimeError("Can't find {} button".format(text))
+            button.click()
+            self.closed = True
+        else:
+            raise NotImplementedError("Can't click current backend")
+
+    def stop_event_loop(self):
+        self.gui.stop_event_loop()
+        self.event_loop_timeout = True
+
+    def test_modal_view_application_close(self):
+        self.view_application('modal')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertFalse(self.result)
+
+    def test_nonmodal_view_application_close(self):
+        self.view_application('nonmodal')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertTrue(self.result)
+
+    def test_livemodal_view_application_close(self):
+        self.view_application('livemodal')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertFalse(self.result)
+
+    def test_live_view_application_close(self):
+        self.view_application('live')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertTrue(self.result)
+
+    def test_modal_view_application_ok(self):
+        self.view_application('modal', button='OK')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertTrue(self.result)
+
+    def test_nonmodal_view_application_ok(self):
+        self.view_application('nonmodal', button='OK')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertTrue(self.result)
+
+    def test_livemodal_view_application_ok(self):
+        self.view_application('livemodal', button='OK')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertTrue(self.result)
+
+    def test_live_view_application_ok(self):
+        self.view_application('live', button='OK')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertTrue(self.result)
+
+    def test_modal_view_application_cancel(self):
+        self.view_application('modal', button='Cancel')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertFalse(self.result)
+
+    def test_nonmodal_view_application_cancel(self):
+        self.view_application('nonmodal', button='Cancel')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertFalse(self.result)
+
+    def test_livemodal_view_application_cancel(self):
+        self.view_application('livemodal', button='Cancel')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertFalse(self.result)
+
+    def test_live_view_application_cancel(self):
+        self.view_application('live', button='Cancel')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+        self.assertFalse(self.result)
+
+    def test_modal_view_application_eventloop_close(self):
+        self.view_application_event_loop('modal')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+
+    def test_nonmodal_view_application_eventloop_close(self):
+        self.view_application_event_loop('nonmodal')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+
+    def test_livemodal_view_application_eventloop_close(self):
+        self.view_application_event_loop('livemodal')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)
+
+    def test_live_view_application_eventloop_close(self):
+        self.view_application_event_loop('live')
+
+        self.assertTrue(self.closed)
+        self.assertFalse(self.event_loop_timeout)


### PR DESCRIPTION
The event loop was being run twice under Qt when using `configure_traits` in conjunction with a modal `kind`.

Also adds fairly comprehensive tests for `view_application` which covers most use cases under Qt.

Fixes #573.