### PR TITLE
Call correct object on label change for TreeNodeObject

### DIFF
--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -174,6 +174,13 @@ class TestTreeView(unittest.TestCase):
             notifiers_list = bogus.trait(trait)._notifiers(False)
             self.assertEqual(expected_listeners, len(notifiers_list))
 
+            if trait == 'name':
+                # fire a label change
+                bogus.name = "Something else"
+            else:
+                # change the children
+                bogus.bogus_list.append(BogusTreeNodeObject())
+
             # Manually close the UI
             press_ok_button(ui)
 

--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -1896,7 +1896,7 @@ class TreeNodeObject(HasPrivateTraits):
             if not remove:
                 def wrapped_listener(target, name, new):
                     """ Ensure listener gets called with correct object. """
-                    return listener(node, name, new)
+                    return listener(self, name, new)
 
                 self._listener_cache[memo] = wrapped_listener
             else:


### PR DESCRIPTION
This fixes #576.  `TreeNodeObject` instances expect to be the object that the label change is applied to.