### PR TITLE
[WIP] Deprecate trait_handler in favor of handler_trait

### DIFF
--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -17,7 +17,7 @@
 """ Defines the list editor factory for the traits user interface toolkits..
 """
 
-
+import warnings
 
 from traits.api import (
     HasTraits,
@@ -27,6 +27,7 @@ from traits.api import (
     Any,
     Int,
     Instance,
+    on_trait_change,
     Property,
     Bool,
     Callable,
@@ -54,9 +55,6 @@ from ..helper import DockStyle
 #  Trait definitions:
 # -------------------------------------------------------------------------
 
-# Trait whose value is a BaseTraitHandler object
-handler_trait = Instance(BaseTraitHandler)
-
 # The visible number of rows displayed
 rows_trait = Range(1, 50, 5, desc="the number of list rows to display")
 
@@ -69,6 +67,12 @@ editor_trait = Instance(EditorFactory)
 #  'ToolkitEditorFactory' class:
 # -------------------------------------------------------------------------
 
+warnings.filterwarnings(
+    "ignore",
+    message=r".*The attribute named 'trait_handler' of class .*",
+    category=Warning,
+    module=".*traitsui.editors.*",
+)
 
 class ToolkitEditorFactory(EditorFactory):
     """ Editor factory for list editors.
@@ -91,7 +95,11 @@ class ToolkitEditorFactory(EditorFactory):
     style = style_trait
 
     #: The trait handler for each list item:
-    trait_handler = handler_trait
+    #: Deprecated. Use handler_trait instead.
+    trait_handler = Instance(BaseTraitHandler)
+
+    #: The trait handler for each list item:
+    handler_trait = Instance(BaseTraitHandler)
 
     #: The number of list rows to display:
     rows = rows_trait
@@ -171,6 +179,15 @@ class ToolkitEditorFactory(EditorFactory):
         if self.use_notebook:
             return toolkit_object("list_editor:NotebookEditor")
         return toolkit_object("list_editor:CustomEditor")
+
+    @on_trait_change("trait_handler")
+    def _deprecate_trait_handler(self, new):
+        warnings.warn(
+            "'trait_handler' is deprecated in {}. "
+            "Use 'handler_trait' instead.".format(type(self).__name__),
+            DeprecationWarning,
+        )
+        self.handler_trait = new
 
 
 # -------------------------------------------------------------------------

--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -27,7 +27,6 @@ from traits.api import (
     Any,
     Int,
     Instance,
-    on_trait_change,
     Property,
     Bool,
     Callable,
@@ -96,7 +95,7 @@ class ToolkitEditorFactory(EditorFactory):
 
     #: The trait handler for each list item:
     #: Deprecated. Use handler_trait instead.
-    trait_handler = Instance(BaseTraitHandler)
+    trait_handler = Property(Instance(BaseTraitHandler))
 
     #: The trait handler for each list item:
     handler_trait = Instance(BaseTraitHandler)
@@ -180,14 +179,21 @@ class ToolkitEditorFactory(EditorFactory):
             return toolkit_object("list_editor:NotebookEditor")
         return toolkit_object("list_editor:CustomEditor")
 
-    @on_trait_change("trait_handler")
-    def _deprecate_trait_handler(self, new):
+    def _get_trait_handler(self):
         warnings.warn(
             "'trait_handler' is deprecated in {}. "
             "Use 'handler_trait' instead.".format(type(self).__name__),
             DeprecationWarning,
         )
-        self.handler_trait = new
+        return self.handler_trait
+
+    def _set_trait_handler(self, value):
+        warnings.warn(
+            "'trait_handler' is deprecated in {}. "
+            "Use 'handler_trait' instead.".format(type(self).__name__),
+            DeprecationWarning,
+        )
+        self.handler_trait = value
 
 
 # -------------------------------------------------------------------------

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -96,10 +96,10 @@ class SimpleEditor(Editor):
             widget.
         """
         # Initialize the trait handler to use:
-        trait_handler = self.factory.trait_handler
-        if trait_handler is None:
-            trait_handler = self.object.base_trait(self.name).handler
-        self._trait_handler = trait_handler
+        handler_trait = self.factory.handler_trait
+        if handler_trait is None:
+            handler_trait = self.object.base_trait(self.name).handler
+        self._handler_trait = handler_trait
 
         if self.scrollable:
             # Create a scrolled window to hold all of the list item controls:
@@ -126,7 +126,7 @@ class SimpleEditor(Editor):
         # Remember the editor to use for each individual list item:
         editor = self.factory.editor
         if editor is None:
-            editor = trait_handler.item_trait.get_editor()
+            editor = handler_trait.item_trait.get_editor()
         self._editor = getattr(editor, self.kind)
 
         # Set up the additional 'list items changed' event handler needed for
@@ -164,11 +164,11 @@ class SimpleEditor(Editor):
         layout = list_pane.layout()
 
         # Create all of the list item trait editors:
-        trait_handler = self._trait_handler
+        handler_trait = self._handler_trait
         resizable = (
-            trait_handler.minlen != trait_handler.maxlen
+            handler_trait.minlen != handler_trait.maxlen
         ) and self.mutable
-        item_trait = trait_handler.item_trait
+        item_trait = handler_trait.item_trait
 
         is_fake = resizable and (len(self.value) == 0)
         if is_fake:
@@ -282,11 +282,11 @@ class SimpleEditor(Editor):
         proxy = sender.proxy
         menu = MakeMenu(self.list_menu, self, True, sender).menu
         len_list = len(proxy.list)
-        not_full = len_list < self._trait_handler.maxlen
+        not_full = len_list < self._handler_trait.maxlen
 
         self._menu_before.enabled(not_full)
         self._menu_after.enabled(not_full)
-        self._menu_delete.enabled(len_list > self._trait_handler.minlen)
+        self._menu_delete.enabled(len_list > self._handler_trait.minlen)
         self._menu_up.enabled(index > 0)
         self._menu_top.enabled(index > 0)
         self._menu_down.enabled(index < (len_list - 1))
@@ -299,7 +299,7 @@ class SimpleEditor(Editor):
         """
         list, index = self.get_info()
         index += offset
-        item_trait = self._trait_handler.item_trait
+        item_trait = self._handler_trait.item_trait
         value = item_trait.default_value_for(self.object, self.name)
         self.value = list[:index] + [value] + list[index:]
         self.update_editor()

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -572,11 +572,11 @@ class TabularAdapter(HasPrivateTraits):
         else:
             # Convert value to the correct trait type.
             try:
-                trait_handler = self.item.trait(self.column_id).handler
+                handler_trait = self.item.trait(self.column_id).handler
                 setattr(
                     self.item,
                     self.column_id,
-                    trait_handler.evaluate(self.value),
+                    handler_trait.evaluate(self.value),
                 )
             except:
                 setattr(self.item, self.column_id, value)

--- a/traitsui/wx/list_editor.py
+++ b/traitsui/wx/list_editor.py
@@ -110,10 +110,10 @@ class SimpleEditor(Editor):
             widget.
         """
         # Initialize the trait handler to use:
-        trait_handler = self.factory.trait_handler
-        if trait_handler is None:
-            trait_handler = self.object.base_trait(self.name).handler
-        self._trait_handler = trait_handler
+        handler_trait = self.factory.handler_trait
+        if handler_trait is None:
+            handler_trait = self.object.base_trait(self.name).handler
+        self._handler_trait = handler_trait
 
         # Create a scrolled window to hold all of the list item controls:
         self.control = wxsp.ScrolledPanel(parent, -1)
@@ -123,7 +123,7 @@ class SimpleEditor(Editor):
         # Remember the editor to use for each individual list item:
         editor = self.factory.editor
         if editor is None:
-            editor = trait_handler.item_trait.get_editor()
+            editor = handler_trait.item_trait.get_editor()
         self._editor = getattr(editor, self.kind)
 
         # Set up the additional 'list items changed' event handler needed for
@@ -162,11 +162,11 @@ class SimpleEditor(Editor):
             toolkit.destroy_control(child)
 
         # Create all of the list item trait editors:
-        trait_handler = self._trait_handler
+        handler_trait = self._handler_trait
         resizable = (
-            trait_handler.minlen != trait_handler.maxlen
+            handler_trait.minlen != handler_trait.maxlen
         ) and self.mutable
-        item_trait = trait_handler.item_trait
+        item_trait = handler_trait.item_trait
         factory = self.factory
         list_sizer = wx.FlexGridSizer(
             len(self.value), (1 + resizable) * factory.columns, 0, 0
@@ -253,7 +253,7 @@ class SimpleEditor(Editor):
 
         list_pane.SetMinSize(
             wx.Size(
-                width + ((trait_handler.maxlen > rows) * scrollbar_dx),
+                width + ((handler_trait.maxlen > rows) * scrollbar_dx),
                 panel_height,
             )
         )
@@ -331,10 +331,10 @@ class SimpleEditor(Editor):
         index = proxy.index
         menu = MakeMenu(self.list_menu, self, True, self.control).menu
         len_list = len(proxy.list)
-        not_full = len_list < self._trait_handler.maxlen
+        not_full = len_list < self._handler_trait.maxlen
         self._menu_before.enabled(not_full)
         self._menu_after.enabled(not_full)
-        self._menu_delete.enabled(len_list > self._trait_handler.minlen)
+        self._menu_delete.enabled(len_list > self._handler_trait.minlen)
         self._menu_up.enabled(index > 0)
         self._menu_top.enabled(index > 0)
         self._menu_down.enabled(index < (len_list - 1))
@@ -349,7 +349,7 @@ class SimpleEditor(Editor):
         """
         list, index = self.get_info()
         index += offset
-        item_trait = self._trait_handler.item_trait
+        item_trait = self._handler_trait.item_trait
         value = item_trait.default_value_for(self.object, self.name)
         self.value = list[:index] + [value] + list[index:]
         wx.CallAfter(self.update_editor)


### PR DESCRIPTION
Similar to the motivation of #796, this PR proposes deprecating `trait_handler` in favor of an attribute with a different name that does not start with "trait".

The `trait_handler` is a trait that can be defined when a `ListEditor` is defined.  I have searched envisage, mayavi and chaco and I can't find evidence of its being redefined.

The name of `trait_handler` is so generic that I can imagine it being a method defined by traits, and traitsui would be overshadowing the method. Such a method does not exist now, but it might be introduced in the future.

This PR is opened for discussion. I haven't assessed how well tested the affected code is, hence the WIP status. 