### PR TITLE
Remove Python 3.5 from test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,11 @@ env:
 matrix:
   include:
     - env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx pyside2"
-    - env: RUNTIME=3.5 TOOLKITS="null pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="null pyside pyqt pyside2"
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="pyqt wx"
-    - os: osx
-      env: RUNTIME=3.5 TOOLKITS="null pyqt5 pyqt pyside2"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyqt pyside2"
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ environment:
   matrix:
     - RUNTIME: '2.7'
       TOOLKITS: "null pyqt pyside wx"
-    - RUNTIME: '3.5'
-      TOOLKITS: "null pyqt pyqt5"
     - RUNTIME: '3.6'
       TOOLKITS: "null pyqt pyqt5"
     - RUNTIME: '3.6'

--- a/etstool.py
+++ b/etstool.py
@@ -94,7 +94,7 @@ supported_combinations = {
 
 dependencies = {
     "numpy",
-    "pandas",
+    "pandas<0.24",
     "pygments",
     "traits",
     "pip",

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -207,6 +207,10 @@ class SimpleSliderEditor(BaseRangeEditor):
     def update_object_on_enter(self):
         """ Handles the user pressing the Enter key in the text field.
         """
+        # it is possible we get the event after the control has gone away
+        if self.control is None:
+            return
+
         try:
             try:
                 value = eval(six.text_type(self.control.text.text()).strip())


### PR DESCRIPTION
Testing on Python 3.5 is not giving us a lot more information, but is adding to CI completion time.  We expect that most users now will be on Python 3.6+ going forward.

Fixes #618.