### PR TITLE
Remove mentions of ThisClass from docs

### DIFF
--- a/docs/source/traitsui_user_manual/factories_basic.rst
+++ b/docs/source/traitsui_user_manual/factories_basic.rst
@@ -765,9 +765,9 @@ InstanceEditor()
 ````````````````
 
 :Suitable for:
-    Instance, Property, self, ThisClass, This
+    Instance, Property, self, This
 :Default for:
-    Instance, self, ThisClass, This
+    Instance, self, This
 :Optional parameters:
     *cachable*, *editable*, *id*, *kind*, *label*, *name*, *object*,
     *orientation*, *values*, *view*


### PR DESCRIPTION
`ThisClass` is due to be either deprecated or removed in Traits 6.0, and isn't something that we want to advertise.

Ref: enthought/traits#697