### PR TITLE
Fix tabular editor column widths on Qt

### DIFF
--- a/traitsui/helper.py
+++ b/traitsui/helper.py
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 #
-#  Copyright (c) 2005, Enthought, Inc.
+#  Copyright (c) 2005-19, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD
@@ -39,10 +39,6 @@ Orientation = Enum("horizontal", "vertical")
 
 # Docking drag bar style:
 DockStyle = Enum("horizontal", "vertical", "tab", "fixed")
-
-# ----------------------------------------------------------------------------
-#  Return a 'user-friendly' name for a specified trait:
-# ----------------------------------------------------------------------------
 
 
 def user_name_for(name):
@@ -106,3 +102,84 @@ def enum_values_changed(values, strfunc=six.text_type):
         inverse_mapping[value] = name
 
     return (names, mapping, inverse_mapping)
+
+
+def compute_column_widths(available_space, requested, min_widths, user_widths):
+    """ Distribute column space amongst columns based on requested space.
+
+    Widths requests can be specified as one of the following:
+
+    - a value greater than 1.0 is treated as a fixed width with no flexibility
+      (ie. a minimum width as specified and a weight of 0.0)
+
+    - a value between 0.0 and 1.0 is treaded as a flexible width column with
+      the specified width as a weight and a minimum width provided by the
+      min_widths entry.
+
+    - a value less than or equal to 0.0 is treated as a flexible width column
+      with a weight of 0.1 and a minimum width provided by the min_widths
+      parameter.
+
+    If user widths are supplied then any non-None values override the
+    requested widths, and are treated as having a flexibility of 0.
+
+    Space is distributed by evaluating each column from smallest weight to
+    largest and seeing if the weighted proportion of the remaining space is
+    more than the minimum, and if so replacing the width with the weighted
+    width.  The column is then removed from the available width and the
+    total weight and the analysis continues.
+
+    Parameters
+    ----------
+    available_space : int
+        The available horizontal space.
+    requested : list of numbers
+        The requested width or weight for each column.
+    min_widths : None or list of ints
+        The minimum width for each flexible column
+    user_widths : None or list of int or None
+        Any widths specified by the user resizing the columns manually.
+
+    Returns
+    -------
+    widths : list of ints
+        The assigned width for each column
+    """
+    widths = []
+    weights = []
+    if min_widths is None:
+        min_widths = [30] * len(requested)
+
+    # determine flexibility and default width of each column
+    for request, min_width in zip(requested, min_widths):
+        if request >= 1.0:
+            weights.append(0.0)
+            widths.append(int(request))
+        else:
+            if request <= 0:
+                weights.append(0.1)
+            else:
+                weights.append(request)
+            widths.append(min_width)
+
+    # if the user has changed the width of a column manually respect that
+    if user_widths is not None:
+        for i, user_width in enumerate(user_widths):
+            if user_width is not None:
+                widths[i] = user_width
+                weights[i] = 0.0
+
+    total_weight = sum(weights)
+    if sum(widths) < available_space and total_weight > 0:
+        # do inflexible first, then work up from smallest to largest
+        for i, weight in sorted(enumerate(weights), key=itemgetter(1, 0)):
+            total_weight = sum(weights)
+            stretched = int(weight / total_weight * available_space)
+            widths[i] = max(stretched, widths[i])
+
+            # once we have dealt with a column, it no longer counts as flexible
+            # and its space is no longer available
+            weights[i] = 0.0
+            available_space -= widths[i]
+
+    return widths

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -22,7 +22,7 @@
 
 from __future__ import absolute_import
 
-import os
+from contextlib import contextmanager
 
 from pyface.qt import QtCore, QtGui
 from pyface.image_resource import ImageResource
@@ -43,6 +43,7 @@ from traits.api import (
 )
 
 from traitsui.tabular_adapter import TabularAdapter
+from traitsui.helper import compute_column_widths
 from .editor import Editor
 from .tabular_model import TabularModel
 import six
@@ -700,7 +701,8 @@ class _TableView(QtGui.QTableView):
         """
         QtGui.QTableView.__init__(self)
 
-        self._initial_size = False
+        self._user_widths = None
+        self._is_resizing = False
         self._editor = editor
         self.setModel(editor.model)
         factory = editor.factory
@@ -736,6 +738,7 @@ class _TableView(QtGui.QTableView):
         # Configure the column headings.
         hheader = self.horizontalHeader()
         hheader.setStretchLastSection(factory.stretch_last_section)
+        hheader.sectionResized.connect(self.columnResized)
         if factory.show_titles:
             hheader.setHighlightSections(False)
         else:
@@ -838,15 +841,13 @@ class _TableView(QtGui.QTableView):
             space be known, we have to wait until the UI that contains this
             table gives it its initial size.
         """
-        QtGui.QTableView.resizeEvent(self, event)
+        super(_TableView, self).resizeEvent(event)
 
         parent = self.parent()
         if (
-            not self._initial_size
-            and parent
+            parent
             and (self.isVisible() or isinstance(parent, QtGui.QMainWindow))
         ):
-            self._initial_size = True
             self.resizeColumnsToContents()
 
     def sizeHintForColumn(self, column):
@@ -868,35 +869,50 @@ class _TableView(QtGui.QTableView):
 
     def resizeColumnsToContents(self):
         """ Reimplemented to support proportional column width specifications.
-            For information about the layout algorithm, see
-            https://svn.enthought.com/enthought/wiki/Traits_3_0_tabular_editor.
+
+        The core part of the computation is carried out in
+        :func:`traitsui.helpers.compute_column_widths`
         """
         editor = self._editor
+        adapter = editor.adapter
         if editor.factory.auto_resize:
             # Use the default implementation.
             return super(_TableView, self).resizeColumnsToContents()
+
         available_space = self.viewport().width()
+        requested = []
+        min_widths = []
+        for column in range(len(adapter.columns)):
+            width = adapter.get_width(editor.object, editor.name, column)
+            requested.append(width)
+            min_widths.append(self.sizeHintForColumn(column))
+
+        widths = compute_column_widths(
+            available_space, requested, min_widths, self._user_widths
+        )
+
         hheader = self.horizontalHeader()
-
-        # Assign sizes for columns with absolute size requests
-        percent_vals, percent_cols = [], []
-        for column in range(len(editor.adapter.columns)):
-            width = editor.adapter.get_width(
-                editor.object, editor.name, column
-            )
-            if width > 1:
-                available_space -= width
+        with self._resizing():
+            for column, width in enumerate(widths):
                 hheader.resizeSection(column, width)
-            else:
-                if width <= 0:
-                    width = 0.1
-                percent_vals.append(width)
-                percent_cols.append(column)
 
-        # Now use the remaining space for columns with proportional or no width
-        # requests.
-        percent_total = sum(percent_vals)
-        for i, column in enumerate(percent_cols):
-            percent = percent_vals[i] / percent_total
-            width = max(30, int(percent * available_space))
-            hheader.resizeSection(column, width)
+    def columnResized(self, index, old, new):
+        """ Handle user-driven resizing of columns.
+
+        This affects the column widths when not using auto-sizing.
+        """
+        if not self._is_resizing:
+            if self._user_widths is None:
+                self._user_widths = [None] * len(self._editor.adapter.columns)
+            self._user_widths[index] = new
+            if not self._editor.factory.auto_resize:
+                self.resizeColumnsToContents()
+
+    @contextmanager
+    def _resizing(self):
+        """ Context manager that guards against recursive column resizing. """
+        self._is_resizing = True
+        try:
+            yield
+        finally:
+            self._is_resizing = False

--- a/traitsui/tests/test_helper.py
+++ b/traitsui/tests/test_helper.py
@@ -1,0 +1,106 @@
+#  Copyright (c) 2019, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+
+from unittest import TestCase
+
+from traitsui.helper import compute_column_widths
+
+
+class TestComputeColumnWidths(TestCase):
+
+    def test_all_default(self):
+        available_space = 200
+        requested = [-1, -1, -1, -1]
+
+        widths = compute_column_widths(available_space, requested, None, None)
+
+        self.assertEqual(widths, [50, 50, 50, 50])
+
+    def test_all_fixed(self):
+        available_space = 200
+        requested = [10, 50, 40, 20]
+
+        widths = compute_column_widths(available_space, requested, None, None)
+
+        self.assertEqual(widths, [10, 50, 40, 20])
+
+    def test_all_fixed_too_wide(self):
+        available_space = 100
+        requested = [10, 50, 40, 20]
+
+        widths = compute_column_widths(available_space, requested, None, None)
+
+        self.assertEqual(widths, [10, 50, 40, 20])
+
+    def test_all_weighted(self):
+        available_space = 200
+        requested = [0.3, 0.2, 0.25, 0.25]
+
+        widths = compute_column_widths(available_space, requested, None, None)
+
+        self.assertEqual(widths, [60, 40, 50, 50])
+
+    def test_all_weighted_default_min(self):
+        available_space = 200
+        requested = [0.4, 0.1, 0.1, 0.4]
+
+        widths = compute_column_widths(available_space, requested, None, None)
+
+        self.assertEqual(widths, [70, 30, 30, 70])
+
+    def test_mixed(self):
+        available_space = 200
+        requested = [0.5, 50, 25, 0.75]
+
+        widths = compute_column_widths(available_space, requested, None, None)
+
+        self.assertEqual(widths, [50, 50, 25, 75])
+
+    def test_mixed_too_wide(self):
+        available_space = 100
+        requested = [0.5, 50, 25, 0.75]
+
+        widths = compute_column_widths(available_space, requested, None, None)
+
+        self.assertEqual(widths, [30, 50, 25, 30])
+
+    def test_user_widths(self):
+        available_space = 225
+        requested = [0.5, 50, 25, 0.75]
+        user_widths = [None, None, 50, None]
+
+        widths = compute_column_widths(
+            available_space, requested, None, user_widths
+        )
+
+        self.assertEqual(widths, [50, 50, 50, 75])
+
+    def test_min_widths(self):
+        available_space = 225
+        requested = [0.5, 50, 0.25, 0.75]
+        min_widths = [30, 100, 50, 30]
+
+        widths = compute_column_widths(
+            available_space, requested, min_widths, None
+        )
+
+        self.assertEqual(widths, [50, 50, 50, 75])
+
+    def test_user_and_min_widths(self):
+        available_space = 200
+        requested = [0.5, 50, 0.25, 0.75]
+        min_widths = [30, 100, 50, 30]
+        user_widths = [None, 75, 25, 50]
+
+        widths = compute_column_widths(
+            available_space, requested, min_widths, user_widths
+        )
+
+        self.assertEqual(widths, [50, 75, 25, 50])


### PR DESCRIPTION
This PR does the following:

- adds a (tested!) algorithm for computing column widths for Table and Tabular editors similar to the way it specified in the documentation
- uses the algorithm in the Qt TabularEditor implementation
- automatically updates on resize of table or user modification of columns, preserving user choices.

The end result is _much_ nicer behaviour when re-sizing the columns.

Fixes #638.