### PR TITLE
TableEditor: add explicit redraw on select event

### DIFF
--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -519,6 +519,8 @@ class TableEditor(Editor, BaseTableEditor):
         finally:
             smodel.blockSignals(False)
 
+        self.refresh_editor()
+
     # -------------------------------------------------------------------------
     #  Private methods:
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #717 

I don't know if we should expect PyQt to handle this redraw, so I'm not sure if this is a fix or just a workaround, but forcing the redraw appears to fix the issue.