### PR TITLE
Fix tutor.py in examples

### DIFF
--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -1482,7 +1482,7 @@ class SectionFactory(HasPrivateTraits):
 
         # Try to find a CSS style sheet, and set up the docutil overrides if
         # found:
-        settings = {}
+        settings = {'output_encoding': 'unicode'}
         css_path = self.css_path
         if css_path != '':
             css_path = os.path.join(self.path, css_path)


### PR DESCRIPTION
Ensure docutils produces a unicode HTML string when compiling .rst.  On Python 3 it was returning a bytestring which meant most pages didn't appear.