### PR TITLE
Replaced call to deprecated functions and classes

### DIFF
--- a/traitsui/table_filter.py
+++ b/traitsui/table_filter.py
@@ -210,7 +210,7 @@ class EvalTableFilter(TableFilter):
         if self._traits is None:
             self._traits = object.trait_names()
         try:
-            return eval(self.expression_, globals(), object.get(*self._traits))
+            return eval(self.expression_, globals(), object.trait_get(*self._traits))
         except:
             return False
 

--- a/traitsui/tests/editors/test_default_override.py
+++ b/traitsui/tests/editors/test_default_override.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equals
+from nose.tools import assert_equal
 
 from traitsui.api import DefaultOverride, EditorFactory
 from traits.api import HasTraits, Int
@@ -39,49 +39,49 @@ def test_simple_override():
     editor_name, editor, ui, obj, name, description, parent = do.simple_editor(
         "ui", dummy_object, "x", "description", "parent"
     )
-    assert_equals(editor_name, "simple_editor")
-    assert_equals(editor.x, 15)
-    assert_equals(editor.y, 25)
-    assert_equals(obj, dummy_object)
-    assert_equals(name, "x")
-    assert_equals(description, "description")
-    assert_equals(parent, "parent")
+    assert_equal(editor_name, "simple_editor")
+    assert_equal(editor.x, 15)
+    assert_equal(editor.y, 25)
+    assert_equal(obj, dummy_object)
+    assert_equal(name, "x")
+    assert_equal(description, "description")
+    assert_equal(parent, "parent")
 
 
 def test_text_override():
     editor_name, editor, ui, obj, name, description, parent = do.text_editor(
         "ui", dummy_object, "x", "description", "parent"
     )
-    assert_equals(editor_name, "text_editor")
-    assert_equals(editor.x, 15)
-    assert_equals(editor.y, 25)
-    assert_equals(obj, dummy_object)
-    assert_equals(name, "x")
-    assert_equals(description, "description")
-    assert_equals(parent, "parent")
+    assert_equal(editor_name, "text_editor")
+    assert_equal(editor.x, 15)
+    assert_equal(editor.y, 25)
+    assert_equal(obj, dummy_object)
+    assert_equal(name, "x")
+    assert_equal(description, "description")
+    assert_equal(parent, "parent")
 
 
 def test_custom_override():
     editor_name, editor, ui, obj, name, description, parent = do.custom_editor(
         "ui", dummy_object, "x", "description", "parent"
     )
-    assert_equals(editor_name, "custom_editor")
-    assert_equals(editor.x, 15)
-    assert_equals(editor.y, 25)
-    assert_equals(obj, dummy_object)
-    assert_equals(name, "x")
-    assert_equals(description, "description")
-    assert_equals(parent, "parent")
+    assert_equal(editor_name, "custom_editor")
+    assert_equal(editor.x, 15)
+    assert_equal(editor.y, 25)
+    assert_equal(obj, dummy_object)
+    assert_equal(name, "x")
+    assert_equal(description, "description")
+    assert_equal(parent, "parent")
 
 
 def test_readonly_override():
     editor_name, editor, ui, obj, name, description, parent = do.readonly_editor(
         "ui", dummy_object, "x", "description", "parent"
     )
-    assert_equals(editor_name, "readonly_editor")
-    assert_equals(editor.x, 15)
-    assert_equals(editor.y, 25)
-    assert_equals(obj, dummy_object)
-    assert_equals(name, "x")
-    assert_equals(description, "description")
-    assert_equals(parent, "parent")
+    assert_equal(editor_name, "readonly_editor")
+    assert_equal(editor.x, 15)
+    assert_equal(editor.y, 25)
+    assert_equal(obj, dummy_object)
+    assert_equal(name, "x")
+    assert_equal(description, "description")
+    assert_equal(parent, "parent")

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -98,7 +98,7 @@ def bitmap_cache(name, standard_size, path=None):
     if bitmap is not None:
         return bitmap
 
-    std_bitmap = bitmap = wx.BitmapFromImage(wx.Image(filename))
+    std_bitmap = bitmap = wx.Bitmap(wx.Image(filename))
     _bitmap_cache[filename] = bitmap
 
     dx = bitmap.GetWidth()


### PR DESCRIPTION
 * wx.BitmapFromImage with wx.Bitmap in in traitsui.wx.helper.py
 * object.get with object.trait_get in traitsui.table_filter.py
 * assert_equals from nose.tools with assert_equal in tests/editors/test_default_override.py

Fixes #774