### PR TITLE
Set initial item focus correctly on Qt

### DIFF
--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -281,7 +281,7 @@ class BaseDialog(BasePanel):
 
         try:
             ui.prepare_ui()
-        except:
+        except BaseException:
             ui.control.setParent(None)
             ui.control.ui = None
             ui.control = None
@@ -291,6 +291,11 @@ class BaseDialog(BasePanel):
 
         ui.handler.position(ui.info)
         restore_window(ui)
+
+        # if an item asked for initial focus, give it to them
+        if ui._focus_control is not None:
+            ui._focus_control.setFocus()
+            ui._focus_control = None
 
         if style == BaseDialog.NONMODAL:
             ui.control.show()

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -896,9 +896,10 @@ class _GroupPanel(object):
             if item.emphasized:
                 self._add_emphasis(control)
 
-            # Give the editor focus if it requested it:
+            # If the item wants focus, remember the control so we can set focus
+            # immediately before opening the UI.
             if item.has_focus:
-                control.setFocus()
+                self.ui._focus_control = control
 
             # Set the correct size on the control, as specified by the user:
             stretch = 0

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -188,6 +188,11 @@ class UI(HasPrivateTraits):
     # The statusbar listeners that have been set up:
     _statusbar = List
 
+    # Control which gets focus after UI is created
+    # Note: this does not track focus after UI creation
+    # only used by Qt backend.
+    _focus_control = Any
+
     # Does the UI contain any scrollable widgets?
     #
     # The _scrollable trait is set correctly, but not used currently because
@@ -202,7 +207,8 @@ class UI(HasPrivateTraits):
     recyclable_traits = [
         '_context', '_revert', '_defined', '_visible', '_enabled', '_checked',
         '_search', '_dispatchers', '_editors', '_names', '_active_group',
-        '_undoable', '_rebuild', '_groups_cache', '_key_bindings'
+        '_undoable', '_rebuild', '_groups_cache', '_key_bindings',
+        '_focus_control'
     ]
 
     # List of additional traits that are discarded when a user interface is


### PR DESCRIPTION
Previously the control was having the focus set too soon, so it did not correctly register.  This changes the algorithm to remember a reference to the control which needs focus, and sets the focus when the UI is set up and ready to go.

Fixes #599 