### PR TITLE
Fix ContextValue __init__

### DIFF
--- a/traitsui/context_value.py
+++ b/traitsui/context_value.py
@@ -1,6 +1,4 @@
-#------------------------------------------------------------------------------
-#
-#  Copyright (c) 2008, Enthought, Inc.
+#  Copyright (c) 2008-19, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD
@@ -12,55 +10,121 @@
 #
 #  Author: David C. Morrill
 #  Date:   08/18/2008
-#
-#------------------------------------------------------------------------------
 
-""" Defines some helper classes and traits used to define 'bindable' editor
-    values.
 """
+Defines some helper classes and traits used to define 'bindable' editor
+values.  These classes and associated traits are designed to simplify
+writing editors by allowing the editor factory to specify a context value
+instance for attributes and have the value on the editor be synchronized
+with the corresponsing value rom the context.
 
-#-------------------------------------------------------------------------
-#  Imports:
-#-------------------------------------------------------------------------
+The factory should look something like this::
+
+    class MyEditorFactory(EditorFactory):
+
+        #: The minimum value.
+        minimum = CVInt
+
+        #: The suffix for the data.
+        suffix = CVType(Unicode)
+
+The editor class needs to have traits which correspond to the context value
+traits, and should be able to react to changes to them::
+
+    class MyEditor(Editor):
+
+        #: The minimum value.
+        minimum = Int
+
+        #: The suffix for the data.
+        suffix = Unicode
+
+This can then be used in views, with values either as constants or as
+instances of :class:`ContextValue` (abbreviated as ``CV``)::
+
+    class MyObject(HasTraits):
+
+        #: An important value.
+        my_value = Unicode
+
+        #: The minimum value.
+        my_minimum = Int(10)
+
+        traits_view = View(
+            Item(
+                'my_value',
+                editor=MyEditorFactory(
+                    minimum=CV('my_minimum'),
+                    suffix=u'...',
+                ),
+            )
+        )
+"""
 
 from __future__ import absolute_import
 
-from traits.api import HasPrivateTraits, Instance, Str, Int, Float, Either
-
-#-------------------------------------------------------------------------
-#  'ContextValue' class:
-#-------------------------------------------------------------------------
+from traits.api import HasStrictTraits, Instance, Str, Int, Float, Either
 
 
-class ContextValue(HasPrivateTraits):
-    """ Defines the name of a context value that can be bound to some editor
-        value.
+class ContextValue(HasStrictTraits):
+    """ Defines the name of a context value that can be bound to an editor
+
+    Resolution of the name follows the same rules as for context values in
+    :class:`.Item`s: if there is no dot in it then it is treated as an
+    attribute of the 'object' context value, other wise the first part
+    specifies the object in the context and the rest are dotted attribute
+    look-ups.
     """
 
-    # The extended trait name of the value that can be bound to the editor
-    # (e.g. 'selection' or 'handler.selection'):
+    #: The extended trait name of the value that can be bound to the editor
+    #: (e.g. 'selection' or 'handler.selection'):
     name = Str
 
-    #-- object Interface -----------------------------------------------------
+    # ------------------------------------------------------------------------
+    # object Interface
+    # ------------------------------------------------------------------------
 
     def __init__(self, name):
-        """ Initializes the object.
-        """
-        self.name = name
+        super(ContextValue, self).__init__(name=name)
 
-# Define a shorthand name for a ContextValue:
+
+#: Define a shorthand name for a ContextValue:
 CV = ContextValue
 
-#-------------------------------------------------------------------------
-#  Trait definitions useful in defining bindable editor traits:
-#-------------------------------------------------------------------------
 
+# Trait definitions useful in defining bindable editor traits ---------------
+
+def CVType(type, **metadata):
+    """ Factory that creates an Either type or ContextValue trait.
+
+    This also sets up one-way synchronization to the editor if no
+    other synchronization is specified.
+
+    Parameters
+    ----------
+    type : trait type
+        The trait type that is expected for constant values.
+    **metadata
+        Additional metadata for the trait.
+
+    Returns
+    -------
+    cv_type_trait : trait
+        A trait which can either hold a constant of the specified
+        type or an instance of the ContextValue class.
+    """
+    metadata.setdefault('sync_value', 'to')
+    return Either(type, InstanceOfContextValue, **metadata)
+
+
+#: Shorthand for an Instance of ContextValue trait.
 InstanceOfContextValue = Instance(ContextValue, allow_none=False)
 
-
-def CVType(type):
-    return Either(type, InstanceOfContextValue, sync_value='to')
-
+#: Int or Context value trait
 CVInt = CVType(Int)
+
+#: Float or Context value trait
 CVFloat = CVType(Float)
+
+#: Str or Context value trait
 CVStr = CVType(Str)

--- a/traitsui/tests/test_context_value.py
+++ b/traitsui/tests/test_context_value.py
@@ -1,0 +1,96 @@
+#  Copyright (c) 2008-19, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+#  Author: Corran Webster
+#  Date:   August 12, 2019
+
+import unittest
+
+from traits.testing.unittest_tools import UnittestTools
+from traits.api import HasTraits, Unicode
+
+from traitsui.context_value import ContextValue, CVFloat, CVInt, CVStr, CVType
+
+
+class CVExample(HasTraits):
+
+    cv_float = CVFloat
+
+    cv_int = CVInt
+
+    cv_str = CVStr
+
+    cv_unicode = CVType(Unicode, something='meta', sync_value='both')
+
+
+class TestContextvalue(UnittestTools, unittest.TestCase):
+
+    def test_context_value(self):
+        cv = ContextValue('trait_name')
+
+        self.assertEqual(cv.name, 'trait_name')
+
+    def test_cv_float_constant(self):
+        cve = CVExample(cv_float=1.1)
+
+        self.assertEqual(cve.cv_float, 1.1)
+
+    def test_cv_float_context_value(self):
+        cv = ContextValue('trait_name')
+        cve = CVExample(cv_float=cv)
+
+        self.assertIs(cve.cv_float, cv)
+
+    def test_cv_int_constant(self):
+        cve = CVExample(cv_int=1)
+
+        self.assertEqual(cve.cv_int, 1)
+
+    def test_cv_int_context_value(self):
+        cv = ContextValue('trait_name')
+        cve = CVExample(cv_int=cv)
+
+        self.assertIs(cve.cv_int, cv)
+
+    def test_cv_str_constant(self):
+        cve = CVExample(cv_str='test')
+
+        self.assertEqual(cve.cv_str, 'test')
+
+    def test_cv_str_context_value(self):
+        cv = ContextValue('trait_name')
+        cve = CVExample(cv_str=cv)
+
+        self.assertIs(cve.cv_str, cv)
+
+    def test_cv_unicode_constant(self):
+        cve = CVExample(cv_unicode=u'test')
+
+        self.assertEqual(cve.cv_unicode, u'test')
+
+    def test_cv_unicode_context_value(self):
+        cv = ContextValue('trait_name')
+        cve = CVExample(cv_unicode=cv)
+
+        self.assertIs(cve.cv_unicode, cv)
+
+    def test_cv_unicode_not_none(self):
+        with self.assertRaises(Exception):
+            CVExample(cv_unicode=None)
+
+    def test_metadata(self):
+        cve = CVExample()
+        t = cve.trait('cv_unicode')
+
+        self.assertEqual(t.something, 'meta')
+        self.assertEqual(t.sync_value, 'both')
+
+        t = cve.trait('cv_float')
+        self.assertEqual(t.sync_value, 'to')


### PR DESCRIPTION
The `__init__` method of `ContextValue` didn't call super.  This fixes that, along with many other code improvements and tests.

For the reviewer: `ContextValue` isn't currently used by any editors, but there are hooks in the base `Editor` class to look for and use them if the editor factory has any.  It allows factories to have an API where values can come dynamically from the context without having to use a separate trait to hold the name of the source value.  It would be good to start using these.