### PR TITLE
[WIP] Deprecate trait_view_for in favor of a new method

### DIFF
--- a/traitsui/handler.py
+++ b/traitsui/handler.py
@@ -358,7 +358,7 @@ class Handler(HasPrivateTraits):
             DeprecationWarning,
             stacklevel=2,
         )
-        self.get_view_for(
+        return self.get_view_for(
             info=info,
             view=view,
             object=object,

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -235,7 +235,7 @@ class CustomEditor(Editor):
         if view == "":
             view = self.view
 
-        return self.ui.handler.trait_view_for(
+        return self.ui.handler.get_view_for(
             self.ui.info, view, object, self.object_name, self.name
         )
 
@@ -423,7 +423,7 @@ class SimpleEditor(CustomEditor):
         """
         # Create the user interface:
         factory = self.factory
-        view = self.ui.handler.trait_view_for(
+        view = self.ui.handler.get_view_for(
             self.ui.info, factory.view, self.value, self.object_name, self.name
         )
         self._dialog_ui = self.value.edit_traits(

--- a/traitsui/wx/instance_editor.py
+++ b/traitsui/wx/instance_editor.py
@@ -284,7 +284,7 @@ class CustomEditor(Editor):
         if view == "":
             view = self.view
 
-        return self.ui.handler.trait_view_for(
+        return self.ui.handler.get_view_for(
             self.ui.info, view, object, self.object_name, self.name
         )
 
@@ -510,7 +510,7 @@ class SimpleEditor(CustomEditor):
         """
         # Create the user interface:
         factory = self.factory
-        view = self.ui.handler.trait_view_for(
+        view = self.ui.handler.get_view_for(
             self.ui.info, factory.view, self.value, self.object_name, self.name
         )
         ui = self.value.edit_traits(


### PR DESCRIPTION
The name of `traitsui.handlers.Handler.trait_view_for` contains "trait" as a prefix and risk overshadowing methods introduced by traits. cf. https://github.com/enthought/traits/issues/705 and the related issues.

This PR proposes one way round this issue: Deprecate the method in favor of a new method using a different name.

I have searched for "trait_view_for" in pyface, envisage, chaco, mayavi and found nothing. It is likely used internally by traitsui only. But to be on the safe side, this PR proposes deprecating it with a method named `get_view_for` that does the same thing. 

`trait_view_for` also searches for method names starting with "trait_view_for_" with a set of magic naming pattern. I can't find evidence of this being used, neither do I think this is a good idea, so it might be safe to deprecate that too.

This PR would need CI tests for wx InstanceEditor in order to go in, but I'd like to get feedback on this first before going forward with this.


