### PR TITLE
Remove uses of etsdevtools.

### DIFF
--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -153,19 +153,6 @@ def save_window(ui):
     geom = ui.control.geometry()
     ui.save_prefs((geom.x(), geom.y(), geom.width(), geom.height()))
 
-#-------------------------------------------------------------------------
-#  Safely tries to pop up an FBI window if etsdevtools.debug is installed
-#-------------------------------------------------------------------------
-
-
-def open_fbi():
-    try:
-        from etsdevtools.developer.helper.fbi import if_fbi
-        if not if_fbi():
-            import traceback
-            traceback.print_exc()
-    except ImportError:
-        pass
 
 #-------------------------------------------------------------------------
 #  'IconButton' class:

--- a/traitsui/qt4/view_application.py
+++ b/traitsui/qt4/view_application.py
@@ -120,6 +120,8 @@ class ViewApplication(object):
         self.id = id
         self.scrollable = scrollable
         self.args = args
+
+        # this will block for modal dialogs, but not non-modals
         self.ui = self.view.ui(self.context,
                                kind=self.kind,
                                handler=self.handler,

--- a/traitsui/qt4/view_application.py
+++ b/traitsui/qt4/view_application.py
@@ -120,15 +120,6 @@ class ViewApplication(object):
         self.id = id
         self.scrollable = scrollable
         self.args = args
-
-        # FIXME: fbi is wx specific at the moment.
-        if os.environ.get('ENABLE_FBI') is not None:
-            try:
-                from etsdevtools.developer.helper.fbi import enable_fbi
-                enable_fbi()
-            except:
-                pass
-
         self.ui = self.view.ui(self.context,
                                kind=self.kind,
                                handler=self.handler,

--- a/traitsui/wx/custom_editor.py
+++ b/traitsui/wx/custom_editor.py
@@ -35,9 +35,6 @@ from traitsui.editors.custom_editor \
 from .editor \
     import Editor
 
-from .helper \
-    import open_fbi
-
 #-------------------------------------------------------------------------
 #  'CustomEditor' class:
 #-------------------------------------------------------------------------
@@ -57,10 +54,7 @@ class CustomEditor(Editor):
         """
         factory = self.factory.factory
         if factory is not None:
-            try:
-                self.control = factory(*((parent, self) + self.factory.args))
-            except:
-                open_fbi()
+            self.control = factory(*((parent, self) + self.factory.args))
         if self.control is None:
             self.control = control = wx.StaticText(
                 parent, -1, 'An error occurred creating a custom editor.\n'

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -540,20 +540,6 @@ def init_wx_handlers(control, object, prefix=''):
             handler(control, method)
 
 #-------------------------------------------------------------------------
-#  Safely tries to pop up an FBI window if etsdevtools.debug is installed
-#-------------------------------------------------------------------------
-
-
-def open_fbi():
-    try:
-        from etsdevtools.developer.helper.fbi import if_fbi
-        if not if_fbi():
-            import traceback
-            traceback.print_exc()
-    except ImportError:
-        pass
-
-#-------------------------------------------------------------------------
 #  'GroupEditor' class:
 #-------------------------------------------------------------------------
 

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -56,7 +56,7 @@ from pyface.dock.api import DockWindow, DockSizer, DockSection, DockRegion, Dock
 
 from .constants import OKColor
 from .editor import Editor
-from .helper import open_fbi, TraitsUIPanel, TraitsUIScrolledPanel
+from .helper import TraitsUIPanel, TraitsUIScrolledPanel
 
 #-------------------------------------------------------------------------
 #  Global data:
@@ -1650,18 +1650,12 @@ class SimpleEditor(Editor):
         """ Returns whether the action should be defined in the user interface.
         """
         if action.defined_when != '':
-            try:
-                if not eval(action.defined_when, globals(), self._context):
-                    return False
-            except:
-                open_fbi()
+            if not eval(action.defined_when, globals(), self._context):
+                return False
 
         if action.visible_when != '':
-            try:
-                if not eval(action.visible_when, globals(), self._context):
-                    return False
-            except:
-                open_fbi()
+            if not eval(action.visible_when, globals(), self._context):
+                return False
 
         return True
 
@@ -1729,11 +1723,8 @@ class SimpleEditor(Editor):
         """
         if condition != '':
             value = True
-            try:
-                if not eval(condition, globals(), self._context):
-                    value = False
-            except:
-                open_fbi()
+            if not eval(condition, globals(), self._context):
+                value = False
             setattr(object, trait, value)
 
 #----- Menu event handlers: ----------------------------------------------

--- a/traitsui/wx/view_application.py
+++ b/traitsui/wx/view_application.py
@@ -130,13 +130,6 @@ class ViewApplication(wx.App):
         self.scrollable = scrollable
         self.args = args
 
-        if os.environ.get('ENABLE_FBI') is not None:
-            try:
-                from etsdevtools.developer.helper.fbi import enable_fbi
-                enable_fbi()
-            except:
-                pass
-
         if redirect_filename.strip() != '':
             super(ViewApplication, self).__init__(1, redirect_filename)
         else:


### PR DESCRIPTION
This PR removes the `open_fbi` function and its uses, and so also removes the (optional) dependence of the code on `etsdevtools`, which is unmaintained.
