### PR TITLE
Replace uses of trait types 'false' and 'true'

### DIFF
--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 import numpy
 
-from traits.api import Bool, HasTraits, Int, Float, Instance, false, TraitError
+from traits.api import Bool, HasTraits, Int, Float, Instance, TraitError
 
 from ..editor import Editor
 
@@ -215,7 +215,7 @@ class SimpleEditor(Editor):
     # -------------------------------------------------------------------------
 
     # Is the editor read-only?
-    readonly = false
+    readonly = Bool(False)
 
     def init(self, parent):
         """ Finishes initializing the editor by creating the underlying toolkit

--- a/traitsui/editors/compound_editor.py
+++ b/traitsui/editors/compound_editor.py
@@ -19,7 +19,7 @@
 
 from __future__ import absolute_import
 
-from traits.api import List, true
+from traits.api import Bool, List
 
 from ..editor_factory import EditorFactory
 
@@ -47,7 +47,7 @@ class ToolkitEditorFactory(EditorFactory):
     editors = editors_trait
 
     #: Is user input set on every keystroke?
-    auto_set = true
+    auto_set = Bool(True)
 
 
 # Define the CompoundEditor class

--- a/traitsui/editors/html_editor.py
+++ b/traitsui/editors/html_editor.py
@@ -22,7 +22,7 @@
 
 from __future__ import absolute_import
 
-from traits.api import Str, false
+from traits.api import Bool, Str
 
 from ..basic_editor_factory import BasicEditorFactory
 
@@ -58,7 +58,7 @@ class ToolkitEditorFactory(BasicEditorFactory):
     # --------------------------------------------------------------------------
 
     #: Should implicit text formatting be converted to HTML?
-    format_text = false
+    format_text = Bool(False)
 
     #: External objects referenced in the HTML are relative to this url
     base_url = Str
@@ -67,7 +67,7 @@ class ToolkitEditorFactory(BasicEditorFactory):
     base_url_name = Str
 
     #: Should links be opened in an external browser?
-    open_externally = false
+    open_externally = Bool(False)
 
     def parse_text(self, text):
         """ Parses the contents of a formatted text string into the

--- a/traitsui/editors/value_editor.py
+++ b/traitsui/editors/value_editor.py
@@ -21,7 +21,7 @@
 
 from __future__ import absolute_import
 
-from traits.api import Instance, Int, false
+from traits.api import Bool, Instance, Int
 
 from .tree_editor import TreeEditor
 from ..view import View
@@ -47,7 +47,7 @@ class _ValueEditor(Editor):
     # -------------------------------------------------------------------------
 
     #: Is the editor read only?
-    readonly = false
+    readonly = Bool(False)
 
     #: The root node of the value tree
     root = Instance(RootNode)

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -31,6 +31,7 @@ import io
 from configobj import ConfigObj
 
 from traits.api import (
+    Bool,
     HasTraits,
     HasPrivateTraits,
     Str,
@@ -39,8 +40,6 @@ from traits.api import (
     Any,
     Code,
     HTML,
-    true,
-    false,
     Dict,
 )
 
@@ -418,7 +417,7 @@ class DemoFile(DemoTreeNodeObject):
     nice_name = Property
 
     #: Files don't allow children:
-    allows_children = false
+    allows_children = Bool(False)
 
     #: Description of what the demo does:
     description = HTML
@@ -492,10 +491,10 @@ class DemoPath(DemoTreeNodeObject):
     init_dic = Property
 
     #: Should .py files be included?
-    use_files = true
+    use_files = Bool(True)
 
     #: Paths do allow children:
-    allows_children = true
+    allows_children = Bool(True)
 
     #: Configuration dictionary for this node
     #: This trait is set when a config file exists for the parent of this path.

--- a/traitsui/qt4/extra/led_editor.py
+++ b/traitsui/qt4/extra/led_editor.py
@@ -9,7 +9,7 @@
 from pyface.qt import QtGui
 from traitsui.qt4.editor import Editor
 from traitsui.basic_editor_factory import BasicEditorFactory
-from traits.api import undefined
+from traits.api import Any, Undefined
 
 
 class _LEDEditor(Editor):
@@ -27,4 +27,4 @@ class LEDEditor(BasicEditorFactory):
     #: The editor class to be created
     klass = _LEDEditor
     #: Alignment is not supported for QT backend
-    alignment = undefined
+    alignment = Any(Undefined)

--- a/traitsui/wx/key_binding_editor.py
+++ b/traitsui/wx/key_binding_editor.py
@@ -24,7 +24,7 @@
 from __future__ import absolute_import
 import wx
 
-from traits.api import Event, false
+from traits.api import Bool, Event
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
 # compatibility. The class has been moved to the
@@ -53,7 +53,7 @@ class KeyBindingEditor(Editor):
     # -------------------------------------------------------------------------
 
     #: Does the editor's control have focus currently?
-    has_focus = false
+    has_focus = Bool(False)
 
     #: Keyboard event
     key = Event


### PR DESCRIPTION
This PR replaces uses of the `false` and `true` convenience trait types with `Bool(False)` or `Bool(True)` as appropriate.

(Note that `Bool(False)` is technically redundant: `Bool()` or even `Bool` would be enough, but I think the explicitly-spelled out default has value for readability.)