### PR TITLE
Remove Use of Category Classes from TraitsUI

### DIFF
--- a/traitsui/dock_window_theme.py
+++ b/traitsui/dock_window_theme.py
@@ -22,7 +22,7 @@
 from __future__ import absolute_import
 
 from pyface.ui_traits import Image
-from traits.api import HasPrivateTraits, Bool
+from traits.api import HasPrivateTraits, Bool, Property, cached_property
 
 from .ui_traits import ATheme
 
@@ -71,6 +71,30 @@ class DockWindowTheme(HasPrivateTraits):
 
     #: Horizontal drag bar theme:
     horizontal_drag = ATheme
+
+    #: The bitmap for the 'tab_inactive_edge' image:
+    tab_inactive_edge_bitmap = Property(depends_on="tab_inactive_edge")
+
+    #: The bitmap for the 'tab_hover_edge' image:
+    tab_hover_edge_bitmap = Property(depends_on="tab_hover_edge")
+
+    # -- Property Implementations ---------------------------------------------
+
+    @cached_property
+    def _get_tab_inactive_edge_bitmap(self):
+        image = self.tab_inactive_edge
+        if image is None:
+            return None
+
+        return image.create_bitmap()
+
+    @cached_property
+    def _get_tab_hover_edge_bitmap(self):
+        image = self.tab_hover_edge
+        if image is None:
+            return self.tab_inactive_edge_bitmap
+
+        return image.create_bitmap()
 
 
 # -------------------------------------------------------------------------

--- a/traitsui/dock_window_theme.py
+++ b/traitsui/dock_window_theme.py
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------
 #
-#  Copyright (c) 2007, Enthought, Inc.
+#  Copyright (c) 2007-19, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD
@@ -98,16 +98,16 @@ class DockWindowTheme(HasPrivateTraits):
 
 
 # -------------------------------------------------------------------------
-#  Define the default theme:
+#  Default theme handling
 # -------------------------------------------------------------------------
 
-# The current default DockWindow theme:
+#: The current default DockWindow theme
 _dock_window_theme = None
-
-# Gets/Sets the default DockWindow theme:
 
 
 def dock_window_theme(theme=None):
+    """ Get or set the default DockWindow theme.
+    """
     global _dock_window_theme
 
     if _dock_window_theme is None:

--- a/traitsui/theme.py
+++ b/traitsui/theme.py
@@ -1,6 +1,6 @@
 # -------------------------------------------------------------------------
 #
-#  Copyright (c) 2007, Enthought, Inc.
+#  Copyright (c) 2007-19, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD
@@ -21,13 +21,9 @@
 
 from __future__ import absolute_import
 
-from traits.api import HasPrivateTraits
+from traits.api import HasPrivateTraits, Property, cached_property
 
 from .ui_traits import Image, HasBorder, HasMargin, Alignment
-
-# -------------------------------------------------------------------------
-#  'Theme' class:
-# -------------------------------------------------------------------------
 
 
 class Theme(HasPrivateTraits):
@@ -49,8 +45,14 @@ class Theme(HasPrivateTraits):
     #: The alignment to use for positioning the label:
     alignment = Alignment(cols=4)
 
-    #: Note: The 'content_color' and 'label_color' traits should be added by a
-    #: toolkit-specific category...
+    #: The color to use for content text (Wx only)
+    content_color = Property
+
+    #: The color to use for label text (Wx only)
+    label_color = Property
+
+    #: The image slice used to draw the theme (Wx only)
+    image_slice = Property(depends_on="image")
 
     # -- Constructor ----------------------------------------------------------
 
@@ -62,6 +64,49 @@ class Theme(HasPrivateTraits):
 
         super(Theme, self).__init__(**traits)
 
+    # -- Property Implementations ---------------------------------------------
 
-# Create a default theme:
+    def _get_content_color(self):
+        import wx
+
+        if self._content_color is None:
+            color = wx.BLACK
+            islice = self.image_slice
+            if islice is not None:
+                color = islice.content_color
+
+            self._content_color = color
+
+        return self._content_color
+
+    def _set_content_color(self, color):
+        self._content_color = color
+
+    def _get_label_color(self):
+        import wx
+
+        if self._label_color is None:
+            color = wx.BLACK
+            islice = self.image_slice
+            if islice is not None:
+                color = islice.label_color
+
+            self._label_color = color
+
+        return self._label_color
+
+    def _set_label_color(self, color):
+        self._label_color = color
+
+    @cached_property
+    def _get_image_slice(self):
+        from traitsui.wx.image_slice import image_slice_for
+
+        if self.image is None:
+            return None
+
+        return image_slice_for(self.image)
+
+
+#: The default theme:
 default_theme = Theme()

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 #
-#  Copyright (c) 2005, Enthought, Inc.
+#  Copyright (c) 2005-19, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -45,7 +45,6 @@ from pyface.wx.drag_and_drop import PythonDropTarget
 
 from traitsui.theme import Theme
 from traitsui.ui import UI
-from traitsui.dock_window_theme import DockWindowTheme
 from traitsui.toolkit import Toolkit
 
 from .constants import WindowColor, screen_dx, screen_dy
@@ -72,11 +71,6 @@ EventSuffix = {
 # Types of popup views:
 Popups = {"popup", "popover", "info"}
 
-# -------------------------------------------------------------------------
-#  Handles UI notification handler requests that occur on a thread other than
-#  the UI thread:
-# -------------------------------------------------------------------------
-
 
 def ui_handler(handler, *args):
     """ Handles UI notification handler requests that occur on a thread other
@@ -87,10 +81,6 @@ def ui_handler(handler, *args):
 
 # Tell the traits notification handlers to use this UI handler
 set_ui_handler(ui_handler)
-
-# -------------------------------------------------------------------------
-#  'GUIToolkit' class:
-# -------------------------------------------------------------------------
 
 
 class GUIToolkit(Toolkit):
@@ -484,86 +474,16 @@ class GUIToolkit(Toolkit):
     #  'Editor' class methods:
     # -------------------------------------------------------------------------
 
-    # Generic UI-base editor:
     def ui_editor(self):
+        """ Generic base UI editor. """
         from . import ui_editor
 
         return ui_editor.UIEditor
-
-    #
-    #    # Drag and drop:
-    #    def dnd_editor ( self, *args, **traits ):
-    #        import dnd_editor as dnd
-    #        return dnd.ToolkitEditorFactory( *args, **traits)
-    #
-    #    # Key Binding:
-    #    def key_binding_editor ( self, *args, **traits ):
-    #        import key_binding_editor as kbe
-    #        return kbe.ToolkitEditorFactory( *args, **traits )
-    #
-    #    # History:
-    #    def history_editor ( self, *args, **traits ):
-    #        import history_editor as he
-    #        return he.HistoryEditor( *args, **traits )
-    #
-    #    # HTML:
-    #    def html_editor ( self, *args, **traits ):
-    #        import html_editor as he
-    #        return he.ToolkitEditorFactory( *args, **traits )
-    #
-    #    # Image:
-    #    def image_editor ( self, *args, **traits ):
-    #        import image_editor as ie
-    #        return ie.ImageEditor( *args, **traits )
-    #
-    #    # ListStr:
-    #    def list_str_editor ( self, *args, **traits ):
-    #        import list_str_editor as lse
-    #        return lse.ListStrEditor( *args, **traits )
-    #
-    #    # Ordered set:
-    #    def ordered_set_editor ( self, *args, **traits ):
-    #        import ordered_set_editor as ose
-    #        return ose.ToolkitEditorFactory( *args, **traits )
-    #
-    #    # Plot:
-    #    def plot_editor ( self, *args, **traits ):
-    #        import plot_editor as pe
-    #        return pe.ToolkitEditorFactory( *args, **traits )
-    #
-    #    # Popup:
-    #    def popup_editor ( self, *args, **traits ):
-    #        import popup_editor as pe
-    #        return pe.PopupEditor( *args, **traits )
-    #
-    #    # RGB Color:
-    #    def rgb_color_editor ( self, *args, **traits ):
-    #        import rgb_color_editor as rgbce
-    #        return rgbce.ToolkitEditorFactory( *args, **traits )
-    #
-    #    # Scrubber:
-    #    def scrubber_editor ( self, *args, **traits ):
-    #        import scrubber_editor as se
-    #        return se.ScrubberEditor( *args, **traits )
-    #
-    #    # Shell:
 
     def shell_editor(self, *args, **traits):
         from . import shell_editor as se
 
         return se.ToolkitEditorFactory(*args, **traits)
-
-
-#
-#    # Tabular:
-#    def tabular_editor ( self, *args, **traits ):
-#        import tabular_editor as te
-#        return te.TabularEditor( *args, **traits )
-#
-#    # Value:
-#    def value_editor ( self, *args, **traits ):
-#        import value_editor as ve
-#        return ve.ToolkitEditorFactory( *args, **traits )
 
 
 class DragHandler(HasPrivateTraits):
@@ -624,11 +544,10 @@ class DragHandler(HasPrivateTraits):
             result = drag_result
         return result
 
-# -------------------------------------------------------------------------
-#  Defines the extensions needed to make the generic Theme class specific to
-#  wxPython:
-# -------------------------------------------------------------------------
 
+# -------------------------------------------------------------------------
+#  Theme Support
+# -------------------------------------------------------------------------
 
 class WXTheme(Category, Theme):
     """ Defines the extensions needed to make the generic Theme class specific
@@ -685,13 +604,13 @@ class WXTheme(Category, Theme):
 
 
 # -------------------------------------------------------------------------
-
+# Event handling
+# -------------------------------------------------------------------------
 
 class EventHandlerWrapper(wx.EvtHandler):
     """ Simple wrapper around wx.EvtHandler used to determine which event
     handlers were added by traitui.
     """
-
     pass
 
 

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -33,24 +33,18 @@ from pyface.toolkit import toolkit_object as pyface_toolkit
 
 _app = pyface_toolkit("init:_app")
 
-from traits.api import (
-    HasPrivateTraits,
-    Instance,
-    Property,
-    Category,
-    cached_property,
-)
+from traits.api import HasPrivateTraits, Instance
 from traits.trait_notifiers import set_ui_handler
 from pyface.wx.drag_and_drop import PythonDropTarget
 
 from traitsui.theme import Theme
 from traitsui.ui import UI
 from traitsui.toolkit import Toolkit
-
 from .constants import WindowColor, screen_dx, screen_dy
 from .helper import position_window
 
 
+#: Mapping from wx events to method suffixes.
 EventSuffix = {
     wx.wxEVT_LEFT_DOWN: "left_down",
     wx.wxEVT_LEFT_DCLICK: "left_dclick",
@@ -68,9 +62,13 @@ EventSuffix = {
     wx.wxEVT_PAINT: "paint",
 }
 
-# Types of popup views:
+#: Types of popup views:
 Popups = {"popup", "popover", "info"}
 
+
+# -------------------------------------------------------------------------
+# Traits UI dispatch infrastructure
+# -------------------------------------------------------------------------
 
 def ui_handler(handler, *args):
     """ Handles UI notification handler requests that occur on a thread other
@@ -82,6 +80,10 @@ def ui_handler(handler, *args):
 # Tell the traits notification handlers to use this UI handler
 set_ui_handler(ui_handler)
 
+
+# -------------------------------------------------------------------------
+# Wx Toolkit Implementation
+# -------------------------------------------------------------------------
 
 class GUIToolkit(Toolkit):
     """ Implementation class for wxPython toolkit.
@@ -544,68 +546,6 @@ class DragHandler(HasPrivateTraits):
             result = drag_result
         return result
 
-
-# -------------------------------------------------------------------------
-#  Theme Support
-# -------------------------------------------------------------------------
-
-class WXTheme(Category, Theme):
-    """ Defines the extensions needed to make the generic Theme class specific
-        to wxPython.
-    """
-
-    #: The color to use for content text:
-    content_color = Property
-
-    #: The color to use for label text:
-    label_color = Property
-
-    #: The image slice used to draw the theme:
-    image_slice = Property(depends_on="image")
-
-    # -- Property Implementations ---------------------------------------------
-
-    def _get_content_color(self):
-        if self._content_color is None:
-            color = wx.BLACK
-            islice = self.image_slice
-            if islice is not None:
-                color = islice.content_color
-
-            self._content_color = color
-
-        return self._content_color
-
-    def _set_content_color(self, color):
-        self._content_color = color
-
-    def _get_label_color(self):
-        if self._label_color is None:
-            color = wx.BLACK
-            islice = self.image_slice
-            if islice is not None:
-                color = islice.label_color
-
-            self._label_color = color
-
-        return self._label_color
-
-    def _set_label_color(self, color):
-        self._label_color = color
-
-    @cached_property
-    def _get_image_slice(self):
-        from .image_slice import image_slice_for
-
-        if self.image is None:
-            return None
-
-        return image_slice_for(self.image)
-
-
-# -------------------------------------------------------------------------
-# Event handling
-# -------------------------------------------------------------------------
 
 class EventHandlerWrapper(wx.EvtHandler):
     """ Simple wrapper around wx.EvtHandler used to determine which event

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -624,7 +624,6 @@ class DragHandler(HasPrivateTraits):
             result = drag_result
         return result
 
-
 # -------------------------------------------------------------------------
 #  Defines the extensions needed to make the generic Theme class specific to
 #  wxPython:
@@ -683,42 +682,6 @@ class WXTheme(Category, Theme):
             return None
 
         return image_slice_for(self.image)
-
-
-# -------------------------------------------------------------------------
-#  Defines the extensions needed to make the generic DockWindowTheme class
-#  specific to wxPython:
-# -------------------------------------------------------------------------
-
-
-class WXDockWindowTheme(Category, DockWindowTheme):
-    """ Defines the extensions needed to make the generic DockWindowTheme class
-        specific to wxPython.
-    """
-
-    #: The bitmap for the 'tab_inactive_edge' image:
-    tab_inactive_edge_bitmap = Property(depends_on="tab_inactive_edge")
-
-    #: The bitmap for the 'tab_hover_edge' image:
-    tab_hover_edge_bitmap = Property(depends_on="tab_hover_edge")
-
-    # -- Property Implementations ---------------------------------------------
-
-    @cached_property
-    def _get_tab_inactive_edge_bitmap(self):
-        image = self.tab_inactive_edge
-        if image is None:
-            return None
-
-        return image.create_image().ConvertToBitmap()
-
-    @cached_property
-    def _get_tab_hover_edge_bitmap(self):
-        image = self.tab_hover_edge
-        if image is None:
-            return self.tab_inactive_edge_bitmap
-
-        return image.create_image().ConvertToBitmap()
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
The `Category` mechanism is deprecated in Traits.  This PR removes all remaining usages of `Category` classes from TraitsUI.  This was achieved by:

- adding the contributed traits properties from `WXTheme` to `Theme` coupled with careful delayed importing of wx-specific modules
- converting the contributed traits properties from `WxDockTheme` to use the `IImageResource` interface and hence become backend-agnostic and therefore safe to move to `DockTheme`.

Plus additional drive-by clean-up of the modules affected.

See https://github.com/enthought/traits/issues/506 for more on deprecation and removal of `Category` from Traits.