### PR TITLE
Replace AdaptedTo with Supports

### DIFF
--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -25,7 +25,6 @@ from __future__ import absolute_import
 import six
 
 from traits.api import (
-    AdaptedTo,
     Adapter,
     Any,
     Bool,
@@ -39,6 +38,7 @@ from traits.api import (
     List,
     Property,
     Str,
+    Supports,
     cached_property,
 )
 
@@ -1014,7 +1014,7 @@ class ITreeNodeAdapterBridge(HasPrivateTraits):
     """
 
     #: The ITreeNode adapter being bridged:
-    adapter = AdaptedTo(ITreeNode)
+    adapter = Supports(ITreeNode)
 
     # -- TreeNode implementation ----------------------------------------------
 


### PR DESCRIPTION
Replace the deprecated `AdaptedTo` with the exact equivalent `Supports`.

Related: enthought/traits#723.
Also related: #674