### PR TITLE
Refactored duplicated code

### DIFF
--- a/traitsui/wx/text_editor.py
+++ b/traitsui/wx/text_editor.py
@@ -85,8 +85,8 @@ class SimpleEditor(Editor):
             control = wx.TextCtrl(parent, -1, self.str_value, style=style)
 
         control.Bind(wx.EVT_KILL_FOCUS, self.update_object)
-
-        control.SetHint(self.factory.placeholder)
+        if control.IsSingleLine():
+            control.SetHint(self.factory.placeholder)
 
         if factory.auto_set:
             parent.Bind(wx.EVT_TEXT, self.update_object, id=control.GetId())

--- a/traitsui/wx/ui_base.py
+++ b/traitsui/wx/ui_base.py
@@ -26,6 +26,7 @@ from traits.api import HasPrivateTraits, Instance
 from traitsui.base_panel import BasePanel as _BasePanel
 from traitsui.menu import Action
 from .editor import Editor
+from .helper import restore_window
 
 
 class ButtonEditor(Editor):
@@ -49,6 +50,52 @@ class ButtonEditor(Editor):
 class BaseDialog(_BasePanel):
     """ Base class for Traits UI dialog boxes.
     """
+
+    # The different dialog styles.
+    NONMODAL = 0
+    MODAL = 1
+    POPUP = 2
+    POPOVER = 3
+    INFO = 4
+
+    # Types of 'popup' dialogs:
+    POPUP_TYPES = {POPUP, POPOVER, INFO}
+
+    def init(self, ui, parent, style):
+        """Initialise the dialog by creating the controls."""
+
+        raise NotImplementedError
+
+    @staticmethod
+    def display_ui(ui, parent, style):
+        ui.owner.init(ui, parent, style)
+        ui.control = ui.owner.control
+        ui.control._parent = parent
+
+        try:
+            ui.prepare_ui()
+        except:
+            ui.control.Destroy()
+            ui.control.ui = None
+            ui.control = None
+            ui.owner = None
+            ui.result = False
+            raise
+
+        ui.handler.position(ui.info)
+        restore_window(ui, is_popup=(style in BaseDialog.POPUP_TYPES))
+
+        ui.control.Layout()
+        # Check if the control is already being displayed modally. This would be
+        # the case if after the window was displayed, some event caused the ui to
+        # get rebuilt (typically when the user fires the 'updated' event on the ui
+        # ). In this case, calling ShowModal again leads to the parent window
+        # hanging even after the control has been closed by clicking OK or Cancel
+        # (maybe the modal mode isn't ending?)
+        if style == BaseDialog.MODAL and not ui.control.IsModal():
+            ui.control.ShowModal()
+        else:
+            ui.control.Show()
 
     def default_icon(self):
         """ Return a default icon for a TraitsUI dialog. """


### PR DESCRIPTION
Moved duplicated code in ui_live.py and ui_modal.py to BaseDialog.display_ui method in ui_base.py for the wx backend.

This is similar to what is done for the qt4 backend.

Added check to ensure the wx.TextCtrl is single line before calling "SetHint" method in
traitsui/wx/text_editor.py to avoid "wx._core.wxAssertionError", because hints can only
be set for single line text controls.
