### PR TITLE
Fix incorrect editor Undo action

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -282,9 +282,7 @@ class Editor(HasPrivateTraits):
         *undo_args
             Any arguments to pass to the undo factory.
         """
-        # Indicate that the contents of the user interface have been changed:
         ui = self.ui
-        ui.modified = True
 
         # Create an undo history entry if we are maintaining a history:
         undoable = ui._undoable
@@ -513,6 +511,9 @@ class Editor(HasPrivateTraits):
             self.item.style != "readonly"
             and object.base_trait(name).type != "event"
         ):
+            # Indicate that the contents of the UI have been changed:
+            self.ui.modified = True
+
             if self.updating:
                     self.log_change(
                     self.get_undo_item, object, name, old_value, new_value

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -513,9 +513,10 @@ class Editor(HasPrivateTraits):
             self.item.style != "readonly"
             and object.base_trait(name).type != "event"
         ):
-            self.log_change(
-                self.get_undo_item, object, name, old_value, new_value
-            )
+            if self.updating:
+                    self.log_change(
+                    self.get_undo_item, object, name, old_value, new_value
+                )
 
         # If the change was not caused by the editor itself:
         if not self.updating:

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -154,40 +154,41 @@ class UserObject(HasTraits):
     user_event = Event
 
 
-@unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
-class TestEditor(GuiTestAssistant, unittest.TestCase):
-    def create_editor(
-        self,
+def create_editor(
         context=None,
         object_name="object",
         name="user_value",
         factory=None,
         is_event=False,
-    ):
-        if context is None:
-            user_object = UserObject()
-            context = {"object": user_object}
-        elif "." in object_name:
-            context_name, xname = object_name.split(".", 1)
-            context_object = context[context_name]
-            user_object = xgetattr(context_object, xname)
-        else:
-            user_object = context[object_name]
-        ui = UI(context=context, handler=default_handler())
+):
+    if context is None:
+        user_object = UserObject()
+        context = {"object": user_object}
+    elif "." in object_name:
+        context_name, xname = object_name.split(".", 1)
+        context_object = context[context_name]
+        user_object = xgetattr(context_object, xname)
+    else:
+        user_object = context[object_name]
+    ui = UI(context=context, handler=default_handler())
 
-        if factory is None:
-            factory = StubEditorFactory()
-        factory.is_event = is_event
+    if factory is None:
+        factory = StubEditorFactory()
+    factory.is_event = is_event
 
-        editor = StubEditor(
-            parent=None,
-            ui=ui,
-            object_name=object_name,
-            name=name,
-            factory=factory,
-            object=user_object,
-        )
-        return editor
+    editor = StubEditor(
+        parent=None,
+        ui=ui,
+        object_name=object_name,
+        name=name,
+        factory=factory,
+        object=user_object,
+    )
+    return editor
+
+
+@unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
+class TestEditor(GuiTestAssistant, unittest.TestCase):
 
     def change_user_value(self, editor, object, name, value):
         if editor.is_event:
@@ -212,7 +213,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             self.event_loop_helper.event_loop_with_timeout(repeat=6)
 
     def test_lifecycle(self):
-        editor = self.create_editor()
+        editor = create_editor()
 
         self.assertEqual(editor.old_value, "test")
         self.assertEqual(editor.name, "user_value")
@@ -253,7 +254,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
     def test_context_object(self):
         user_object = UserObject(user_value="other_test")
         context = {"object": UserObject(), "other_object": user_object}
-        editor = self.create_editor(
+        editor = create_editor(
             context=context, object_name="other_object"
         )
 
@@ -283,7 +284,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         editor.dispose()
 
     def test_event_trait(self):
-        editor = self.create_editor(name="user_event", is_event=True)
+        editor = create_editor(name="user_event", is_event=True)
         user_object = editor.object
 
         self.assertEqual(editor.name, "user_event")
@@ -307,7 +308,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             )
         }
         user_object = context["object"].user_auxiliary
-        editor = self.create_editor(
+        editor = create_editor(
             context=context, object_name="object.user_auxiliary"
         )
 
@@ -349,7 +350,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
 
     def test_factory_sync_simple(self):
         factory = StubEditorFactory(auxiliary_value="test")
-        editor = self.create_editor(factory=factory)
+        editor = create_editor(factory=factory)
         editor.prepare(None)
 
         # preparation copies the auxiliary value from the factory
@@ -359,7 +360,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
 
     def test_factory_sync_cv_simple(self):
         factory = StubEditorFactory()
-        editor = self.create_editor(factory=factory)
+        editor = create_editor(factory=factory)
         editor.prepare(None)
 
         # preparation copies the auxiliary CV int value from the factory
@@ -374,7 +375,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             ),
             "other_object": UserObject(user_value="another_test"),
         }
-        editor = self.create_editor(context=context)
+        editor = create_editor(context=context)
         editor.prepare(None)
 
         # test simple name
@@ -410,7 +411,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
     # Testing sync_value "from" ---------------------------------------------
 
     def test_sync_value_from(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
 
@@ -432,7 +433,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             user_object.user_auxiliary = 12
 
     def test_sync_value_from_object(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
 
@@ -456,7 +457,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         user_object = UserObject()
         other_object = UserObject(user_auxiliary=20)
         context = {"object": user_object, "other_object": other_object}
-        editor = self.create_editor(context=context)
+        editor = create_editor(context=context)
         editor.prepare(None)
 
         with self.assertTraitChanges(editor, "auxiliary_value", count=1):
@@ -480,7 +481,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         # set up the editor
         user_object = UserObject(user_auxiliary=UserObject(user_value=20))
         context = {"object": user_object}
-        editor = self.create_editor(context=context)
+        editor = create_editor(context=context)
         editor.prepare(None)
 
         with self.assertTraitChanges(editor, "auxiliary_value", count=1):
@@ -506,7 +507,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             user_object.user_auxiliary.user_value = 13
 
     def test_sync_value_from_list(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
 
@@ -533,7 +534,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             user_object.user_list = ["one", "two", "three"]
 
     def test_sync_value_from_event(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
 
@@ -554,7 +555,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         factory = StubEditorFactory(
             auxiliary_cv_int=ContextValue("object.user_auxiliary")
         )
-        editor = self.create_editor(factory=factory)
+        editor = create_editor(factory=factory)
         user_object = editor.object
 
         with self.assertTraitChanges(editor, "auxiliary_cv_int", count=1):
@@ -575,7 +576,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
     # Testing sync_value "to" -----------------------------------------------
 
     def test_sync_value_to(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
         editor.auxiliary_value = 20
@@ -596,7 +597,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             editor.auxiliary_value = 12
 
     def test_sync_value_to_object(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
         editor.auxiliary_value = 20
@@ -621,7 +622,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         user_object = UserObject()
         other_object = UserObject()
         context = {"object": user_object, "other_object": other_object}
-        editor = self.create_editor(context=context)
+        editor = create_editor(context=context)
         editor.prepare(None)
         editor.auxiliary_value = 20
 
@@ -645,12 +646,12 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
     def test_sync_value_to_chained(self):
         user_object = UserObject(user_auxiliary=UserObject())
         context = {"object": user_object}
-        editor = self.create_editor(context=context)
+        editor = create_editor(context=context)
         editor.prepare(None)
         editor.auxiliary_value = 20
 
         with self.assertTraitChanges(
-            user_object.user_auxiliary, "user_value", count=1
+                user_object.user_auxiliary, "user_value", count=1
         ):
             editor.sync_value(
                 "object.user_auxiliary.user_value", "auxiliary_value", "to"
@@ -659,7 +660,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         self.assertEqual(user_object.user_auxiliary.user_value, 20)
 
         with self.assertTraitChanges(
-            user_object.user_auxiliary, "user_value", count=1
+                user_object.user_auxiliary, "user_value", count=1
         ):
             editor.auxiliary_value = 11
 
@@ -668,12 +669,12 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         editor.dispose()
 
         with self.assertTraitDoesNotChange(
-            user_object.user_auxiliary, "user_value"
+                user_object.user_auxiliary, "user_value"
         ):
             editor.auxiliary_value = 12
 
     def test_sync_value_to_list(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
 
@@ -700,7 +701,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
             editor.auxiliary_list = ["one", "two", "three"]
 
     def test_sync_value_to_event(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
 
@@ -721,7 +722,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         factory = StubEditorFactory(
             auxiliary_cv_float=ContextValue("object.user_auxiliary")
         )
-        editor = self.create_editor(factory=factory)
+        editor = create_editor(factory=factory)
         user_object = editor.object
         editor.auxiliary_cv_float = 20.0
 
@@ -743,7 +744,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
     # Testing sync_value "both" -----------------------------------------------
 
     def test_sync_value_both(self):
-        editor = self.create_editor()
+        editor = create_editor()
         user_object = editor.object
         editor.prepare(None)
 

--- a/traitsui/tests/test_undo.py
+++ b/traitsui/tests/test_undo.py
@@ -22,7 +22,6 @@ from traitsui.undo import UndoHistory
 GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
 no_gui_test_assistant = GuiTestAssistant.__name__ == "Unimplemented"
 if no_gui_test_assistant:
-
     # ensure null toolkit has an inheritable GuiTestAssistant
     class GuiTestAssistant(object):
         pass
@@ -33,8 +32,20 @@ class TestEditorUndo(GuiTestAssistant, unittest.TestCase):
 
     def check_history(self, editor, expected_history_now,
                       expected_history_length):
-        return (editor.ui.history.now == expected_history_now and
-                len(editor.ui.history.history) == expected_history_length)
+        if (editor.ui.history.now == expected_history_now and
+                len(editor.ui.history.history) == expected_history_length):
+            for itm in editor.ui.history.history:
+                if len(itm) > 1:
+                    return False
+            return True
+
+    def undo(self, editor):
+        self.gui.invoke_later(editor.ui.history.undo)
+        self.event_loop_helper.event_loop_with_timeout()
+
+    def redo(self, editor):
+        self.gui.invoke_later(editor.ui.history.redo)
+        self.event_loop_helper.event_loop_with_timeout()
 
     def test_undo(self):
         editor = create_editor()
@@ -49,8 +60,7 @@ class TestEditorUndo(GuiTestAssistant, unittest.TestCase):
             self.gui.set_trait_later(editor.control, "control_value", "ab")
 
         # Perform an UNDO
-        self.gui.invoke_later(editor.ui.history.undo)
-        self.event_loop_helper.event_loop_with_timeout()
+        self.undo(editor)
 
         # Expect 2 items in history and pointer at first item
         self.assertEventuallyTrue(editor, "ui",
@@ -60,8 +70,7 @@ class TestEditorUndo(GuiTestAssistant, unittest.TestCase):
                                   timeout=5.0)
 
         # Perform a REDO
-        self.gui.invoke_later(editor.ui.history.redo)
-        self.event_loop_helper.event_loop_with_timeout()
+        self.redo(editor)
 
         # Expect 2 items in history and pointer at second item
         self.assertEventuallyTrue(editor, "ui",
@@ -75,8 +84,7 @@ class TestEditorUndo(GuiTestAssistant, unittest.TestCase):
             self.gui.set_trait_later(editor.control, "control_value", "abc")
 
         # Perform an UNDO
-        self.gui.invoke_later(editor.ui.history.undo)
-        self.event_loop_helper.event_loop_with_timeout()
+        self.undo(editor)
 
         # Expect 3 items in history and pointer at second item
         self.assertEventuallyTrue(editor, "ui",
@@ -91,8 +99,25 @@ class TestEditorUndo(GuiTestAssistant, unittest.TestCase):
         self.event_loop_helper.event_loop_with_timeout()
 
         # Expect 3 items in history and pointer at second item
+        # Note: Modifying the history after an UNDO, clears the future,
+        # hence, we expect 3 items in the history, not 4
         self.assertEventuallyTrue(editor, "ui",
                                   functools.partial(self.check_history,
                                                     expected_history_now=3,
+                                                    expected_history_length=3),
+                                  timeout=5.0)
+
+        # The following sequence after modifying the history had caused
+        # the application to hang, verify it.
+
+        # Perform an UNDO
+        self.undo(editor)
+        self.undo(editor)
+        self.redo(editor)
+
+        # Expect 3 items in history and pointer at second item
+        self.assertEventuallyTrue(editor, "ui",
+                                  functools.partial(self.check_history,
+                                                    expected_history_now=2,
                                                     expected_history_length=3),
                                   timeout=5.0)

--- a/traitsui/tests/test_undo.py
+++ b/traitsui/tests/test_undo.py
@@ -1,0 +1,93 @@
+#  Copyright (c) 2019-20, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+#  Author: Midhun PM
+#  Date:   February 04, 2020
+
+import functools
+import unittest
+
+from pyface.toolkit import toolkit_object
+
+from traitsui.tests.test_editor import create_editor
+from traitsui.undo import UndoHistory
+
+GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
+no_gui_test_assistant = GuiTestAssistant.__name__ == "Unimplemented"
+
+
+@unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
+class TestEditorUndo(GuiTestAssistant, unittest.TestCase):
+
+    def check_history(self, editor, expected_history_now,
+                      expected_history_length):
+        return (editor.ui.history.now == expected_history_now and
+                len(editor.ui.history.history) == expected_history_length)
+
+    def test_undo(self):
+        editor = create_editor()
+        editor.prepare(None)
+        editor.ui.history = UndoHistory()
+
+        self.assertEqual(editor.old_value, "test")
+
+        # Enter "ab"
+        with editor.updating_value():
+            self.gui.set_trait_later(editor.control, "control_value", "a")
+            self.gui.set_trait_later(editor.control, "control_value", "ab")
+
+        # Perform an UNDO
+        self.gui.invoke_later(editor.ui.history.undo)
+        self.event_loop_helper.event_loop_with_timeout()
+
+        # Expect 2 items in history and pointer at first item
+        self.assertEventuallyTrue(editor, "ui",
+                                  functools.partial(self.check_history,
+                                                    expected_history_now=1,
+                                                    expected_history_length=2),
+                                  timeout=5.0)
+
+        # Perform a REDO
+        self.gui.invoke_later(editor.ui.history.redo)
+        self.event_loop_helper.event_loop_with_timeout()
+
+        # Expect 2 items in history and pointer at second item
+        self.assertEventuallyTrue(editor, "ui",
+                                  functools.partial(self.check_history,
+                                                    expected_history_now=2,
+                                                    expected_history_length=2),
+                                  timeout=5.0)
+
+        # Enter a new character 'c' at the end
+        with editor.updating_value():
+            self.gui.set_trait_later(editor.control, "control_value", "abc")
+
+        # Perform an UNDO
+        self.gui.invoke_later(editor.ui.history.undo)
+        self.event_loop_helper.event_loop_with_timeout()
+
+        # Expect 3 items in history and pointer at second item
+        self.assertEventuallyTrue(editor, "ui",
+                                  functools.partial(self.check_history,
+                                                    expected_history_now=2,
+                                                    expected_history_length=3),
+                                  timeout=5.0)
+
+        # Enter a new character 'd' at the end
+        with editor.updating_value():
+            self.gui.set_trait_later(editor.control, "control_value", "abd")
+        self.event_loop_helper.event_loop_with_timeout()
+
+        # Expect 3 items in history and pointer at second item
+        self.assertEventuallyTrue(editor, "ui",
+                                  functools.partial(self.check_history,
+                                                    expected_history_now=3,
+                                                    expected_history_length=3),
+                                  timeout=5.0)

--- a/traitsui/tests/test_undo.py
+++ b/traitsui/tests/test_undo.py
@@ -34,9 +34,13 @@ class TestEditorUndo(GuiTestAssistant, unittest.TestCase):
                       expected_history_length):
         if (editor.ui.history.now == expected_history_now and
                 len(editor.ui.history.history) == expected_history_length):
+
+            # Ensure that there is exactly 1 entry in each history item since
+            # no entries can be merged in this test.
             for itm in editor.ui.history.history:
-                if len(itm) > 1:
+                if len(itm) != 1:
                     return False
+
             return True
 
     def undo(self, editor):

--- a/traitsui/tests/test_undo.py
+++ b/traitsui/tests/test_undo.py
@@ -21,6 +21,11 @@ from traitsui.undo import UndoHistory
 
 GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
 no_gui_test_assistant = GuiTestAssistant.__name__ == "Unimplemented"
+if no_gui_test_assistant:
+
+    # ensure null toolkit has an inheritable GuiTestAssistant
+    class GuiTestAssistant(object):
+        pass
 
 
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")


### PR DESCRIPTION
Fixes #672 

The method that logs changes made to an editor: `traitsui.editor.Editor.log_change` was being called when the user performs some new action on the editor and also when an undo/redo action is performed. 

This was resulting in a corrupted `history` in `traitsui/ui.py:103`

This PR checks adds a check by looking at the `updating` flag which indicates the source of the change whether on the editor itself or externally and only calls `log_change` if the change was made on the editor.  

I feel that only changes made by the user need to be logged and not external changes, can't think of a case where the user should be allowed to undo an external change.

Looking for suggestions how to test this thoroughly. 