### PR TITLE
Fix table editor styling

### DIFF
--- a/traitsui/editors/table_editor.py
+++ b/traitsui/editors/table_editor.py
@@ -85,70 +85,70 @@ class ToolkitEditorFactory(EditorFactory):
     #  Trait definitions:
     #-------------------------------------------------------------------------
 
-    # List of initial table column descriptors
+    #: List of initial table column descriptors
     columns = List(Instance('traitsui.table_column.TableColumn'))
 
-    # List of other table column descriptors (not initially displayed)
+    #: List of other table column descriptors (not initially displayed)
     other_columns = List(
         Instance('traitsui.table_column.TableColumn'))
 
-    # The object trait containing the list of column descriptors
+    #: The object trait containing the list of column descriptors
     columns_name = Str
 
-    # The desired number of visible rows in the table
+    #: The desired number of visible rows in the table
     rows = Int
 
-    # The optional extended name of the trait used to specify an external filter
-    # for the table data. The value of the trait must either be an instance of
-    # TableEditor, a callable that accepts one argument (a table row) and
-    # returns True or False to indicate whether the specified object passes the
-    # filter or not, or **None** to indicate that no filter is to be applied:
+    #: The optional extended name of the trait used to specify an external filter
+    #: for the table data. The value of the trait must either be an instance of
+    #: TableEditor, a callable that accepts one argument (a table row) and
+    #: returns True or False to indicate whether the specified object passes the
+    #: filter or not, or **None** to indicate that no filter is to be applied:
     filter_name = Str
 
-    # Initial filter that should be applied to the table
+    #: Initial filter that should be applied to the table
     filter = Instance('traitsui.table_filter.TableFilter')
 
-    # List of available filters that can be applied to the table
+    #: List of available filters that can be applied to the table
     filters = List(Instance(
         'traitsui.table_filter.TableFilter'))
 
-    # The optional extended trait name of the trait used to notify that the
-    # filter has changed and the displayed objects should be updated.
-    # It should be an Event.
+    #: The optional extended trait name of the trait used to notify that the
+    #: filter has changed and the displayed objects should be updated.
+    #: It should be an Event.
     update_filter_name = Str
 
-    # Filter object used to allow a user to search the table.
-    # NOTE: If left as None, the table will not be searchable.
+    #: Filter object used to allow a user to search the table.
+    #: NOTE: If left as None, the table will not be searchable.
     search = Instance('traitsui.table_filter.TableFilter')
 
-    # Default context menu to display when any cell is right-clicked
+    #: Default context menu to display when any cell is right-clicked
     menu = Instance('traitsui.menu.Menu')
 
-    # Default trait name containg menu
+    #: Default trait name containg menu
     menu_name = Str
 
-    # Are objects deletable from the table?
+    #: Are objects deletable from the table?
     deletable = BoolOrCallable(False)
 
-    # Is the table editable?
+    #: Is the table editable?
     editable = Bool(True)
 
-    # Should the editor become active after the first click
+    #: Should the editor become active after the first click
     edit_on_first_click = Bool(True)
 
-    # Can the user reorder the items in the table?
+    #: Can the user reorder the items in the table?
     reorderable = Bool(False)
 
-    # Can the user configure the table columns?
+    #: Can the user configure the table columns?
     configurable = Bool(True)
 
-    # Should the cells of the table automatically size to the optimal size?
+    #: Should the cells of the table automatically size to the optimal size?
     auto_size = Bool(True)
 
-    # Mirrors the Qt QSizePolicy.Policy attribute, for horizontal and vertical
-    # dimensions.  For these to be useful, set auto_size to False.  If these
-    # are None, then the table size policy will not be set in that dimension
-    # (for backwards compatibility).
+    #: Mirrors the Qt QSizePolicy.Policy attribute, for horizontal and vertical
+    #: dimensions.  For these to be useful, set auto_size to False.  If these
+    #: are None, then the table size policy will not be set in that dimension
+    #: (for backwards compatibility).
     h_size_policy = Enum(
         None,
         "preferred",
@@ -168,172 +168,166 @@ class ToolkitEditorFactory(EditorFactory):
         "minimum_expanding",
         "ignored")
 
-    # Should a new row automatically be added to the end of the table to allow
-    # the user to create new entries? If True, **row_factory** must be set.
+    #: Should a new row automatically be added to the end of the table to allow
+    #: the user to create new entries? If True, **row_factory** must be set.
     auto_add = Bool(False)
 
-    # Should the table items be presented in reverse order?
+    #: Should the table items be presented in reverse order?
     reverse = Bool(False)
 
-    # The DockWindow graphical theme:
+    #: The DockWindow graphical theme:
     dock_theme = Any
 
-    # View to use when editing table items.
-    # NOTE: If not specified, the table items are not editable in a separate
-    # pane of the editor.
+    #: View to use when editing table items.
+    #: NOTE: If not specified, the table items are not editable in a separate
+    #: pane of the editor.
     edit_view = AView(' ')
 
-    # The handler to apply to **edit_view**
+    #: The handler to apply to **edit_view**
     edit_view_handler = Instance(Handler)
 
-    # Width to use for the edit view
+    #: Width to use for the edit view
     edit_view_width = Float(-1.0)
 
-    # Height to use for the edit view
+    #: Height to use for the edit view
     edit_view_height = Float(-1.0)
 
-    # Layout orientation of the table and its associated editor pane. This
-    # attribute applies only if **edit_view** is not ' '.
+    #: Layout orientation of the table and its associated editor pane. This
+    #: attribute applies only if **edit_view** is not ' '.
     orientation = Orientation
 
-    # Is the table sortable by clicking on the column headers?
+    #: Is the table sortable by clicking on the column headers?
     sortable = Bool(True)
 
-    # Does sorting affect the model (vs. just the view)?
+    #: Does sorting affect the model (vs. just the view)?
     sort_model = Bool(False)
 
-    # Should grid lines be shown on the table?
+    #: Should grid lines be shown on the table?
     show_lines = Bool(True)
 
-    # Should the toolbar be displayed? (Note that False will override settings
-    # such as 'configurable', etc., and is a quick way to prevent the toolbar
-    # from being displayed; but True will not cause a toolbar to appear if one
-    # would not otherwise have been displayed)
+    #: Should the toolbar be displayed? (Note that False will override settings
+    #: such as 'configurable', etc., and is a quick way to prevent the toolbar
+    #: from being displayed; but True will not cause a toolbar to appear if one
+    #: would not otherwise have been displayed)
     show_toolbar = Bool(False)
 
-    # The vertical scroll increment for the table:
+    #: The vertical scroll increment for the table:
     scroll_dy = Range(1, 32)
 
-    # Grid line color
+    #: Grid line color.  Does not work on Qt.
     line_color = Color(0xC4C0A9)
 
-    # Show column labels?
+    #: Show column labels?
     show_column_labels = Bool(True)
 
-    # Show row labels?
+    #: Show row labels?
     show_row_labels = Bool(False)
 
-    # Font to use for text in cells
+    #: Font to use for text in cells
     cell_font = Font
 
-    # Color to use for text in cells
-    cell_color = Color('black')
+    #: Color to use for text in cells
+    cell_color = Color(default=None, allow_none=True)
 
-    # Color to use for cell backgrounds
-    # The default is the "WindowColor" constant declared in ui.api:
-    # we shall set the value in a trait initializer method, in order to avoid
-    # circular imports.
-    cell_bg_color = Color
+    #: Color to use for cell backgrounds
+    cell_bg_color = Color(default=None, allow_none=True)
 
-    # Color to use for read-only cell backgrounds
-    cell_read_only_bg_color = Color(0xF8F7F1)
+    #: Color to use for read-only cell backgrounds
+    cell_read_only_bg_color = Color(default=None, allow_none=True)
 
-    # Whether to even-odd alternate the background color.
+    #: Whether to even-odd alternate the background color. Qt only.
     alternate_bg_color = Bool(False)
 
-    # Font to use for text in labels
+    #: Font to use for text in labels
     label_font = Font
 
-    # Color to use for text in labels
-    label_color = Color('black')
+    #: Color to use for text in labels
+    label_color = Color(default=None, allow_none=True)
 
-    # Color to use for label backgrounds
-    # The default is the "WindowColor" constant declared in ui.api:
-    # we shall set the value in a trait initializer method, in order to avoid
-    # circular imports.
-    label_bg_color = Color
+    #: Color to use for label backgrounds. Some Qt styles (eg. MacOS) ignore this.
+    label_bg_color = Color(default=None, allow_none=True)
 
-    # Background color of selected item
-    selection_bg_color = Color('light blue', allow_none=True)
+    #: Background color of selected item.  Does not work on Qt.
+    selection_bg_color = Color(default=None, allow_none=True)
 
-    # Color of selected text
-    selection_color = Color('black')
+    #: Color of selected text.  Does not work on Qt.
+    selection_color = Color(default=None, allow_none=True)
 
-    # Height (in pixels) of column labels
+    #: Height (in pixels) of column labels
     column_label_height = Int(25)
 
-    # Width (in pixels) of row labels
+    #: Width (in pixels) of row labels
     row_label_width = Int(82)
 
-    # The initial height of each row (<= 0 means use default value):
+    #: The initial height of each row (<= 0 means use default value):
     row_height = Int(0)
 
-    # The optional extended name of the trait that the indices of the items
-    # currently passing the table filter are synced with:
+    #: The optional extended name of the trait that the indices of the items
+    #: currently passing the table filter are synced with:
     filtered_indices = Str
 
-    # The selection mode of the table. The meaning of the various values are as
-    # follows:
-    #
-    # row
-    #   Entire rows are selected. At most one row can be selected at once.
-    #   This is the default.
-    # rows
-    #   Entire rows are selected. More than one row can be selected at once.
-    # column
-    #   Entire columns are selected. At most one column can be selected at
-    #   once.
-    # columns
-    #   Entire columns are selected. More than one column can be selected at
-    #   once.
-    # cell
-    #   Single cells are selected. Only one cell can be selected at once.
-    # cells
-    #   Single cells are selected. More than one cell can be selected at once.
+    #: The selection mode of the table. The meaning of the various values are as
+    #: follows:
+    #:
+    #: row
+    #:   Entire rows are selected. At most one row can be selected at once.
+    #:   This is the default.
+    #: rows
+    #:   Entire rows are selected. More than one row can be selected at once.
+    #: column
+    #:   Entire columns are selected. At most one column can be selected at
+    #:   once.
+    #: columns
+    #:   Entire columns are selected. More than one column can be selected at
+    #:   once.
+    #: cell
+    #:   Single cells are selected. Only one cell can be selected at once.
+    #: cells
+    #:   Single cells are selected. More than one cell can be selected at once.
     selection_mode = Enum('row', 'rows', 'column', 'columns', 'cell', 'cells')
 
-    # The optional extended name of the trait that the current selection is
-    # synced with:
+    #: The optional extended name of the trait that the current selection is
+    #: synced with:
     selected = Str
 
-    # The optional extended trait name of the trait that the indices of the
-    # current selection are synced with:
+    #: The optional extended trait name of the trait that the indices of the
+    #: current selection are synced with:
     selected_indices = Str
 
-    # The optional extended trait name of the trait that should be assigned
-    # an ( object, column ) tuple when a table cell is clicked on (Note: If you
-    # want to receive repeated clicks on the same cell, make sure the trait is
-    # defined as an Event):
+    #: The optional extended trait name of the trait that should be assigned
+    #: an ( object, column ) tuple when a table cell is clicked on (Note: If you
+    #: want to receive repeated clicks on the same cell, make sure the trait is
+    #: defined as an Event):
     click = Str
 
-    # The optional extended trait name of the trait that should be assigned
-    # an ( object, column ) tuple when a table cell is double-clicked on
-    # (Note: if you want to receive repeated double-clicks on the same cell,
-    # make sure the trait is defined as an Event):
+    #: The optional extended trait name of the trait that should be assigned
+    #: an ( object, column ) tuple when a table cell is double-clicked on
+    #: (Note: if you want to receive repeated double-clicks on the same cell,
+    #: make sure the trait is defined as an Event):
     dclick = Str
 
-    # Called when a table item is selected
+    #: Called when a table item is selected
     on_select = Any
 
-    # Called when a table item is double clicked
+    #: Called when a table item is double clicked
     on_dclick = Any
 
-    # A factory to generate new rows.
-    # NOTE: If None, then the user will not be able to add new rows to the
-    # table. If not None, then it must be a callable that accepts
-    # **row_factory_args** and **row_factory_kw** and returns a new object
-    # that can be added to the table.
+    #: A factory to generate new rows.
+    #: NOTE: If None, then the user will not be able to add new rows to the
+    #: table. If not None, then it must be a callable that accepts
+    #: **row_factory_args** and **row_factory_kw** and returns a new object
+    #: that can be added to the table.
     row_factory = Any
 
-    # Arguments to pass to the **row_factory** callable when a new row is
-    # created
+    #: Arguments to pass to the **row_factory** callable when a new row is
+    #: created
     row_factory_args = Tuple
 
-    # Keyword arguments to pass to the **row_factory** callable when a new row
-    # is created
+    #: Keyword arguments to pass to the **row_factory** callable when a new row
+    #: is created
     row_factory_kw = Dict
 
-    # Hooks for replacing parts of the implementation.
+    #: Hooks for replacing parts of the implementation.
     table_view_factory = Callable()
     source_model_factory = Callable()
     model_factory = Callable()
@@ -396,24 +390,6 @@ class ToolkitEditorFactory(EditorFactory):
         self.editable = False
         return super(ToolkitEditorFactory, self).readonly_editor(
             ui, object, name, description, parent)
-
-    def _cell_bg_color_default(self):
-        """ Returns the default value of the cell background color.
-        """
-        # NOTE: We are initializing the 'cell_bg_color' trait in this method
-        # instead of in the trait definition so as to delay importing from
-        # ui.api until needed (will lead to circular imports otherwise).
-        from ..api import WindowColor
-        return WindowColor
-
-    def _label_bg_color_default(self):
-        """ Returns the default value of the cell background color.
-        """
-        # NOTE: We are initializing the 'cell_bg_color' trait in this method
-        # instead of in the trait definition so as to delay importing from
-        # ui.api until needed (will lead to circular imports otherwise).
-        from ..api import WindowColor
-        return WindowColor
 
     #-------------------------------------------------------------------------
     #  Event handlers:

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -1166,6 +1166,8 @@ class TableView(QtGui.QTableView):
             set_resize_mode(QtGui.QHeaderView.ResizeToContents)
         elif not factory.show_row_labels:
             vheader.hide()
+        if factory.row_height > 0:
+            vheader.setDefaultSectionSize(factory.row_height)
         self.setAlternatingRowColors(factory.alternate_bg_color)
         self.setHorizontalScrollMode(QtGui.QAbstractItemView.ScrollPerPixel)
         # Configure the column headings.

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -874,6 +874,22 @@ class TableDelegate(QtGui.QStyledItemDelegate):
         """
         editor.setGeometry(option.rect)
 
+    def paint(self, painter, option, index):
+        self.initStyleOption(option, index)
+
+        if ((option.state & QtGui.QStyle.State_Selected) and
+                (option.state & QtGui.QStyle.State_Active)):
+            factory = self.parent()._editor.factory
+            if factory.selection_bg_color is not None:
+                option.palette.setColor(
+                    QtGui.QPalette.Highlight, factory.selection_bg_color_)
+            if factory.selection_color is not None:
+                option.palette.setColor(
+                    QtGui.QPalette.HighlightedText, factory.selection_color_)
+
+        QtGui.QApplication.style().drawControl(
+            QtGui.QStyle.CE_ItemViewItem, option, painter, None);
+
 
 class TableView(QtGui.QTableView):
     """A QTableView configured to behave as expected by TraitsUI."""

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -168,7 +168,7 @@ class TableEditor(Editor, BaseTableEditor):
 
         # Create the vertical header context menu and connect to its signals
         self.header_menu = QtGui.QMenu(self.table_view)
-        insertable = factory.row_factory is not None and not factory.auto_add
+        insertable = factory.row_factory is not None
         if factory.editable:
             if insertable:
                 action = self.header_menu.addAction('Insert new item')
@@ -970,8 +970,7 @@ class TableView(QtGui.QTableView):
         editor = self._editor
         if row == -1:
             factory = editor.factory
-            if (factory.editable and factory.row_factory is not None and
-                    not factory.auto_add):
+            if (factory.editable and factory.row_factory is not None):
                 event.accept()
                 editor.empty_menu.exec_(position)
 
@@ -1003,7 +1002,7 @@ class TableView(QtGui.QTableView):
             row = vheader.logicalIndexAt(event.pos().y())
             if row == -1:
                 factory = editor.factory
-                if factory.row_factory is not None and not factory.auto_add:
+                if factory.row_factory is not None:
                     editor.empty_menu.exec_(event.globalPos())
             else:
                 editor.header_row = row
@@ -1159,7 +1158,7 @@ class TableView(QtGui.QTableView):
         # Configure the row headings.
         vheader = self.verticalHeader()
         set_resize_mode = set_qheader_section_resize_mode(vheader)
-        insertable = factory.row_factory is not None and not factory.auto_add
+        insertable = factory.row_factory is not None
         if ((factory.editable and (insertable or factory.deletable)) or
                 factory.reorderable):
             vheader.installEventFilter(self)

--- a/traitsui/qt4/table_model.py
+++ b/traitsui/qt4/table_model.py
@@ -90,6 +90,11 @@ class TableModel(QtCore.QAbstractTableModel):
         obj = self._editor.items()[mi.row()]
         column = self._editor.columns[mi.column()]
 
+        if self._editor.factory is None:
+            # XXX This should never happen, but it does,
+            # probably during shutdown, but I haven't investigated
+            return None
+
         if role == QtCore.Qt.DisplayRole or role == QtCore.Qt.EditRole:
             text = column.get_value(obj)
             if text is not None:

--- a/traitsui/qt4/table_model.py
+++ b/traitsui/qt4/table_model.py
@@ -198,10 +198,12 @@ class TableModel(QtCore.QAbstractTableModel):
             if role == QtCore.Qt.DisplayRole:
                 return str(section + 1)
 
+        if editor.factory is None:
+            # XXX This should never happen, but it does,
+            # probably during shutdown, but I haven't investigated
+            return None
+
         if role == QtCore.Qt.FontRole:
-            if editor.factory is None:
-                # XXX I think this should never happen, but it does
-                return None
             font = editor.factory.label_font
             if font is not None:
                 return QtGui.QFont(font)

--- a/traitsui/table_column.py
+++ b/traitsui/table_column.py
@@ -87,7 +87,7 @@ class TableColumn(HasPrivateTraits):
     text_color = Color('black')
 
     # Text font for this column:
-    text_font = Font
+    text_font = Either(None, Font)
 
     # Cell background color for this column:
     cell_color = Either(Color('white'), None)

--- a/traitsui/wx/constants.py
+++ b/traitsui/wx/constants.py
@@ -19,54 +19,69 @@
     editors and text editor factories.
 """
 
-#-------------------------------------------------------------------------
-#  Imports:
-#-------------------------------------------------------------------------
-
 from __future__ import absolute_import
 import sys
 
 import wx
 
-#-------------------------------------------------------------------------
-#  Constants:
-#-------------------------------------------------------------------------
-
-# Define platform and wx version constants:
+#: Define platform and wx version constants:
 is_mac = (sys.platform == 'darwin')
 is_wx26 = (float('.'.join(wx.__version__.split('.')[0:2])) < 2.8)
 
-# Default dialog title
+#: Default dialog title
 DefaultTitle = 'Edit properties'
 
-# Color of valid input
+#: Color of valid input
 OKColor = wx.WHITE
 
-# Color to highlight input errors
+#: Color to highlight input errors
 ErrorColor = wx.Colour(255, 192, 192)
 
-# Color for background of read-only fields
+#: Color for background of read-only fields
 ReadonlyColor = wx.Colour(244, 243, 238)
 
-# Color for background of fields where objects can be dropped
+#: Color for background of fields where objects can be dropped
 DropColor = wx.Colour(215, 242, 255)
 
-# Color for an editable field
+#: Color for an editable field
 EditableColor = wx.WHITE
 
-# Color for background of windows (like dialog background color)
+#: Color for background of windows (like dialog background color)
 if is_mac:
     WindowColor = wx.Colour(232, 232, 232)
     BorderedGroupColor = wx.Colour(224, 224, 224)
 else:
     WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)
 
-# Standard width of an image bitmap
+#: Default colour for table foreground
+TableCellColor = wx.BLACK
+
+#: Default colour for table background
+TableCellBackgroundColor = wx.WHITE
+
+#: Default colour for table background
+TableReadOnlyBackgroundColor = ReadonlyColor
+
+#: Default colour for table background
+TableLabelColor = TableCellColor
+
+#: Default colour for table background
+TableLabelBackgroundColor = WindowColor
+
+#: Default foreground colour for table selection
+TableSelectionTextColor = TableCellColor
+
+#: Default background colour for table selection (light blue)
+TableSelectionBackgroundColor = wx.Colour(173, 216, 230)
+
+#: Standard width of an image bitmap
 standard_bitmap_width = 120
 
-# Width of a scrollbar
+#: Width of a scrollbar
 scrollbar_dx = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
 
-# Screen size values:
+#: Screen width
 screen_dx = wx.SystemSettings.GetMetric(wx.SYS_SCREEN_X)
+
+#: Screen height
 screen_dy = wx.SystemSettings.GetMetric(wx.SYS_SCREEN_Y)

--- a/traitsui/wx/table_editor.py
+++ b/traitsui/wx/table_editor.py
@@ -24,12 +24,12 @@ from operator import itemgetter
 
 import wx
 
-from pyface.ui.wx.grid.api import Grid
 from pyface.dock.api import (
     DockWindow, DockSizer, DockSection, DockRegion, DockControl
 )
 from pyface.image_resource import ImageResource
 from pyface.timer.api import do_later
+from pyface.ui.wx.grid.api import Grid
 from traits.api import (
     Int, List, Instance, Str, Any, Button, Tuple, HasPrivateTraits, Bool,
     Event, Property

--- a/traitsui/wx/table_editor.py
+++ b/traitsui/wx/table_editor.py
@@ -18,65 +18,44 @@
 """ Defines the table editor for the wxPython user interface toolkit.
 """
 
-#-------------------------------------------------------------------------
-#  Imports:
-#-------------------------------------------------------------------------
-
 from __future__ import absolute_import
 
 from operator import itemgetter
 
 import wx
 
-from traits.api \
-    import Int, List, Instance, Str, Any, Button, Tuple, \
-    HasPrivateTraits, Bool, Event, Property
+from pyface.ui.wx.grid.api import Grid
+from pyface.dock.api import (
+    DockWindow, DockSizer, DockSection, DockRegion, DockControl
+)
+from pyface.image_resource import ImageResource
+from pyface.timer.api import do_later
+from traits.api import (
+    Int, List, Instance, Str, Any, Button, Tuple, HasPrivateTraits, Bool,
+    Event, Property
+)
 
-from traitsui.api \
-    import View, Item, UI, InstanceEditor, EnumEditor, Handler, SetEditor, \
+from traitsui.api import (
+    View, Item, UI, InstanceEditor, EnumEditor, Handler, SetEditor,
     ListUndoItem
+)
+from traitsui.editors.table_editor import BaseTableEditor, customize_filter
+from traitsui.menu import Action, ToolBar
+from traitsui.table_column import TableColumn, ObjectColumn
+from traitsui.table_filter import TableFilter
+from traitsui.ui_traits import SequenceTypes
 
-from traitsui.editors.table_editor \
-    import BaseTableEditor, customize_filter
-
-from traitsui.menu \
-    import Action, ToolBar
-
-from traitsui.table_column \
-    import TableColumn, ObjectColumn
-
-from traitsui.table_filter \
-    import TableFilter
-
-from traitsui.ui_traits \
-    import SequenceTypes
-
-from pyface.ui.wx.grid.api \
-    import Grid
-
-from pyface.dock.api \
-    import DockWindow, DockSizer, DockSection, DockRegion, DockControl
-
-from pyface.image_resource \
-    import ImageResource
-
-from pyface.timer.api \
-    import do_later
-
-from .editor \
-    import Editor
-
-from .table_model \
-    import TableModel, TraitGridSelection
-
+from .constants import (
+    TableCellBackgroundColor, TableCellColor, TableLabelBackgroundColor,
+    TableLabelColor, TableReadOnlyBackgroundColor,
+    TableSelectionBackgroundColor, TableSelectionTextColor,
+)
+from .editor import Editor
+from .table_model import TableModel, TraitGridSelection
 from .helper import TraitsUIPanel
 
 
-#-------------------------------------------------------------------------
-#  Constants:
-#-------------------------------------------------------------------------
-
-# Mapping from TableEditor selection modes to Grid selection modes:
+#: Mapping from TableEditor selection modes to Grid selection modes:
 GridModes = {
     'row': 'rows',
     'rows': 'rows',
@@ -86,9 +65,12 @@ GridModes = {
     'cells': 'cell'
 }
 
-#-------------------------------------------------------------------------
-#  'TableEditor' class:
-#-------------------------------------------------------------------------
+
+def _get_color(color, default_color):
+    """ Return the color if it is not None, otherwise use default. """
+    if color is not None:
+        return color
+    return default_color
 
 
 class TableEditor(Editor, BaseTableEditor):
@@ -164,11 +146,6 @@ class TableEditor(Editor, BaseTableEditor):
     # Is 'auto_add' mode in effect? (I.e., new rows are automatically added to
     # the end of the table when the user modifies current last row.)
     auto_add = Bool(False)
-
-    #-------------------------------------------------------------------------
-    #  Finishes initializing the editor by creating the underlying toolkit
-    #  widget:
-    #-------------------------------------------------------------------------
 
     def init(self, parent):
         """ Finishes initializing the editor by creating the underlying toolkit
@@ -295,10 +272,6 @@ class TableEditor(Editor, BaseTableEditor):
         # Finish the panel layout setup:
         panel.SetSizer(sizer)
 
-    #-------------------------------------------------------------------------
-    #  Creates the associated grid control used to implement the table:
-    #-------------------------------------------------------------------------
-
     def _create_grid(self, parent, sizer):
         """ Creates the associated grid control used to implement the table.
         """
@@ -306,6 +279,19 @@ class TableEditor(Editor, BaseTableEditor):
         selection_mode = GridModes[factory.selection_mode]
         if factory.selection_bg_color is None:
             selection_mode = ''
+
+        cell_color = _get_color(factory.cell_color, TableCellColor)
+        cell_bg_color = _get_color(factory.cell_bg_color,
+                                   TableCellBackgroundColor)
+        cell_read_only_bg_color = _get_color(factory.cell_read_only_bg_color,
+                                             TableReadOnlyBackgroundColor)
+        label_bg_color = _get_color(factory.label_bg_color,
+                                    TableLabelBackgroundColor)
+        label_color = _get_color(factory.label_color, TableLabelColor)
+        selection_text_color = _get_color(factory.selection_color,
+                                          TableSelectionTextColor)
+        selection_bg_color = _get_color(factory.selection_bg_color,
+                                        TableSelectionBackgroundColor)
 
         self.grid = grid = Grid(
             parent,
@@ -315,14 +301,14 @@ class TableEditor(Editor, BaseTableEditor):
             show_row_headers=factory.show_row_labels,
             show_column_headers=factory.show_column_labels,
             default_cell_font=factory.cell_font,
-            default_cell_text_color=factory.cell_color,
-            default_cell_bg_color=factory.cell_bg_color,
-            default_cell_read_only_color=factory.cell_read_only_bg_color,
+            default_cell_text_color=cell_color,
+            default_cell_bg_color=cell_bg_color,
+            default_cell_read_only_color=cell_read_only_bg_color,
             default_label_font=factory.label_font,
-            default_label_text_color=factory.label_color,
-            default_label_bg_color=factory.label_bg_color,
-            selection_bg_color=factory.selection_bg_color,
-            selection_text_color=factory.selection_color,
+            default_label_text_color=label_color,
+            default_label_bg_color=label_bg_color,
+            selection_bg_color=selection_bg_color,
+            selection_text_color=selection_text_color,
             autosize=factory.auto_size,
             read_only=not factory.editable,
             edit_on_first_click=factory.edit_on_first_click,
@@ -375,10 +361,6 @@ class TableEditor(Editor, BaseTableEditor):
 
         return grid.control
 
-    #-------------------------------------------------------------------------
-    #  Creates the table editing tool bar:
-    #-------------------------------------------------------------------------
-
     def _create_toolbar(self, parent, sizer):
         """ Creates the table editing toolbar.
         """
@@ -413,10 +395,6 @@ class TableEditor(Editor, BaseTableEditor):
 
             sizer.Add(tb_sizer, 0, wx.ALIGN_RIGHT | wx.EXPAND)
 
-    #-------------------------------------------------------------------------
-    #  Disposes of the contents of an editor:
-    #-------------------------------------------------------------------------
-
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
@@ -445,10 +423,6 @@ class TableEditor(Editor, BaseTableEditor):
 
         super(TableEditor, self).dispose()
 
-    #-------------------------------------------------------------------------
-    #  Updates the editor when the object trait changes external to the editor:
-    #-------------------------------------------------------------------------
-
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
             editor.
@@ -456,18 +430,10 @@ class TableEditor(Editor, BaseTableEditor):
         # fixme: Do we need to override this method?
         pass
 
-    #-------------------------------------------------------------------------
-    #  Refreshes the editor control:
-    #-------------------------------------------------------------------------
-
     def refresh(self):
         """ Refreshes the editor control.
         """
         self.grid._grid.Refresh()
-
-    #-------------------------------------------------------------------------
-    #  Sets the current selection to a set of specified objects:
-    #-------------------------------------------------------------------------
 
     def set_selection(self, objects=[], notify=True):
         """ Sets the current selection to a set of specified objects.
@@ -477,10 +443,6 @@ class TableEditor(Editor, BaseTableEditor):
 
         self.grid.set_selection([TraitGridSelection(obj=object)
                                  for object in objects], notify=notify)
-
-    #-------------------------------------------------------------------------
-    #  Sets the current selection to a set of specified object/column pairs:
-    #-------------------------------------------------------------------------
 
     def set_extended_selection(self, *pairs):
         """ Sets the current selection to a set of specified object/column
@@ -494,10 +456,6 @@ class TableEditor(Editor, BaseTableEditor):
 
         self.grid.set_selection(grid_selections)
 
-    #-------------------------------------------------------------------------
-    #  Creates a new row object using the provided factory:
-    #-------------------------------------------------------------------------
-
     def create_new_row(self):
         """ Creates a new row object using the provided factory.
         """
@@ -508,10 +466,6 @@ class TableEditor(Editor, BaseTableEditor):
 
         return self.ui.evaluate(factory.row_factory,
                                 *factory.row_factory_args, **kw)
-
-    #-------------------------------------------------------------------------
-    #  Adds a new object as a new row after the currently selected indices:
-    #-------------------------------------------------------------------------
 
     def add_row(self, object=None, index=None):
         """ Adds a specified object as a new row after the specified index.
@@ -556,10 +510,6 @@ class TableEditor(Editor, BaseTableEditor):
 
         if in_row_mode:
             self.set_selection(items)
-
-    #-------------------------------------------------------------------------
-    #  Moves a column from one place to another:
-    #-------------------------------------------------------------------------
 
     def move_column(self, from_column, to_column):
         """ Moves the specified **from_column** from its current position to
@@ -653,11 +603,6 @@ class TableEditor(Editor, BaseTableEditor):
 
     #-- UI preference save/restore interface ---------------------------------
 
-    #-------------------------------------------------------------------------
-    #  Restores any saved user preference information associated with the
-    #  editor:
-    #-------------------------------------------------------------------------
-
     def restore_prefs(self, prefs):
         """ Restores any saved user preference information associated with the
             editor.
@@ -698,10 +643,6 @@ class TableEditor(Editor, BaseTableEditor):
         except Exception:
             pass
 
-    #-------------------------------------------------------------------------
-    #  Returns any user preference information associated with the editor:
-    #-------------------------------------------------------------------------
-
     def save_prefs(self):
         """ Returns any user preference information associated with the editor.
         """
@@ -734,10 +675,6 @@ class TableEditor(Editor, BaseTableEditor):
                     [item for item in values if item[0] in items])
 
     #-- Event Handlers -------------------------------------------------------
-
-    #-------------------------------------------------------------------------
-    #  Handles the user selecting items (rows, columns, cells) in the table:
-    #-------------------------------------------------------------------------
 
     def _selection_row_updated(self, event):
         """ Handles the user selecting items (rows, columns, cells) in the
@@ -1038,10 +975,6 @@ class TableEditor(Editor, BaseTableEditor):
                 toolbar.delete.enabled = toolbar.move_up.enabled = \
                     toolbar.move_down.enabled = False
 
-    #-------------------------------------------------------------------------
-    #  Handles the contents of the model being resorted:
-    #-------------------------------------------------------------------------
-
     def _model_sorted(self):
         """ Handles the contents of the model being resorted.
         """
@@ -1051,10 +984,6 @@ class TableEditor(Editor, BaseTableEditor):
         values = self.selected_values
         if len(values) > 0:
             do_later(self.set_extended_selection, values)
-
-    #-------------------------------------------------------------------------
-    #  Handles the current filter being changed:
-    #-------------------------------------------------------------------------
 
     def _filter_changed(self, old_filter, new_filter):
         """ Handles the current filter being changed.
@@ -1069,19 +998,11 @@ class TableEditor(Editor, BaseTableEditor):
             self.model.filter = new_filter
             self.filter_modified()
 
-    #-------------------------------------------------------------------------
-    #  Refresh the list of available filters:
-    #-------------------------------------------------------------------------
-
     def _refresh_filters(self, filters):
         factory = self.factory
         # hack: The following line forces the 'filters' to be changed...
         factory.filters = []
         factory.filters = filters
-
-    #-------------------------------------------------------------------------
-    #  Allows the user to customize the current set of table filters:
-    #-------------------------------------------------------------------------
 
     def _customize_filters(self, filter):
         """ Allows the user to customize the current set of table filters.
@@ -1108,10 +1029,6 @@ class TableEditor(Editor, BaseTableEditor):
         else:
             self.filter = filter
 
-    #-------------------------------------------------------------------------
-    #  Handles the user requesting that columns not be sorted:
-    #-------------------------------------------------------------------------
-
     def on_no_sort(self):
         """ Handles the user requesting that columns not be sorted.
         """
@@ -1120,10 +1037,6 @@ class TableEditor(Editor, BaseTableEditor):
         values = self.selected_values
         if len(values) > 0:
             self.set_extended_selection(values)
-
-    #-------------------------------------------------------------------------
-    #  Handles the user requesting to move the current item up one row:
-    #-------------------------------------------------------------------------
 
     def on_move_up(self):
         """ Handles the user requesting to move the current item up one row.
@@ -1141,10 +1054,6 @@ class TableEditor(Editor, BaseTableEditor):
             self.set_selection(objects)
         else:
             self.set_extended_selection(self.selected_values)
-
-    #-------------------------------------------------------------------------
-    #  Handles the user requesting to move the current item down one row:
-    #-------------------------------------------------------------------------
 
     def on_move_down(self):
         """ Handles the user requesting to move the current item down one row.
@@ -1164,10 +1073,6 @@ class TableEditor(Editor, BaseTableEditor):
         else:
             self.set_extended_selection(self.selected_values)
 
-    #-------------------------------------------------------------------------
-    #  Handles the user requesting a table search:
-    #-------------------------------------------------------------------------
-
     def on_search(self):
         """ Handles the user requesting a table search.
         """
@@ -1177,19 +1082,10 @@ class TableEditor(Editor, BaseTableEditor):
             handler=TableSearchHandler(editor=self)
         )
 
-    #-------------------------------------------------------------------------
-    #  Handles the user requesting to add a new row to the table:
-    #-------------------------------------------------------------------------
-
     def on_add(self):
         """ Handles the user requesting to add a new row to the table.
         """
         self.add_row()
-
-    #-------------------------------------------------------------------------
-    #  Handles the user requesting to delete the currently selected items of
-    #  the table:
-    #-------------------------------------------------------------------------
 
     def on_delete(self):
         """ Handles the user requesting to delete the currently selected items
@@ -1234,11 +1130,6 @@ class TableEditor(Editor, BaseTableEditor):
         else:
             self._update_toolbar(False)
 
-    #-------------------------------------------------------------------------
-    #  Handles the user requesting to set the user preference items for the
-    #  table:
-    #-------------------------------------------------------------------------
-
     def on_prefs(self):
         """ Handles the user requesting to set the user preference items for the
             table.
@@ -1264,10 +1155,6 @@ class TableEditor(Editor, BaseTableEditor):
                       buttons=['Undo', 'OK', 'Cancel'],
                       kind='livemodal'))
 
-    #-------------------------------------------------------------------------
-    #  Prepares to have a context menu action called:
-    #-------------------------------------------------------------------------
-
     def prepare_menu(self, row, column):
         """ Prepares to have a context menu action called.
         """
@@ -1277,10 +1164,6 @@ class TableEditor(Editor, BaseTableEditor):
             self.set_selection(object)
             selection = [object]
         self.set_menu_context(selection, object, column)
-
-    #-------------------------------------------------------------------------
-    #  Set one or more attributes without notifying the grid model:
-    #-------------------------------------------------------------------------
 
     def setx(self, **keywords):
         """ Set one or more attributes without notifying the grid model.
@@ -1294,27 +1177,15 @@ class TableEditor(Editor, BaseTableEditor):
 
 #-- Private Methods: -----------------------------------------------------
 
-    #-------------------------------------------------------------------------
-    #  Adds an 'undo' item to the undo history (if any):
-    #-------------------------------------------------------------------------
-
     def _add_undo(self, undo_item, extend=False):
         history = self.ui.history
         if history is not None:
             history.add(undo_item, extend)
 
-#-------------------------------------------------------------------------
-#  'TableFilterEditor' class:
-#-------------------------------------------------------------------------
-
 
 class TableFilterEditor(Handler):
     """ Editor that manages table filters.
     """
-
-    #-------------------------------------------------------------------------
-    #  Trait definitions:
-    #-------------------------------------------------------------------------
 
     # TableEditor this editor is associated with
     editor = Instance(TableEditor)
@@ -1457,10 +1328,6 @@ class TableFilterEditor(Handler):
         if (not self.filter.template) and len(info.filter.factory.values) > 1:
             info.delete.enabled = True
 
-#-------------------------------------------------------------------------
-#  'TableEditorToolbar' class:
-#-------------------------------------------------------------------------
-
 
 class TableEditorToolbar(HasPrivateTraits):
     """ Toolbar displayed in table editors.
@@ -1528,10 +1395,6 @@ class TableEditorToolbar(HasPrivateTraits):
 
     # The toolbar control:
     control = Any
-
-    #-------------------------------------------------------------------------
-    #  Initializes the toolbar for a specified window:
-    #-------------------------------------------------------------------------
 
     def __init__(self, parent=None, **traits):
         super(TableEditorToolbar, self).__init__(**traits)
@@ -1602,10 +1465,6 @@ class TableEditorToolbar(HasPrivateTraits):
         """
         getattr(self.editor, action.action)()
 
-#-------------------------------------------------------------------------
-#  'TableSearchHandler' class:
-#-------------------------------------------------------------------------
-
 
 class TableSearchHandler(Handler):
     """ Handler for saerching a table.
@@ -1633,10 +1492,6 @@ class TableSearchHandler(Handler):
     # Search status message:
     status = Str
 
-    #-------------------------------------------------------------------------
-    #  Handles the user clicking the 'Find next' button:
-    #-------------------------------------------------------------------------
-
     def handler_find_next_changed(self, info):
         """ Handles the user clicking the **Find** button.
         """
@@ -1652,10 +1507,6 @@ class TableSearchHandler(Handler):
                     break
             else:
                 self.status = 'No more matches found'
-
-    #-------------------------------------------------------------------------
-    #  Handles the user clicking the 'Find previous' button:
-    #-------------------------------------------------------------------------
 
     def handler_find_previous_changed(self, info):
         """ Handles the user clicking the **Find previous** button.
@@ -1673,10 +1524,6 @@ class TableSearchHandler(Handler):
             else:
                 self.status = 'No more matches found'
 
-    #-------------------------------------------------------------------------
-    #  Handles the user clicking the 'Select' button:
-    #-------------------------------------------------------------------------
-
     def handler_select_changed(self, info):
         """ Handles the user clicking the **Select** button.
         """
@@ -1691,10 +1538,6 @@ class TableSearchHandler(Handler):
                 self.status = '1 item selected'
             else:
                 self.status = '%d items selected' % len(items)
-
-    #-------------------------------------------------------------------------
-    #  Handles the user clicking 'OK' button:
-    #-------------------------------------------------------------------------
 
     def handler_OK_changed(self, info):
         """ Handles the user clicking the OK button.


### PR DESCRIPTION
Improves situation for #594 although it is not a complete fix.  This:

- fixes most color traits on the Qt TableEditor so that they work as advertised and match behaviour of WxPython backend as closely as feasible.
- fixes the font traits on the Qt TableEditor so that they actually do something.
- fixes the row_height on the Qt TableEditor so that if gives the right default size.

It also includes some drive-by documentation fixes.