### PR TITLE
FEAT: QT VideoEditor pulling frames

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -80,9 +80,10 @@ import glob
 import os
 import subprocess
 import sys
-from shutil import rmtree, copy as copyfile
-from tempfile import mkdtemp
 from contextlib import contextmanager
+from shutil import copy as copyfile
+from shutil import rmtree
+from tempfile import mkdtemp
 
 import click
 

--- a/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -35,7 +35,7 @@ def np_from_QImage(qimage):
 
 
 def qimage_function(image_fun):
-    """ Turns a image funciton into a QImage function """
+    """ Turns a image funciton into a QImage function, bound within a box """
     def qimage_conv_fun(image, box_dims):
         _np_image = image_fun(np_from_QImage(image))
         pil_image = Image.fromarray(_np_image)

--- a/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -141,7 +141,8 @@ class VideoEditorDemo(HasTraits):
 
 
 # Create the demo:
-demo = VideoEditorDemo(image_fun=test_image_fun)
+# demo = VideoEditorDemo(image_fun=test_image_fun)
+demo = VideoEditorDemo()
 demo.video_url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"  # noqa: E501
 
 # Run the demo (if invoked from the command line):

--- a/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -6,15 +6,49 @@ VideoEditor
 
 
 """
-
 import numpy as np
+from PIL import Image
+from pyface.qt.QtGui import QImage
 from traits.api import Bool, Button, Callable, Float, HasTraits, Range, Str
 from traitsui.api import ButtonEditor, HGroup, Item, UItem, View
 from traitsui.editors.video_editor import MediaStatus, PlayerState, VideoEditor
 
 
+def QImage_from_np(image):
+    assert (np.max(image) <= 255)
+    image8 = image.astype(np.uint8, order='C', casting='unsafe')
+    height, width, colors = image8.shape
+    bytesPerLine = 4 * width
+
+    image = QImage(image8.data, width, height, bytesPerLine,
+                   QImage.Format_RGB32)
+    return image
+
+
+def np_from_QImage(qimage):
+    # Creates a numpy array from a pyqt(5) QImage object
+    width, height = qimage.width(), qimage.height()
+    channels = qimage.pixelFormat().channelCount()
+    return np.array(
+        qimage.bits().asarray(width * height * channels)
+    ).reshape(height, width, channels).astype('u1')
+
+
+def qimage_function(image_fun):
+    """ Turns a image funciton into a QImage function """
+    def qimage_conv_fun(image, box_dims):
+        _np_image = image_fun(np_from_QImage(image))
+        pil_image = Image.fromarray(_np_image)
+        pil_image.thumbnail(box_dims, Image.ANTIALIAS)
+        _np_image = np.array(pil_image)
+        image = QImage_from_np(_np_image)
+        return image, _np_image
+    return qimage_conv_fun
+
+
+@qimage_function
 def test_image_fun(image):
-    return image // 4
+    return image.transpose(1, 0, 2)
 
 
 class VideoEditorDemo(HasTraits):

--- a/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -7,9 +7,14 @@ VideoEditor
 
 """
 
-from traits.api import Bool, Button, Float, HasTraits, Range, Str
-from traitsui.api import ButtonEditor, Item, UItem, View, HGroup
-from traitsui.editors.video_editor import VideoEditor, MediaStatus, PlayerState
+import numpy as np
+from traits.api import Bool, Button, Callable, Float, HasTraits, Range, Str
+from traitsui.api import ButtonEditor, HGroup, Item, UItem, View
+from traitsui.editors.video_editor import MediaStatus, PlayerState, VideoEditor
+
+
+def test_image_fun(image):
+    return image // 4
 
 
 class VideoEditorDemo(HasTraits):
@@ -41,6 +46,8 @@ class VideoEditorDemo(HasTraits):
 
     playback_rate = Float(1.0)
 
+    image_fun = Callable()
+
     def _state_changed(self, new):
         if new == 'stopped' or new == 'paused':
             self.button_label = 'Play'
@@ -68,6 +75,7 @@ class VideoEditorDemo(HasTraits):
                 muted='muted',
                 volume='volume',
                 playback_rate='playback_rate',
+                image_fun='image_fun'
             ),
         ),
         HGroup(
@@ -99,7 +107,7 @@ class VideoEditorDemo(HasTraits):
 
 
 # Create the demo:
-demo = VideoEditorDemo()
+demo = VideoEditorDemo(image_fun=test_image_fun)
 demo.video_url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"  # noqa: E501
 
 # Run the demo (if invoked from the command line):

--- a/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -34,19 +34,27 @@ def np_from_QImage(qimage):
     ).reshape(height, width, channels).astype('u1')
 
 
-def qimage_function(image_fun):
-    """ Turns a image funciton into a QImage function, bound within a box """
-    def qimage_conv_fun(image, box_dims):
-        _np_image = image_fun(np_from_QImage(image))
-        pil_image = Image.fromarray(_np_image)
-        pil_image.thumbnail(box_dims, Image.ANTIALIAS)
-        _np_image = np.array(pil_image)
-        image = QImage_from_np(_np_image)
-        return image, _np_image
-    return qimage_conv_fun
+def qimage_function(antialiasing=True):
+    def antialis_fun(image_fun):
+        """
+        Turns a image funciton into a QImage function,
+        bound within the viewing frames box.
+        """
+        def qimage_conv_fun(image, box_dims):
+            _np_image = image_fun(np_from_QImage(image))
+            pil_image = Image.fromarray(_np_image)
+            if antialiasing:
+                pil_image.thumbnail(box_dims, Image.ANTIALIAS)
+            else:
+                pil_image.thumbnail(box_dims)
+            _np_image = np.array(pil_image)
+            image = QImage_from_np(_np_image)
+            return image, _np_image
+        return qimage_conv_fun
+    return antialis_fun
 
 
-@qimage_function
+@qimage_function(antialiasing=False)
 def test_image_fun(image):
     return image.transpose(1, 0, 2)
 
@@ -141,8 +149,8 @@ class VideoEditorDemo(HasTraits):
 
 
 # Create the demo:
-# demo = VideoEditorDemo(image_fun=test_image_fun)
-demo = VideoEditorDemo()
+demo = VideoEditorDemo(image_fun=test_image_fun)
+# demo = VideoEditorDemo()
 demo.video_url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"  # noqa: E501
 
 # Run the demo (if invoked from the command line):

--- a/traitsui/editors/video_editor.py
+++ b/traitsui/editors/video_editor.py
@@ -11,11 +11,10 @@
 
 from __future__ import absolute_import
 
-from traits.api import Enum, Property, Str
+from traits.api import Callable, Enum, Property, Str
 
 from ..basic_editor_factory import BasicEditorFactory
 from ..toolkit import toolkit_object
-
 
 AspectRatio = Enum('keep', 'ignore', 'expand')
 PlayerState = Enum('stopped', 'playing', 'paused')
@@ -77,6 +76,10 @@ class VideoEditor(BasicEditorFactory):
     #: The name of a trait to synchronise with the player's error state.
     #: The referenced trait should be a Str.
     video_error = Str(sync_value='to', sync_name='video_error')
+
+    #: The name of a trait to synchronise with the player's image function.
+    #: The referenced trait should be a Str.
+    image_fun = Str(sync_value='both', sync_name='image_fun')
 
     def _get_klass(self):
         """ Returns the editor class to be instantiated.

--- a/traitsui/qt4/video_editor.py
+++ b/traitsui/qt4/video_editor.py
@@ -58,12 +58,10 @@ def QImage_from_np(image):
     assert (np.max(image) <= 255)
     image8 = image.astype(np.uint8, order='C', casting='unsafe')
     height, width, colors = image8.shape
-    bytesPerLine = 3 * width
+    bytesPerLine = 4 * width
 
     image = QImage(image8.data, width, height, bytesPerLine,
-                   QImage.Format_RGB888)
-
-    image = image.rgbSwapped()
+                   QImage.Format_RGB32)
     return image
 
 


### PR DESCRIPTION
This is currently not working, but the same implementation using pyqt5 instead of pyside2 does work.

It may be related to [this bug report](https://bugreports.qt.io/browse/PYSIDE-794?attachmentOrder=desc)

This is the basic idea for inserting a QAbstractVideoSurface between the input from the data source and the output QVideoWidget. This allows a user defined image transformation function to be inserted in before painting to the QVideoWidget.

I'm sure the actual implementation of this would need to be discussed and changed.

