### PR TITLE
Python 3.8 API change: cgi.escape -> html.escape

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -13,8 +13,7 @@
 """
 
 
-
-import cgi
+import html
 import re
 
 from pyface.qt import QtCore, QtGui
@@ -351,7 +350,7 @@ def show_help(ui, button):
     group = ui._groups[ui._active_group]
     template = help_template()
     if group.help != "":
-        header = template.group_help % cgi.escape(group.help)
+        header = template.group_help % html.escape(group.help)
     else:
         header = template.no_group_help
     fields = []
@@ -360,8 +359,8 @@ def show_help(ui, button):
             fields.append(
                 template.item_help
                 % (
-                    cgi.escape(item.get_label(ui)),
-                    cgi.escape(item.get_help(ui)),
+                    html.escape(item.get_label(ui)),
+                    html.escape(item.get_help(ui)),
                 )
             )
     html = template.group_html % (header, "\n".join(fields))

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -23,7 +23,7 @@ import wx
 import wx.html as wh
 import re
 
-from cgi import escape
+from html import escape
 
 from traits.api import Instance, Undefined
 
@@ -57,7 +57,6 @@ from .helper import (
 from .constants import screen_dx, screen_dy, WindowColor
 
 from .ui_base import BaseDialog
-from .constants import is_mac
 
 
 # Pattern of all digits


### PR DESCRIPTION
Python 3.8 API change: https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals

Since the documentation says the old location is deprecated in Python 3.2 I did hard replace rather than try/except. 