### PR TITLE
FIX: Allow using TupleEditor for all classes derived from BaseTuple.

### DIFF
--- a/traitsui/editors/tuple_editor.py
+++ b/traitsui/editors/tuple_editor.py
@@ -22,10 +22,10 @@ from __future__ import absolute_import
 from traits.trait_base import SequenceTypes
 
 from traits.api import (
+    BaseTuple,
     Bool,
     HasTraits,
     List,
-    Tuple,
     Unicode,
     Int,
     Any,
@@ -154,7 +154,7 @@ class TupleStructure(HasTraits):
 
         if types is None:
             type = editor.value_trait.handler
-            if isinstance(type, Tuple):
+            if isinstance(type, BaseTuple):
                 types = type.types
 
         if not isinstance(types, SequenceTypes):


### PR DESCRIPTION
Fixes #746 

Earlier, explicitly using `editor=TupleEditor()`, for instances of `traits.api.ValidatedTuple`, without re-specifying the `types` attribute in the editor factory, raised errors. This PR fixes this issue, by allowing the use of `editor=TupleEditor()` for all traits items that are instances of `traits.api.BaseTuple`.