### PR TITLE
Define Color, Font and RGBColor TraitFactories in TraitsUI

### DIFF
--- a/examples/demo/Advanced/NumPy_array_tabular_editor_demo.py
+++ b/examples/demo/Advanced/NumPy_array_tabular_editor_demo.py
@@ -14,8 +14,8 @@ index of each point in the array, as well as a red flag if the point lies within
 from __future__ import absolute_import
 from numpy import sqrt
 from numpy.random import random
-from traits.api import HasTraits, Property, Array, Font
-from traitsui.api import View, Item, TabularEditor
+from traits.api import HasTraits, Property, Array
+from traitsui.api import View, Item, TabularEditor, Font
 from traitsui.tabular_adapter import TabularAdapter
 
 #-- Tabular Adapter Definition -------------------------------------------

--- a/examples/demo/Advanced/Tabular_editor_demo.py
+++ b/examples/demo/Advanced/Tabular_editor_demo.py
@@ -100,9 +100,9 @@ feels stand out about this approach are:
 from __future__ import absolute_import
 from random import randint, choice, shuffle
 from traits.api import HasTraits, Str, Int, List, Instance, Property, \
-    Constant, Color
+    Constant
 from traits.etsconfig.api import ETSConfig
-from traitsui.api import View, Group, Item, TabularEditor
+from traitsui.api import View, Group, Item, TabularEditor, Color
 from traitsui.tabular_adapter import TabularAdapter
 
 #-- Person Class Definition ----------------------------------------------

--- a/examples/demo/Applications/Python_source_browser.py
+++ b/examples/demo/Applications/Python_source_browser.py
@@ -31,12 +31,12 @@ from os.path \
 
 from traits.api \
     import HasPrivateTraits, Str, Float, List, Directory, File, Code, \
-    Instance, Property, Font, cached_property
+    Instance, Property, cached_property
 
 import traitsui.api
 
 from traitsui.api \
-    import View, Item, HSplit, VSplit, TabularEditor
+    import View, Item, HSplit, VSplit, TabularEditor, Font
 
 from traitsui.tabular_adapter \
     import TabularAdapter

--- a/examples/demo/Extras/Tree_editor_with_TreeNodeRenderer.py
+++ b/examples/demo/Extras/Tree_editor_with_TreeNodeRenderer.py
@@ -25,10 +25,10 @@ import numpy as np
 
 from pyface.qt import QtCore, QtGui, qt_api
 from traits.api import (
-    Array, Float, HasTraits, Instance, Int, List, RGBColor, Unicode
+    Array, Float, HasTraits, Instance, Int, List, Unicode
 )
 
-from traitsui.api import TreeEditor, TreeNode, UItem, View
+from traitsui.api import TreeEditor, TreeNode, UItem, View, RGBColor
 from traitsui.tree_node_renderer import AbstractTreeNodeRenderer
 from traitsui.qt4.tree_editor import WordWrapRenderer
 

--- a/examples/demo/Standard_Editors/ColorEditor_demo.py
+++ b/examples/demo/Standard_Editors/ColorEditor_demo.py
@@ -10,10 +10,10 @@ This demo shows each of the four styles of the ColorEditor
 # Imports:
 from __future__ import absolute_import
 from traits.api \
-    import HasTraits, Color
+    import HasTraits
 
 from traitsui.api \
-    import Item, Group, View
+    import Item, Group, View, Color
 
 # Demo class definition:
 

--- a/examples/demo/Standard_Editors/FontEditor_demo.py
+++ b/examples/demo/Standard_Editors/FontEditor_demo.py
@@ -18,9 +18,9 @@ This example also displays some other less common style choices.
 
 # Imports:
 from __future__ import absolute_import
-from traits.api import HasTraits, Font
+from traits.api import HasTraits
 
-from traitsui.api import Item, Group, View
+from traitsui.api import Item, Group, View, Font
 
 
 class FontEditorDemo(HasTraits):

--- a/examples/demo/Standard_Editors/Popup_versions/ColorEditor_demo.py
+++ b/examples/demo/Standard_Editors/Popup_versions/ColorEditor_demo.py
@@ -5,8 +5,8 @@ This demo shows each of the four styles of the ColorEditor.
 """
 
 from __future__ import absolute_import
-from traits.api import HasTraits, Color
-from traitsui.api import Item, Group, View
+from traits.api import HasTraits
+from traitsui.api import Item, Group, View, Color
 
 #-------------------------------------------------------------------------
 #  Demo Class

--- a/examples/demo/Standard_Editors/Popup_versions/FontEditor_demo.py
+++ b/examples/demo/Standard_Editors/Popup_versions/FontEditor_demo.py
@@ -5,8 +5,8 @@ This demo shows each of the four styles of the FontEditor.
 """
 
 from __future__ import absolute_import
-from traits.api import HasTraits, Font
-from traitsui.api import Item, Group, View
+from traits.api import HasTraits
+from traitsui.api import Item, Group, View, Font
 
 #-------------------------------------------------------------------------
 #  Demo Class

--- a/examples/demo/Standard_Editors/Popup_versions/TupleEditor_demo.py
+++ b/examples/demo/Standard_Editors/Popup_versions/TupleEditor_demo.py
@@ -5,8 +5,8 @@ This demo shows each of the four styles of the TupleEditor.
 """
 
 from __future__ import absolute_import
-from traits.api import HasTraits, Tuple, Color, Range, Str
-from traitsui.api import Item, Group, View
+from traits.api import HasTraits, Tuple, Range, Str
+from traitsui.api import Item, Group, View, Color
 
 #-------------------------------------------------------------------------
 #  Demo Class

--- a/examples/demo/Standard_Editors/RGBColorEditor_demo.py
+++ b/examples/demo/Standard_Editors/RGBColorEditor_demo.py
@@ -10,10 +10,10 @@ This demo shows each of the four styles of the ColorEditor
 # Imports:
 from __future__ import absolute_import
 from traits.api \
-    import HasTraits, RGBColor
+    import HasTraits
 
 from traitsui.api \
-    import Item, Group, View
+    import Item, Group, View, RGBColor
 
 # Demo class definition:
 

--- a/examples/demo/Standard_Editors/TupleEditor_demo.py
+++ b/examples/demo/Standard_Editors/TupleEditor_demo.py
@@ -10,10 +10,10 @@ This demo shows each of the four styles of the TupleEditor
 # Imports:
 from __future__ import absolute_import
 from traits.api \
-    import HasTraits, Tuple, Color, Range, Str
+    import HasTraits, Tuple, Range, Str
 
 from traitsui.api \
-    import Item, Group, View
+    import Item, Group, View, Color
 
 # The main demo class:
 

--- a/examples/tutorials/doc_examples/examples/override_editor.py
+++ b/examples/tutorials/doc_examples/examples/override_editor.py
@@ -4,8 +4,8 @@
 # override_editor.py --- Example of overriding a trait
 #                        editor
 from __future__ import absolute_import
-from traits.api import HasTraits, Trait, Color
-from traitsui.api import ColorEditor
+from traits.api import HasTraits, Trait
+from traitsui.api import Color, ColorEditor
 
 
 class Polygon(HasTraits):

--- a/examples/tutorials/traitsui_4.0/editors/tabular_editor/sm_person_example.py
+++ b/examples/tutorials/traitsui_4.0/editors/tabular_editor/sm_person_example.py
@@ -51,10 +51,10 @@ from random \
     import randint, choice, shuffle
 
 from traits.api \
-    import HasTraits, Str, Int, List, Instance, Property, Constant, Color
+    import HasTraits, Str, Int, List, Instance, Property, Constant
 
 from traitsui.api \
-    import View, Group, Item, Margin, TabularEditor
+    import View, Group, Item, Margin, TabularEditor, Color
 
 from traitsui.tabular_adapter \
     import TabularAdapter

--- a/integrationtests/ui/test_ui.py
+++ b/integrationtests/ui/test_ui.py
@@ -21,11 +21,11 @@ import wx
 
 from traits.api \
     import Trait, HasTraits, Str, Int, Range, List, Event, File, Directory, \
-    Bool, Color, Font, Enum
+    Bool, Enum
 
 from traitsui.api \
     import View, Handler, Item, CheckListEditor, ButtonEditor, FileEditor, \
-    DirectoryEditor, ImageEnumEditor
+    DirectoryEditor, ImageEnumEditor, Color, Font
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/integrationtests/ui/test_ui3.py
+++ b/integrationtests/ui/test_ui3.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 import wx
 
 from traits.api import Trait, HasTraits, Str, Int
-from traitsui.api import View, Group
-from traits.api import Color
+from traitsui.api import Color, View, Group
 
 #-------------------------------------------------------------------------
 #  Model/View classes:

--- a/integrationtests/ui/test_ui4.py
+++ b/integrationtests/ui/test_ui4.py
@@ -21,8 +21,7 @@ from __future__ import absolute_import
 import wx
 
 from traits.api import Trait, HasTraits, Str, Int
-from traitsui.api import View, Group
-from traits.api import Color
+from traitsui.api import Color, View, Group
 
 #-------------------------------------------------------------------------
 #  Model classes:

--- a/integrationtests/ui/test_ui5.py
+++ b/integrationtests/ui/test_ui5.py
@@ -30,10 +30,8 @@ from traits.api \
 
 from traitsui.api \
     import View, Handler, Item, CheckListEditor, ButtonEditor, FileEditor, \
-    DirectoryEditor, ImageEnumEditor
+    DirectoryEditor, ImageEnumEditor, Color, Font
 
-from traits.api \
-    import Color, Font
 
 #-------------------------------------------------------------------------
 #  Constants:

--- a/traitsui/api.py
+++ b/traitsui/api.py
@@ -169,7 +169,14 @@ from .tabular_adapter import TabularAdapter
 
 from .toolkit import toolkit
 
-from .toolkit_traits import ColorTrait, FontTrait, RGBColorTrait
+from .toolkit_traits import (
+    Color,
+    ColorTrait,
+    Font,
+    FontTrait,
+    RGBColor,
+    RGBColorTrait,
+)
 
 from .tree_node import (
     ITreeNode,

--- a/traitsui/editors/code_editor.py
+++ b/traitsui/editors/code_editor.py
@@ -22,9 +22,10 @@ useful for tools such as debuggers.
 
 from __future__ import absolute_import
 
-from traits.api import Instance, Str, Color, Enum, Bool
+from traits.api import Instance, Str, Enum, Bool
 
 from ..editor_factory import EditorFactory
+from ..toolkit_traits import Color
 
 # -------------------------------------------------------------------------
 #  'ToolkitEditorFactory' class:

--- a/traitsui/editors/scrubber_editor.py
+++ b/traitsui/editors/scrubber_editor.py
@@ -22,11 +22,11 @@
 from __future__ import absolute_import
 
 from pyface.ui_traits import Alignment
-from traits.api import Float, Color, Property
+from traits.api import Float, Property
 
 from ..basic_editor_factory import BasicEditorFactory
-
 from ..toolkit import toolkit_object
+from ..toolkit_traits import Color
 
 # -------------------------------------------------------------------------
 #  Create the editor factory object:

--- a/traitsui/editors/table_editor.py
+++ b/traitsui/editors/table_editor.py
@@ -26,8 +26,6 @@ from traits.api import (
     List,
     Instance,
     Str,
-    Color,
-    Font,
     Any,
     Tuple,
     Dict,
@@ -40,19 +38,13 @@ from traits.api import (
 )
 
 from ..editor_factory import EditorFactory
-
 from ..handler import Handler
-
 from ..helper import Orientation
-
 from ..item import Item
-
 from ..table_filter import TableFilter
-
+from ..toolkit_traits import Color, Font
 from ..ui_traits import AView
-
 from ..view import View
-
 from .enum_editor import EnumEditor
 
 

--- a/traitsui/list_str_adapter.py
+++ b/traitsui/list_str_adapter.py
@@ -24,7 +24,6 @@ from __future__ import absolute_import
 from traits.api import (
     Any,
     Bool,
-    Color,
     Enum,
     Event,
     HasPrivateTraits,
@@ -35,6 +34,7 @@ from traits.api import (
     on_trait_change,
     provides,
 )
+from .toolkit_traits import Color
 import six
 
 # -------------------------------------------------------------------------

--- a/traitsui/table_column.py
+++ b/traitsui/table_column.py
@@ -28,13 +28,11 @@ from traits.api import (
     Any,
     Bool,
     Callable,
-    Color,
     Constant,
     Either,
     Enum,
     Expression,
     Float,
-    Font,
     HasPrivateTraits,
     Instance,
     Int,
@@ -47,6 +45,7 @@ from traits.trait_base import user_name_for, xgetattr
 from .editor_factory import EditorFactory
 from .menu import Menu
 from .ui_traits import Image, AView, EditorStyle
+from .toolkit_traits import Color, Font
 from .view import View
 
 # Set up a logger:

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -21,15 +21,15 @@
 
 from __future__ import absolute_import
 
+import six
+
 from traits.api import (
     Any,
     Bool,
-    Color,
     Either,
     Enum,
     Event,
     Float,
-    Font,
     HasPrivateTraits,
     HasTraits,
     Instance,
@@ -42,7 +42,8 @@ from traits.api import (
     on_trait_change,
     provides,
 )
-import six
+
+from .toolkit_traits import Color, Font
 
 
 class ITabularAdapter(Interface):

--- a/traitsui/tests/null_backend/test_font_trait.py
+++ b/traitsui/tests/null_backend/test_font_trait.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 from nose.tools import assert_equals
 
-from traits.api import HasTraits, Font
+from traits.api import HasTraits
 
+from traitsui.toolkit_traits import Font
 from traitsui.tests._tools import *
 
 

--- a/traitsui/tests/test_color_column.py
+++ b/traitsui/tests/test_color_column.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 from unittest import TestCase
 
-from traits.api import HasTraits, Str, Int, RGBColor, List
-from traitsui.api import View, Group, Item, TableEditor, ObjectColumn
+from traits.api import HasTraits, Str, Int, List
+from traitsui.api import View, Group, Item, TableEditor, ObjectColumn, RGBColor
 from traitsui.color_column import ColorColumn
 
 from traitsui.tests._tools import skip_if_null, store_exceptions_on_all_threads

--- a/traitsui/toolkit_traits.py
+++ b/traitsui/toolkit_traits.py
@@ -1,15 +1,79 @@
-from __future__ import absolute_import
+#  Copyright (c) 2005-20, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in enthought/LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+
+
+# XXX eventually should replace with traits.api
+from traits.trait_factory import TraitFactory
 
 from .toolkit import toolkit
 
 
 def ColorTrait(*args, **traits):
+    """ Returns a trait whose value must be a GUI toolkit-specific color.
+
+    Description
+    -----------
+    For wxPython, the returned trait accepts any of the following values:
+
+    * A wx.Colour instance
+    * A wx.ColourPtr instance
+    * an integer whose hexadecimal form is 0x*RRGGBB*, where *RR* is the red
+      value, *GG* is the green value, and *BB* is the blue value
+
+    Default Value
+    -------------
+    For wxPython, 0xffffff (that is, white)
+    """
     return toolkit().color_trait(*args, **traits)
 
 
 def RGBColorTrait(*args, **traits):
+    """ Returns a trait whose value must be a GUI toolkit-specific RGB-based
+        color.
+
+    Description
+    -----------
+    For wxPython, the returned trait accepts any of the following values:
+
+    * A tuple of the form (*r*, *g*, *b*), in which *r*, *g*, and *b* represent
+      red, green, and blue values, respectively, and are floats in the range
+      from 0.0 to 1.0
+    * An integer whose hexadecimal form is 0x*RRGGBB*, where *RR* is the red
+      value, *GG* is the green value, and *BB* is the blue value
+
+    Default Value
+    -------------
+    For wxPython, (1.0, 1.0, 1.0) (that is, white)
+    """
     return toolkit().rgb_color_trait(*args, **traits)
 
 
 def FontTrait(*args, **traits):
+    """ Returns a trait whose value must be a GUI toolkit-specific font.
+
+    Description
+    -----------
+    For wxPython, the returned trait accepts any of the following:
+
+    * a wx.Font instance
+    * a wx.FontPtr instance
+    * a string describing the font, including one or more of the font family,
+      size, weight, style, and typeface name.
+
+    Default Value
+    -------------
+    For wxPython, 'Arial 10'
+    """
     return toolkit().font_trait(*args, **traits)
+
+
+Color = TraitFactory(ColorTrait)
+
+RGBColor = TraitFactory(RGBColorTrait)
+
+Font = TraitFactory(FontTrait)

--- a/traitsui/ui_editors/array_view_editor.py
+++ b/traitsui/ui_editors/array_view_editor.py
@@ -22,14 +22,12 @@
 
 from __future__ import absolute_import
 
-from traits.api import Instance, Property, List, Str, Bool, Font
+from traits.api import Instance, Property, List, Str, Bool
 
 from ..api import View, Item, TabularEditor, BasicEditorFactory
-
 from ..tabular_adapter import TabularAdapter
-
 from ..toolkit import toolkit_object
-
+from ..toolkit_traits import Font
 from ..ui_editor import UIEditor
 
 # -- Tabular Adapter Definition -------------------------------------------

--- a/traitsui/ui_editors/data_frame_editor.py
+++ b/traitsui/ui_editors/data_frame_editor.py
@@ -15,7 +15,6 @@ from traits.api import (
     Dict,
     Either,
     Enum,
-    Font,
     Instance,
     List,
     Property,
@@ -27,6 +26,7 @@ from traitsui.editors.tabular_editor import TabularEditor
 from traitsui.item import Item
 from traitsui.tabular_adapter import TabularAdapter
 from traitsui.toolkit import toolkit_object
+from traitsui.toolkit_traits import Font
 from traitsui.ui_editor import UIEditor
 from traitsui.view import View
 import six


### PR DESCRIPTION
This creates versions of the `Color`, `Font` and `RGBColor` trait factories inside TraitsUI.  This will allow deprecation of the UI traits from `traits.traits` as users can be instructed to use `traitsui.api` to get them rather than `traits.api` (see https://github.com/enthought/traits/issues/728).