### PR TITLE
Fix missing commas in convert_to_color functions

### DIFF
--- a/traitsui/null/rgb_color_trait.py
+++ b/traitsui/null/rgb_color_trait.py
@@ -56,7 +56,8 @@ def convert_to_color(object, name, value):
     if isinstance(value, int):
         num = int(value)
         return (
-            (num / 0x10000) / 255.0((num / 0x100) & 0xFF) / 255.0,
+            (num / 0x10000) / 255.0,
+            ((num / 0x100) & 0xFF) / 255.0,
             (num & 0xFF) / 255.0,
         )
     raise TraitError

--- a/traitsui/wx/rgb_color_trait.py
+++ b/traitsui/wx/rgb_color_trait.py
@@ -65,7 +65,8 @@ def convert_to_color(object, name, value):
     if isinstance(value, int):
         num = int(value)
         return (
-            (num / 0x10000) / 255.0((num / 0x100) & 0xFF) / 255.0,
+            (num / 0x10000) / 255.0,
+            ((num / 0x100) & 0xFF) / 255.0,
             (num & 0xFF) / 255.0,
         )
     if isinstance(value, wx.Colour):


### PR DESCRIPTION
These were missing before the black reformat and caused SyntaxWarnings then.