### PR TITLE
Refactor base editor

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -411,7 +411,8 @@ class Editor(HasPrivateTraits):
         if len(parts) == 1:
             object = self.context_object
         else:
-            object, name = parts
+            object_name, name = parts
+            object = self.ui.context[object_name]
 
         return (object, name, partial(xgetattr, object, name))
 


### PR DESCRIPTION
General clean-up and fixes for `Editor` base class.  The biggest change is the removal of the use of `eval` in the synchronization code, replacing it with `xgetattr`.