### PR TITLE
Create TraitListEvent with keyword arguments

### DIFF
--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -332,7 +332,8 @@ class _ListStrEditor(Editor):
             except ValueError:
                 pass
             else:
-                event = TraitListEvent(0, added, removed)
+                event = TraitListEvent(
+                    index=0, added=added, removed=removed)
                 self._multi_selected_indices_items_changed(event)
 
     def _multi_selected_indices_changed(self, selected_indices):

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -446,7 +446,8 @@ class TabularEditor(Editor):
         except:
             pass
         else:
-            list_event = TraitListEvent(0, added, removed)
+            list_event = TraitListEvent(
+                index=0, added=added, removed=removed)
             self._multi_selected_rows_items_changed(list_event)
 
     def _multi_selected_rows_changed(self, selected_rows):

--- a/traitsui/wx/list_str_editor.py
+++ b/traitsui/wx/list_str_editor.py
@@ -408,9 +408,9 @@ class _ListStrEditor(Editor):
         try:
             self._multi_selected_indices_items_changed(
                 TraitListEvent(
-                    0,
-                    [values.index(item) for item in event.removed],
-                    [values.index(item) for item in event.added],
+                    index=0,
+                    removed=[values.index(item) for item in event.removed],
+                    added=[values.index(item) for item in event.added],
                 )
             )
         except Exception:

--- a/traitsui/wx/tabular_editor.py
+++ b/traitsui/wx/tabular_editor.py
@@ -583,9 +583,9 @@ class TabularEditor(Editor):
         try:
             self._multi_selected_rows_items_changed(
                 TraitListEvent(
-                    0,
-                    [values.index(item) for item in event.removed],
-                    [values.index(item) for item in event.added],
+                    index=0,
+                    removed=[values.index(item) for item in event.removed],
+                    added=[values.index(item) for item in event.added],
                 )
             )
         except:


### PR DESCRIPTION
Related to #791

This PR changes all instantiation of `TraitListEvent` to use keyword arguments.