### PR TITLE
GHI 617 : Update doc links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,8 @@ Important Links
 
 - Website and Documentation: `<http://docs.enthought.com/traitsui>`__
 
-  * User Manual `<http://docs.enthought.com/traitsui/traitsui_user_maunal>`__
-  * Tutorial `<http://docs.enthought.com/traitsui/tutorial>`__
+  * User Manual `<http://docs.enthought.com/traitsui/traitsui_user_manual>`__
+  * Tutorial `<http://docs.enthought.com/traitsui/tutorials>`__
   * API Documentation `<http://docs.enthought.com/traitsui/api>`__
 
 - Source code repository: `<https://github.com/enthought/traitsui>`__

--- a/docs/source/tutorials/traits_ui_scientific_app.rst
+++ b/docs/source/tutorials/traits_ui_scientific_app.rst
@@ -72,7 +72,7 @@ GUI, and not on the code.
 
 TraitsUI provides a beautiful answer to this problem by building
 graphical representations of an object. Traits and TraitsUI have their
-own manuals (`http://code.enthought.com/traits/ <http://code.enthought.com/traits/>`_) and the reader is encouraged to
+own manuals (`http://docs.enthought.com/traits/ <http://docs.enthought.com/traits/>`_) and the reader is encouraged to
 refer to these for more information.
 
 We will use TraitsUI for *all* our GUIs. This forces us to store all the
@@ -1126,7 +1126,7 @@ ____
    `http://matplotlib.sourceforge.net <http://matplotlib.sourceforge.net>`_
 
 .. [#] The traits and traitsUI user guide:
-   `http://code.enthought.com/traits <http://code.enthought.com/traits>`_
+   `http://docs.enthought.com/traits <http://docs.enthought.com/traits>`_
 
 .. [#] ctypes: `http://starship.python.net/crew/theller/ctypes/ <http://starship.python.net/crew/theller/ctypes/>`_
 

--- a/docs/source/tutorials/traits_ui_scientific_app.rst
+++ b/docs/source/tutorials/traits_ui_scientific_app.rst
@@ -1128,10 +1128,10 @@ ____
 .. [#] The traits and traitsUI user guide:
    `http://docs.enthought.com/traits <http://docs.enthought.com/traits>`_
 
-.. [#] ctypes: `http://starship.python.net/crew/theller/ctypes/ <http://starship.python.net/crew/theller/ctypes/>`_
+.. [#] ctypes: `https://docs.python.org/3/library/ctypes.html <https://docs.python.org/3/library/ctypes.html>`_
 
 .. [#] threading: `http://docs.python.org/lib/module-threading.html <http://docs.python.org/lib/module-threading.html>`_
 
-.. [#] chaco: `http://code.enthought.com/chaco/ <http://code.enthought.com/chaco/>`_
+.. [#] chaco: `http://docs.enthought.com/chaco/ <http://docs.enthought.com/chaco/>`_
 
 .. vim:spell:spelllang=en_us


### PR DESCRIPTION
Fixed typos in links and also update the obsolete code.enthought.com to docs.enthought.com (#617)

However, after make, the webpage style looks different from the usual ones. 
