### PR TITLE
Fixed incorrect calls and testfailures for wxpython 4+

### DIFF
--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -166,7 +166,7 @@ def press_ok_button(ui):
     if is_current_backend_wx():
         import wx
 
-        ok_button = ui.control.FindWindowByName("button")
+        ok_button = ui.control.FindWindowByName("button", ui.control)
         click_event = wx.CommandEvent(
             wx.wxEVT_COMMAND_BUTTON_CLICKED, ok_button.GetId()
         )

--- a/traitsui/tests/editors/test_csv_editor.py
+++ b/traitsui/tests/editors/test_csv_editor.py
@@ -68,7 +68,7 @@ def test_csv_editor_external_append():
     # list externally
 
     def _wx_get_text_value(ui):
-        txt_ctrl = ui.control.FindWindowByName("text")
+        txt_ctrl = ui.control.FindWindowByName("text", ui.control)
         return txt_ctrl.GetValue()
 
     def _qt_get_text_value(ui):

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -130,7 +130,7 @@ def test_wx_list_str_multi_selected_index():
         # the following is equivalent to setting the text in the text control,
         # then pressing OK
 
-        liststrctrl = ui.control.FindWindowByName("listCtrl")
+        liststrctrl = ui.control.FindWindowByName("listCtrl", ui.control)
         selected_1 = get_selected(liststrctrl)
 
         obj.selected_indices = [0]

--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -61,16 +61,16 @@ def test_wx_spin_control_editing_should_not_crash():
             # range editor, enter a number, and clicking ok without defocusing
 
             # SpinCtrl object
-            spin = ui.control.FindWindowByName("wxSpinCtrl")
+            spin = ui.control.FindWindowByName("wxSpinCtrl", ui.control)
             spin.SetFocusFromKbd()
 
             # on Windows, a wxSpinCtrl does not have children, and we cannot do
             # the more fine-grained testing below
             if len(spin.GetChildren()) == 0:
-                spin.SetValueString("4")
+                spin.SetValue("4")
             else:
                 # TextCtrl object of the spin control
-                spintxt = spin.FindWindowByName("text")
+                spintxt = spin.FindWindowByName("text", spin)
                 spintxt.SetValue("4")
 
             # press the OK button and close the dialog

--- a/traitsui/tests/test_color_column.py
+++ b/traitsui/tests/test_color_column.py
@@ -4,7 +4,7 @@ from traits.api import HasTraits, Str, Int, List
 from traitsui.api import View, Group, Item, TableEditor, ObjectColumn, RGBColor
 from traitsui.color_column import ColorColumn
 
-from traitsui.tests._tools import skip_if_not_qt4, store_exceptions_on_all_threads
+from traitsui.tests._tools import skip_if_null, store_exceptions_on_all_threads
 
 
 class MyEntry(HasTraits):
@@ -34,7 +34,7 @@ class MyData(HasTraits):
 
 
 class TestColorColumn(TestCase):
-    @skip_if_not_qt4
+    @skip_if_null
     def test_color_column(self):
         # Behaviour: column ui should display without error
 

--- a/traitsui/tests/test_toolkit.py
+++ b/traitsui/tests/test_toolkit.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-import warnings
+
 import unittest
 
 from traits.trait_base import ETSConfig

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -105,7 +105,7 @@ def test_reset_without_destroy_wx():
         ui._editors[0], traitsui.wx.text_editor.SimpleEditor
     )
     nose.tools.assert_is_instance(
-        ui._editors[0].control, wx._controls.TextCtrl
+        ui._editors[0].control, wx.TextCtrl
     )
 
     ui.reset(destroy=False)
@@ -168,7 +168,9 @@ def test_destroy_after_ok_wx():
     control.Destroy = count_calls(control.Destroy)
 
     # press the OK button and close the dialog
-    okbutton = ui.control.FindWindowByName("button")
+    okbutton = ui.control.FindWindowByName("button", ui.control)
+    assert okbutton.Label == 'OK'
+
     click_event = wx.CommandEvent(
         wx.wxEVT_COMMAND_BUTTON_CLICKED, okbutton.GetId()
     )

--- a/traitsui/wx/ui_wizard.py
+++ b/traitsui/wx/ui_wizard.py
@@ -44,15 +44,9 @@ def ui_wizard(ui, parent):
     object.
     """
     # Create the copy of the 'context' we will need while editing:
-    context = ui.context
-    ui._context = context
-    new_context = {}
-    for name, value in context.items():
-        if value is not None:
-            new_context[name] = value.clone_traits()
-        else:
-            new_context[name] = None
-
+    ui._context = context = ui.context
+    new_context = {name: None if value is None else value.clone_traits()
+                   for name, value in context.items()}
     ui.context = new_context
 
     # Now bind the context values to the 'info' object:
@@ -156,7 +150,7 @@ def ui_wizard(ui, parent):
         ui.result = False
 
     # Clean up loose ends, like restoring the original context:
-    wizard.Unbind(wz.EVT_WIZARD_PAGE_CHANGING, page_changing)
+    wizard.Unbind(wz.EVT_WIZARD_PAGE_CHANGING, handler=page_changing)
     save_window(ui)
     ui.finish()
     ui.context = ui._context
@@ -174,11 +168,9 @@ def page_changing(event):
         new_page = page.GetPrev()
 
     # If the page has a disabled PageGroupEditor object, veto the page change:
-    if (
-        (new_page is not None)
-        and (new_page.editor is not None)
-        and (not new_page.editor.enabled)
-    ):
+    if ((new_page is not None)
+            and (new_page.editor is not None)
+            and (not new_page.editor.enabled)):
         event.Veto()
 
         # If their is a message associated with the editor, display it:
@@ -187,12 +179,12 @@ def page_changing(event):
             wx.MessageBox(msg)
 
 
-class UIWizardPage(wz.PyWizardPage):
+class UIWizardPage(wz.WizardPage):
     """ A page within a wizard interface.
     """
 
     def __init__(self, wizard, pages):
-        wz.PyWizardPage.__init__(self, wizard)
+        super().__init__(wizard)
         self.next = self.previous = self.editor = None
         self.pages = pages
 
@@ -211,11 +203,11 @@ class UIWizardPage(wz.PyWizardPage):
         """
         editor = self.editor
         if (editor is not None) and (editor.next != ""):
-            next = editor.next
-            if next is None:
+            next_ = editor.next
+            if next_ is None:
                 return None
             for page in self.pages:
-                if page.id == next:
+                if page.id == next_:
                     return page
         return self.next
 


### PR DESCRIPTION
Fixed incorrect calls and testfailures for wxpython 4+ by replacing: 
 * "control.Unbind(wx.EVT_XXX, handler)" with "control.Unbind(wx.EVT_XXX, handler=handler)" in wx.ui_wizard.py
  * deprecated "wz.PyWizardPage" with "wz.WizardPage" in wx.ui_wizard.py
  * missing method spin.SetValueString("4") with spin.SetValue("4") in test_range_editor_spinner.py
  * missing attribute "wx._controls.TextCtrl" with "wx.TextCtrl" in test_ui.py
  * "control.FindWindowByName(name)" with "control.FindWindowByName(name, control)" in:
     * test/_tools.py
     * test/test_csv_editor.py
     * test/test_liststr_editor_selection.py
     * test/test_range_editor_spinner.py
     * test/test_ui.py

Other improvements include:
 * Readded TestColorColumn.test_color_column to the test-suite when ETS_TOOLS="wx"
 * Removed unused import of warnings in test_toolkit.py
 * In ui_wizard.py:
   * Replaced local variable "next" with "next_" in order to not shadow the next builtin method.
   * Simplified a for-loop in the ui_wizard function in ui_wizard.py with a dictionary-comprehension.
   * Using super().__init__ call in the UIWizardPage.__init__ method.
   * Fixed the indent according to python guidestyle.

Fixes #755