### PR TITLE
Unify py file parsing between demo.py and tutor.py

### DIFF
--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -97,11 +97,6 @@ snippet_editor = ListEditor(
 dir_pat1 = re.compile(r'^(\d\d\d\d)_(.*)$')
 dir_pat2 = re.compile(r'^(.*)_(\d+\.\d+)$')
 
-# Regular expression used to match section header in a Python source file:
-section_pat1 = re.compile(r'^#-*\[(.*)\]')  # Normal
-section_pat2 = re.compile(r'^#-*<(.*)>')    # Hidden
-section_pat3 = re.compile(r'^#-*\((.*)\)')  # Description
-
 # Regular expression used to extract item titles from URLs:
 url_pat1 = re.compile(r'^(.*)\[(.*)\](.*)$')  # Normal
 
@@ -796,10 +791,6 @@ class Lab(ASection):
                          show_label=False,
                          editor=TitleEditor()
                          ),
-                    '_',
-                    Item('visible',
-                         label='View hidden sections'
-                         )
                 ),
             ),
             Tabbed(

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -1396,49 +1396,6 @@ class SectionFactory(HasPrivateTraits):
 
         self.descriptions.append(item)
 
-    def _check_embedded_code(self, lines, start):
-        """ Checks for an embedded Python code snippet within a description.
-        """
-        n = len(lines)
-        while start < n:
-            line = lines[start].strip()
-
-            if line == '':
-                start += 1
-                continue
-
-            if (line[:1] != '[') or (line[-1:] != ']'):
-                break
-
-            del lines[start]
-
-            n -= 1
-            title = line[1:-1].strip()
-            line = lines[start] + '.'
-            pad = len(line) - len(line.strip())
-            clines = []
-
-            while start < n:
-                line = lines[start] + '.'
-                len_line = len(line.strip())
-                if (len_line > 1) and ((len(line) - len_line) < pad):
-                    break
-
-                if (len(clines) > 0) or (len_line > 1):
-                    clines.append(line[pad: -1])
-
-                start += 1
-
-            # Add the new code snippet:
-            self.snippets.append(CodeItem(
-                title=title or 'Code',
-                content='\n'.join(clines)
-            ))
-
-            break
-
-        return start
-
 #-------------------------------------------------------------------------
 #  Tutor tree editor:
 #-------------------------------------------------------------------------

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -1217,7 +1217,7 @@ class SectionFactory(HasPrivateTraits):
         """ Creates the code snippets for a Python source file.
         """
         description, source = parse_source(path)
-        title = ''
+        title = "Description"
         self._add_description(description, title)
         self.snippets.append(CodeItem(
             title="Code",

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -103,11 +103,6 @@ url_pat1 = re.compile(r'^(.*)\[(.*)\](.*)$')  # Normal
 # Is this running on the Windows platform?
 is_windows = (sys.platform in ('win32', 'win64'))
 
-# Python file section types:
-IsCode = 0
-IsHiddenCode = 1
-IsDescription = 2
-
 # HTML template for a default lecture:
 DefaultLecture = """<html>
   <head>

--- a/traitsui/extras/tutor.py
+++ b/traitsui/extras/tutor.py
@@ -1219,14 +1219,11 @@ class SectionFactory(HasPrivateTraits):
         description, source = parse_source(path)
         title = ''
         self._add_description(description, title)
-        self._add_code_snippet('Code', path, source)
-
-    def _add_code_snippet(self, title, path, content):
         self.snippets.append(CodeItem(
-            title=title or 'Code',
+            title="Code",
             path=path,
-            hidden=(type == IsHiddenCode),
-            content=content
+            hidden=False,
+            content=source
         ))
 
     def _add_txt_item(self, path):


### PR DESCRIPTION
Closes #698 

- Use the parser from `demo.py` to get the docstring and code in `tutor.py`. This means we no longer support different types of sections (*description*, *hidden*, *normal*) in a py file.



This is follow on to PR #702.