### PR TITLE
Use a common utility to generate HTML from RST in demo.py and tutor.py

### DIFF
--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -861,25 +861,30 @@ class Demo(HasPrivateTraits):
 
 
 # -------------------------------------------------------------------------
-#  Function to run the demo:
+#  Utilities to convert rst strings/files to html.
 # -------------------------------------------------------------------------
 
 
-def demo(
-    use_files=False, dir_name=None, config_filename="", title="Traits UI Demos"
-):
-    if dir_name is None:
-        dir_name = dirname(abspath(sys.argv[0]))
-    path, name = split(dir_name)
-    if len(config_filename) > 0 and not isabs(config_filename):
-        config_filename = join(path, name, config_filename)
-    Demo(
-        path=path,
-        title=title,
-        root=DemoPath(
-            name=name, use_files=use_files, config_filename=config_filename
-        ),
-    ).configure_traits()
+def _get_settings(css_path=None):
+    """ Helper function to make settings dictionary
+    consumable by docutils
+
+    Parameters
+    ----------
+    css_path: string or None (default)
+        If not None, use the CSS stylesheet.
+
+    Returns
+    -------
+    dict
+    """
+    settings = {'output_encoding': 'unicode'}
+    if css_path is not None:
+        settings['stylesheet_path'] = css_path
+        settings['embed_stylesheet'] = True
+        settings['stylesheet'] = None
+
+    return settings
 
 
 def publish_html_str(rst_str, css_path=None):
@@ -898,21 +903,12 @@ def publish_html_str(rst_str, css_path=None):
     -------
     string
     """
-    # If docutils is not installed, just add it as a text string item:
     try:
         from docutils.core import publish_string
     except Exception:
         return rst_str
 
-    # Try to find a CSS style sheet, and set up the docutil overrides if
-    # found:
-    settings = {'output_encoding': 'unicode'}
-    if css_path is not None:
-        settings['stylesheet_path'] = css_path
-        settings['embed_stylesheet'] = True
-        settings['stylesheet'] = None
-
-    # Convert it from restructured text to HTML:
+    settings = _get_settings(css_path)
     return publish_string(rst_str,
                           writer_name='html',
                           settings_overrides=settings)
@@ -935,21 +931,35 @@ def publish_html_file(rst_file_path, html_out_path, css_path=None):
     -------
     None
     """
-    # If docutils is not installed, just add it as a text string item:
     try:
         from docutils.core import publish_file
     except Exception:
         return
 
-    # Try to find a CSS style sheet, and set up the docutil overrides if
-    # found:
-    settings = {'output_encoding': 'unicode'}
-    if css_path is not None:
-        settings['stylesheet_path'] = css_path
-        settings['embed_stylesheet'] = True
-        settings['stylesheet'] = None
-
+    settings = _get_settings(css_path)
     publish_file(source_path=rst_file_path,
                  destination_path=html_out_path,
                  writer_name='html',
                  settings_overrides=settings)
+
+
+# -------------------------------------------------------------------------
+#  Function to run the demo:
+# -------------------------------------------------------------------------
+
+
+def demo(
+    use_files=False, dir_name=None, config_filename="", title="Traits UI Demos"
+):
+    if dir_name is None:
+        dir_name = dirname(abspath(sys.argv[0]))
+    path, name = split(dir_name)
+    if len(config_filename) > 0 and not isabs(config_filename):
+        config_filename = join(path, name, config_filename)
+    Demo(
+        path=path,
+        title=title,
+        root=DemoPath(
+            name=name, use_files=use_files, config_filename=config_filename
+        ),
+    ).configure_traits()

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -878,3 +878,76 @@ def demo(
             name=name, use_files=use_files, config_filename=config_filename
         ),
     ).configure_traits()
+
+
+def publish_html_str(rst_str, css_path=None):
+    """ Format RST string to html using `docutils` if available.
+    Otherwise, return the input `rst_str`.
+
+    Parameters
+    ----------
+    rst_str: string
+        reStructuredText
+
+    css_path: string or None (default)
+        If not None, use the CSS stylesheet.
+
+    Returns
+    -------
+    string
+    """
+    # If docutils is not installed, just add it as a text string item:
+    try:
+        from docutils.core import publish_string
+    except Exception:
+        return rst_str
+
+    # Try to find a CSS style sheet, and set up the docutil overrides if
+    # found:
+    settings = {'output_encoding': 'unicode'}
+    if css_path is not None:
+        settings['stylesheet_path'] = css_path
+        settings['embed_stylesheet'] = True
+        settings['stylesheet'] = None
+
+    # Convert it from restructured text to HTML:
+    return publish_string(rst_str,
+                          writer_name='html',
+                          settings_overrides=settings)
+
+
+def publish_html_file(rst_file_path, html_out_path, css_path=None):
+    """ Format reStructuredText in `rst_file_path` to html using `docutils`
+    if available. Otherwise, does nothing.
+
+    Parameters
+    ----------
+    rst_file_path: string
+
+    html_out_path: string
+
+    css_path: string or None (default)
+        If not None, use the CSS stylesheet.
+
+    Returns
+    -------
+    None
+    """
+    # If docutils is not installed, just add it as a text string item:
+    try:
+        from docutils.core import publish_file
+    except Exception:
+        return
+
+    # Try to find a CSS style sheet, and set up the docutil overrides if
+    # found:
+    settings = {'output_encoding': 'unicode'}
+    if css_path is not None:
+        settings['stylesheet_path'] = css_path
+        settings['embed_stylesheet'] = True
+        settings['stylesheet'] = None
+
+    publish_file(source_path=rst_file_path,
+                 destination_path=html_out_path,
+                 writer_name='html',
+                 settings_overrides=settings)

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -32,6 +32,7 @@ from configobj import ConfigObj
 
 from traits.api import (
     Bool,
+    cached_property,
     HasTraits,
     HasPrivateTraits,
     Str,
@@ -484,7 +485,7 @@ class DemoPath(DemoTreeNodeObject):
     nice_name = Property
 
     #: Description of the contents of the directory:
-    description = Property(HTML)
+    description = Property(HTML, depends_on="_description")
 
     #: Source code contained in the '__init__.py' file:
     source = Property(Code)
@@ -504,6 +505,9 @@ class DemoPath(DemoTreeNodeObject):
 
     #: Configuration file for this node.
     config_filename = Str
+
+    #: Shadow trait for description property
+    _description = Str
 
     #: Cached value of the nice_name property.
     _nice_name = Str
@@ -537,6 +541,7 @@ class DemoPath(DemoTreeNodeObject):
     #  Implementation of the 'description' property:
     # -------------------------------------------------------------------------
 
+    @cached_property
     def _get_description(self):
         if self._description is None:
             self._get_init()

--- a/traitsui/extras/demo.py
+++ b/traitsui/extras/demo.py
@@ -189,7 +189,9 @@ class DemoFileHandler(Handler):
         sys.stdout = sys.stderr = self
 
         # Read in the demo source file:
-        df.description, df.source = parse_source(df.path)
+        description, source = parse_source(df.path)
+        df.description = publish_html_str(description)
+        df.source = source
         # Try to run the demo source file:
 
         # Append the path for the demo source file to sys.path, so as to
@@ -539,7 +541,7 @@ class DemoPath(DemoTreeNodeObject):
         if self._description is None:
             self._get_init()
 
-        return self._description
+        return publish_html_str(self._description)
 
     # -------------------------------------------------------------------------
     #  Implementation of the 'source' property:

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -50,6 +50,7 @@ from traitsui.menu \
 
 from traitsui.tree_node \
     import TreeNode
+from traitsui.extras.demo import publish_html_str, publish_html_file
 
 from pyface.image_resource \
     import ImageResource
@@ -1452,7 +1453,7 @@ class SectionFactory(HasPrivateTraits):
         if css_path != '':
             css_path = os.path.join(self.path, css_path)
 
-        html = publish_html(content, css_path)
+        html = publish_html_str(content, css_path)
 
         # Choose the right HTML renderer:
         if is_windows and wx_available:
@@ -1734,76 +1735,3 @@ class Tutor(HasPrivateTraits):
         section = SectionFactory(title=title).trait_set(path=path).section
         if section is not None:
             self.section = self.root = section
-
-
-def publish_html(rst_str, css_path=None):
-    """ Format RST string to html using `docutils` if available.
-    Otherwise, return the input `rst_str`.
-
-    Parameters
-    ----------
-    rst_str: string
-        reStructuredText
-
-    css_path: string or None (default)
-        If not None, use the CSS stylesheet.
-
-    Returns
-    -------
-    string
-    """
-    # If docutils is not installed, just add it as a text string item:
-    try:
-        from docutils.core import publish_string
-    except Exception:
-        return rst_str
-
-    # Try to find a CSS style sheet, and set up the docutil overrides if
-    # found:
-    settings = {'output_encoding': 'unicode'}
-    if css_path is not None:
-        settings['stylesheet_path'] = css_path
-        settings['embed_stylesheet'] = True
-        settings['stylesheet'] = None
-
-    # Convert it from restructured text to HTML:
-    return publish_string(rst_str,
-                          writer_name='html',
-                          settings_overrides=settings)
-
-
-def publish_html_file(rst_file_path, html_out_path, css_path=None):
-    """ Format reStructuredText in `rst_file_path` to html using `docutils`
-    if available. Otherwise, does nothing.
-
-    Parameters
-    ----------
-    rst_file_path: string
-
-    html_out_path: string
-
-    css_path: string or None (default)
-        If not None, use the CSS stylesheet.
-
-    Returns
-    -------
-    None
-    """
-    # If docutils is not installed, just add it as a text string item:
-    try:
-        from docutils.core import publish_file
-    except Exception:
-        return
-
-    # Try to find a CSS style sheet, and set up the docutil overrides if
-    # found:
-    settings = {'output_encoding': 'unicode'}
-    if css_path is not None:
-        settings['stylesheet_path'] = css_path
-        settings['embed_stylesheet'] = True
-        settings['stylesheet'] = None
-
-    publish_file(source_path=rst_file_path,
-                 destination_path=html_out_path,
-                 writer_name='html',
-                 settings_overrides=settings)

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -1464,7 +1464,11 @@ class SectionFactory(HasPrivateTraits):
 
         content = content.strip()
 
-        html = publish_html(content, self.css_path)
+        css_path = self.css_path
+        if css_path != '':
+            css_path = os.path.join(self.path, css_path)
+
+        html = publish_html(content, css_path)
 
         # Choose the right HTML renderer:
         if is_windows and wx_available:

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -1464,27 +1464,7 @@ class SectionFactory(HasPrivateTraits):
 
         content = content.strip()
 
-        # If docutils is not installed, just add it as a text string item:
-        try:
-            from docutils.core import publish_string
-        except:
-            self.descriptions.append(TextStrItem(content=content,
-                                                 title=title))
-            return
-
-        # Try to find a CSS style sheet, and set up the docutil overrides if
-        # found:
-        settings = {'output_encoding': 'unicode'}
-        css_path = self.css_path
-        if css_path != '':
-            css_path = os.path.join(self.path, css_path)
-            settings['stylesheet_path'] = css_path
-            settings['embed_stylesheet'] = True
-            settings['stylesheet'] = None
-
-        # Convert it from restructured text to HTML:
-        html = publish_string(content, writer_name='html',
-                              settings_overrides=settings)
+        html = publish_html(content, self.css_path)
 
         # Choose the right HTML renderer:
         if is_windows and wx_available:
@@ -1766,3 +1746,39 @@ class Tutor(HasPrivateTraits):
         section = SectionFactory(title=title).trait_set(path=path).section
         if section is not None:
             self.section = self.root = section
+
+
+def publish_html(rst_str, css_path=None):
+    """ Format RST string to html using `docutils` if available.
+    Otherwise, return the input `rst_str`.
+
+    Parameters
+    ----------
+    rst_str: string
+        reStructuredText
+
+    css_path: string or None (default)
+        If not None, use the CSS stylesheet.
+
+    Returns
+    -------
+    string
+    """
+    # If docutils is not installed, just add it as a text string item:
+    try:
+        from docutils.core import publish_string
+    except Exception:
+        return rst_str
+
+    # Try to find a CSS style sheet, and set up the docutil overrides if
+    # found:
+    settings = {'output_encoding': 'unicode'}
+    if css_path is not None:
+        settings['stylesheet_path'] = css_path
+        settings['embed_stylesheet'] = True
+        settings['stylesheet'] = None
+
+    # Convert it from restructured text to HTML:
+    return publish_string(rst_str,
+                          writer_name='html',
+                          settings_overrides=settings)

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -1282,28 +1282,26 @@ class SectionFactory(HasPrivateTraits):
 
         # Get the name of the HTML file we will write to:
         dir, base_name = os.path.split(path)
-        html_filepath = os.path.join(dir,
-                                     os.path.splitext(base_name)[0] + '.htm')
+        html = os.path.join(dir, os.path.splitext(base_name)[0] + '.htm')
 
         # If the HTML file does not exist, or is older than the restructured
         # text file, then let docutils convert it to HTML:
-        is_file = os.path.isfile(html_filepath)
+        is_file = os.path.isfile(html)
         if ((not is_file) or
-            (os.path.getmtime(path) > os.path.getmtime(html_filepath)) or
-                (os.path.getmtime(css_path) >
-                    os.path.getmtime(html_filepath))):
+            (os.path.getmtime(path) > os.path.getmtime(html)) or
+                (os.path.getmtime(css_path) > os.path.getmtime(html))):
 
             # Delete the current HTML file (if any):
             if is_file:
-                os.remove(html_filepath)
+                os.remove(html)
 
             # Let docutils create a new HTML file from the restructured text
             # file:
-            publish_html_file(path, html_filepath, css_path)
+            publish_html_file(path, html, css_path)
 
-        if os.path.isfile(html_filepath):
+        if os.path.isfile(html):
             # If there is now a valid HTML file, use it:
-            self._create_html_item(path=html_filepath)
+            self._create_html_item(path=html)
         else:
             # Otherwise, just use the original restructured text file:
             self._add_txt_item(path)


### PR DESCRIPTION
contributes to #698. 
This PR unifies the document text generation between **demo.py** and **tutor.py** by using utility functions which are thin wrappers around `docutils` to generate html from reStructuredText.. A future PR would unify the text parsing between **demo.py** and **tutor.py**.