### PR TITLE
Convert Union back to Either as Union which is not released in traits 6.0

### DIFF
--- a/traitsui/context_value.py
+++ b/traitsui/context_value.py
@@ -62,7 +62,7 @@ instances of :class:`ContextValue` (abbreviated as ``CV``)::
 """
 
 
-from traits.api import HasStrictTraits, Instance, Str, Int, Float, Union
+from traits.api import HasStrictTraits, Instance, Str, Int, Float, Either
 
 
 class ContextValue(HasStrictTraits):
@@ -114,7 +114,7 @@ def CVType(type, **metadata):
         type or an instance of the ContextValue class.
     """
     metadata.setdefault("sync_value", "to")
-    return Union(type, InstanceOfContextValue, **metadata)
+    return Either(type, InstanceOfContextValue, **metadata)
 
 
 #: Shorthand for an Instance of ContextValue trait.

--- a/traitsui/editors/button_editor.py
+++ b/traitsui/editors/button_editor.py
@@ -21,7 +21,7 @@
 
 
 from pyface.ui_traits import Image
-from traits.api import Str, Range, Enum, Property, Union
+from traits.api import Str, Range, Enum, Property, Either
 
 from ..editor_factory import EditorFactory
 from ..ui_traits import AView
@@ -54,7 +54,7 @@ class ToolkitEditorFactory(EditorFactory):
     # values.  If this is set, then the value, label, and label_value traits
     # are ignored; instead, they will be set from this list.  When this button
     # is clicked, the value set will be the one selected from the drop-down.
-    values_trait = Union(None, Str)
+    values_trait = Either(None, Str)
 
     # (Optional) Image to display on the button
     image = Image

--- a/traitsui/editors/csv_list_editor.py
+++ b/traitsui/editors/csv_list_editor.py
@@ -20,7 +20,7 @@ It allows the user to edit the list in a text field, using commas
 #
 # ------------------------------------------------------------------------------
 
-from traits.api import Str, Int, Float, Enum, Range, Bool, TraitError, Union
+from traits.api import Str, Int, Float, Enum, Range, Bool, TraitError, Either
 from traits.trait_handlers import RangeTypes
 
 from .text_editor import TextEditor
@@ -236,7 +236,7 @@ class CSVListEditor(TextEditor):
     """
 
     #: The separator of the element in the list.
-    sep = Union(None, Str, default=",")
+    sep = Either(None, Str, default=",")
 
     #: If False, it is an error to have a trailing separator.
     ignore_trailing_sep = Bool(True)

--- a/traitsui/editors/table_editor.py
+++ b/traitsui/editors/table_editor.py
@@ -32,7 +32,7 @@ from traits.api import (
     Bool,
     Callable,
     Range,
-    Union,
+    Either,
     on_trait_change,
 )
 
@@ -56,7 +56,7 @@ customize_filter = TableFilter(name="Customize...")
 # -------------------------------------------------------------------------
 
 # A trait whose value can be True, False, or a callable function
-BoolOrCallable = Union(Bool, Callable, default=False)
+BoolOrCallable = Either(Bool, Callable, default=False)
 
 
 class ToolkitEditorFactory(EditorFactory):

--- a/traitsui/editors/table_editor.py
+++ b/traitsui/editors/table_editor.py
@@ -32,7 +32,7 @@ from traits.api import (
     Bool,
     Callable,
     Range,
-    Either,
+    Trait,
     on_trait_change,
 )
 
@@ -56,7 +56,7 @@ customize_filter = TableFilter(name="Customize...")
 # -------------------------------------------------------------------------
 
 # A trait whose value can be True, False, or a callable function
-BoolOrCallable = Either(Bool, Callable, default=False)
+BoolOrCallable = Trait(False, Bool, Callable)
 
 
 class ToolkitEditorFactory(EditorFactory):

--- a/traitsui/qt4/extra/bounds_editor.py
+++ b/traitsui/qt4/extra/bounds_editor.py
@@ -1,6 +1,6 @@
 from pyface.qt import QtGui, QtCore
 
-from traits.api import Float, Any, Str, Union
+from traits.api import Float, Any, Str, Either
 
 from traitsui.editors.api import RangeEditor
 from traitsui.qt4.editor import Editor
@@ -186,8 +186,8 @@ class _BoundsEditor(Editor):
 
 class BoundsEditor(RangeEditor):
 
-    min = Union(None, Float)
-    max = Union(None, Float)
+    min = Either(None, Float)
+    max = Either(None, Float)
 
     def _get_simple_editor_class(self):
         return _BoundsEditor

--- a/traitsui/table_column.py
+++ b/traitsui/table_column.py
@@ -36,7 +36,7 @@ from traits.api import (
     Int,
     Property,
     Str,
-    Union,
+    Either,
 )
 
 from traits.trait_base import user_name_for, xgetattr
@@ -77,7 +77,7 @@ class TableColumn(HasPrivateTraits):
     text_color = Color("black")
 
     #: Text font for this column:
-    text_font = Union(None, Font)
+    text_font = Either(None, Font)
 
     #: Cell background color for this column:
     cell_color = Color("white", allow_none=True)

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -36,7 +36,7 @@ from traits.api import (
     List,
     Property,
     Str,
-    Union,
+    Either,
     cached_property,
     on_trait_change,
     provides,
@@ -239,7 +239,7 @@ class TabularAdapter(HasPrivateTraits):
 
     #: The name of the trait on a row item containing the value to use
     #: as a row label. If ``None``, the label will be the empty string.
-    row_label_name = Union(None, Str)
+    row_label_name = Either(None, Str)
 
     #: For each adapter, specifies the column indices the adapter handles.
     adapter_column_indices = Property(depends_on="adapters,columns")

--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -38,7 +38,7 @@ from traits.api import (
     Property,
     Str,
     Supports,
-    Union,
+    Either,
     cached_property,
 )
 
@@ -126,7 +126,7 @@ class TreeNode(HasPrivateTraits):
     formatter = Callable()
 
     #: Functions for formatting the other columns.
-    column_formatters = List(Union(None, Callable))
+    column_formatters = List(Either(None, Callable))
 
     #: Function for formatting the tooltip
     tooltip_formatter = Callable()

--- a/traitsui/ui_editors/data_frame_editor.py
+++ b/traitsui/ui_editors/data_frame_editor.py
@@ -18,7 +18,7 @@ from traits.api import (
     Property,
     Str,
     Tuple,
-    Union,
+    Either,
 )
 
 from traitsui.basic_editor_factory import BasicEditorFactory
@@ -58,10 +58,10 @@ class DataFrameAdapter(TabularAdapter):
     format = Property()
 
     #: The format for each element, or a mapping column ID to format.
-    _formats = Union(Str, Dict, default="%s")
+    _formats = Either(Str, Dict, default="%s")
 
     #: The font for each element, or a mapping column ID to font.
-    _fonts = Union(Font, Dict, default="Courier 10")
+    _fonts = Either(Font, Dict, default="Courier 10")
 
     def _get_index_alignment(self):
         import numpy as np
@@ -305,13 +305,13 @@ class DataFrameEditor(BasicEditorFactory):
     show_titles = Bool(True)
 
     #: Optional list of either column ID or pairs of (column title, column ID).
-    columns = List(Union(Str, Tuple(Str, Str)))
+    columns = List(Either(Str, Tuple(Str, Str)))
 
     #: The format for each element, or a mapping column ID to format.
-    formats = Union(Str, Dict, default="%s")
+    formats = Either(Str, Dict, default="%s")
 
     #: The font for each element, or a mapping column ID to font.
-    fonts = Union(Font, Dict, default="Courier 10")
+    fonts = Either(Font, Dict, default="Courier 10")
 
     #: The optional extended name of the trait to synchronize the selection
     #: values with:

--- a/traitsui/wx/extra/bounds_editor.py
+++ b/traitsui/wx/extra/bounds_editor.py
@@ -1,6 +1,6 @@
 import wx
 
-from traits.api import Float, Any, Str, Union
+from traits.api import Float, Any, Str, Either
 from traitsui.editors.api import RangeEditor
 from traitsui.wx.editor import Editor
 from traitsui.wx.helper import TraitsUIPanel, Slider
@@ -235,8 +235,8 @@ class _BoundsEditor(Editor):
 
 class BoundsEditor(RangeEditor):
 
-    min = Union(None, Float)
-    max = Union(None, Float)
+    min = Either(None, Float)
+    max = Either(None, Float)
 
     def _get_simple_editor_class(self):
         return _BoundsEditor

--- a/traitsui/wx/ui_wizard.py
+++ b/traitsui/wx/ui_wizard.py
@@ -25,7 +25,7 @@
 import wx
 import wx.adv as wz
 
-from traits.api import Str, Union
+from traits.api import Str, Either
 
 from .constants import DefaultTitle
 from .helper import restore_window, save_window, GroupEditor
@@ -36,7 +36,7 @@ from .ui_panel import fill_panel_for_group
 # -------------------------------------------------------------------------
 
 # Trait that allows only None or a string value
-none_str_trait = Union(None, Str, default="")
+none_str_trait = Either(None, Str, default="")
 
 
 def ui_wizard(ui, parent):


### PR DESCRIPTION
**Targeting release branch for 7.0**

This PR reverts the `Union` back to `Either` as `Union` was not released with Traits 6.

Not sure if we wanted this on master too. We can cherry pick in either direction.