### PR TITLE
Add scrollable trait to the ListEditor

### DIFF
--- a/docs/source/traitsui_user_manual/factories_basic.rst
+++ b/docs/source/traitsui_user_manual/factories_basic.rst
@@ -905,7 +905,7 @@ ListEditor()
 :Default for:
     List [18]_
 :Optional parameters:
-    *editor*, *rows*, *style*, *trait_handler*, *use_notebook*
+    *editor*, *rows*, *style*, *scrollable*, *trait_handler*, *use_notebook*
 
     The following parameters are used only if *use_notebook* is True:
     *deletable*, *dock_style*, *export*, *page_name*, *select*, *view*
@@ -923,11 +923,13 @@ reordering items within the list.
 The simple style displays a single item at a time, with small arrows on the
 right side to scroll the display. The custom style shows multiple items. The
 number of items displayed is controlled by the *rows* parameter; if the number
-of items in the list exceeds this value, then the list display scrolls. The
-editor used for each item in the list is determined by the *editor* and *style*
-parameters. The text style of list editor is identical to the custom style,
-except that the editors for the items are text editors. The read-only style
-displays the contents of the list as static text.
+of items in the list exceeds this value, then the list display scrolls. If the
+*scrollable* parameter is False, the editor displays all objects in the list and
+does not render the vertical scrollbar. The editor used for each item in the list
+is determined by the *editor* and *style* parameters. The text style of list
+editor is identical to the custom style, except that the editors for the items
+are text editors. The read-only style displays the contents of the list as
+static text.
 
 By default, the items use the trait handler appropriate to the type of items in
 the list. You can specify a different handler to use for the items using the

--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -86,7 +86,7 @@ class ToolkitEditorFactory(EditorFactory):
     mutable = Bool(True)
 
     #: Should the scrollbars be displayed if the list is too long.
-    scrollable = Bool(True)
+    scrollable = Bool(True, sync_value=True)
 
     #: The style of editor to use for each item:
     style = style_trait

--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -85,6 +85,9 @@ class ToolkitEditorFactory(EditorFactory):
     #: Can the list be reorganized, or have items added and deleted.
     mutable = Bool(True)
 
+    #: Should the scrollbars be displayed if the list is too long.
+    scrollable = Bool(True)
+
     #: The style of editor to use for each item:
     style = style_trait
 

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -209,6 +209,8 @@ class SimpleEditor(Editor):
         # early (ie. before it contains something).
         if self.control.widget() is None:
             self.control.setWidget(list_pane)
+            if not self.scrollable:
+                self.control.setMinimumHeight(list_pane.sizeHint().height())
 
     def update_editor_item(self, event):
         """ Updates the editor when an item in the object trait changes
@@ -381,6 +383,11 @@ class SimpleEditor(Editor):
         """ Trait handler to set the mutable trait from the factory.
         """
         return self.factory.mutable
+
+    def _scrollable_default(self):
+        """ Trait handler to set the scrollable from the factory.
+        """
+        return self.factory.scrollable
 
 
 class CustomEditor(SimpleEditor):

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -33,9 +33,10 @@ from .menu import MakeMenu
 
 
 class SimpleEditor(Editor):
-    """ Simple style of editor for lists, which displays a scrolling list box
-    with only one item visible at a time. A icon next to the list box displays
-    a menu of operations on the list.
+    """ Simple style of editor for lists, which displays a list box with only
+    one item visible at a time. A icon next to the list box displays a menu of
+    operations on the list.
+
     """
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
The `scrollable` trait of the `ListEditor` allows us to hide the vertical scrollbar, and display all the items contained in the list.

Drive-by fixes -- Removes some duplicate code.