### PR TITLE
Base Editor Cleanup

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -168,7 +168,7 @@ class Editor(HasPrivateTraits):
         self.update_editor()
 
     def init(self, parent):
-        """ Creating the underlying toolkit for the widget.
+        """ Create and initialize the underlying toolkit widget.
 
         This method must be overriden by subclasses.  Implementations must
         ensure that the :attr:`control` trait is set to an appropriate

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -179,14 +179,14 @@ class Editor(HasPrivateTraits):
         parent : toolkit control
             The parent toolkit object of the editor's toolkit objects.
         """
-        raise NotImplementedError
+        raise NotImplementedError("This method must be overriden.")
 
     def set_focus(self):
         """ Assigns focus to the editor's underlying toolkit widget.
 
         This method must be overriden by subclasses.
         """
-        raise NotImplementedError
+        raise NotImplementedError("This method must be overriden.")
 
     def dispose(self):
         """ Disposes of the contents of an editor.

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -1,6 +1,4 @@
-# ------------------------------------------------------------------------------
-#
-#  Copyright (c) 2005, Enthought, Inc.
+#  Copyright (c) 2005-19, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD
@@ -12,8 +10,6 @@
 #
 #  Author: David C. Morrill
 #  Date:   10/07/2004
-#
-# ------------------------------------------------------------------------------
 
 """ Defines the abstract Editor class, which represents an editing control for
     an object trait in a Traits-based user interface.
@@ -37,7 +33,6 @@ from traits.api import (
     ReadOnly,
     Set,
     Str,
-    Trait,
     TraitError,
     TraitListEvent,
     Tuple,
@@ -56,9 +51,6 @@ from .undo import UndoItem
 from .item import Item
 import six
 
-# -------------------------------------------------------------------------
-#  Trait definitions:
-# -------------------------------------------------------------------------
 
 # Reference to an EditorFactory object
 factory_trait = Instance(EditorFactory)
@@ -68,10 +60,6 @@ class Editor(HasPrivateTraits):
     """ Represents an editing control for an object trait in a Traits-based
         user interface.
     """
-
-    # -------------------------------------------------------------------------
-    #  Trait definitions:
-    # -------------------------------------------------------------------------
 
     #: The UI (user interface) this editor is part of:
     ui = Instance("traitsui.ui.UI", clean_up=True)
@@ -464,6 +452,8 @@ class Editor(HasPrivateTraits):
 
         return (object, name, partial(xgetattr, object, name))
 
+    # -- Trait synchronization code -----------------------------------------
+
     def _sync_values(self):
         """ Initialize and synchronize editor and factory traits
 
@@ -542,12 +532,12 @@ class Editor(HasPrivateTraits):
 
         Parameters
         ----------
-        user_name : string
+        user_name : str
             The name of the trait to be used on the user object. If empty, no
             synchronization will be set up.
-        editor_name : string
+        editor_name : str
             The name of the relevant editor trait.
-        mode : string, optional; one of 'to', 'from' or 'both'
+        mode : str, optional; one of 'to', 'from' or 'both'
             The direction of synchronization. 'from' means that trait changes
             in the user object should be propagated to the editor. 'to' means
             that trait changes in the editor should be propagated to the user
@@ -648,7 +638,7 @@ class Editor(HasPrivateTraits):
             The object in the TraitsUI context that is being bound.
         xuser_name: : str
             The extended name of the trait to be used on the user object.
-        editor_name : string
+        editor_name : str
             The name of the relevant editor trait.
         is_list : bool, optional
             If true, synchronization for item events will be set up in


### PR DESCRIPTION
The second in a series of PRs to replace #684. Requires #685 to be merged before this is merged.

A couple of small code improvements:

- add a `clean_up` trait metadata for traits that should be set to `None` during disposal.
- add a contextmanager for when the underlying trait is being modified from a change in the editor.

Plus add docstrings, remove redundant comments and other drive-by clean-up.