### PR TITLE
Rewrite nose tests to use unittest

### DIFF
--- a/traitsui/tests/editors/test_code_editor.py
+++ b/traitsui/tests/editors/test_code_editor.py
@@ -10,17 +10,20 @@
 #
 # ------------------------------------------------------------------------------
 
-import nose
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Bool, Enum, Instance, Str
 from traitsui.handler import ModelView
-from traitsui.view import View, Group
+from traitsui.view import View
 from traitsui.item import Item
 from traitsui.editors.code_editor import CodeEditor
 
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
 
 
 class CodeModel(HasTraits):
@@ -43,56 +46,53 @@ class CodeView(ModelView):
         return traits_view
 
 
-@skip_if_not_qt4
-def test_code_editor_show_line_numbers():
-    """ CodeEditor should honor the `show_line_numbers` setting
-    """
+class TestCodeEditor(unittest.TestCase):
 
-    def is_line_numbers_visible(ui):
+    @skip_if_not_qt4
+    def test_code_editor_show_line_numbers(self):
+        """ CodeEditor should honor the `show_line_numbers` setting
+        """
+
+        def is_line_numbers_visible(ui):
+            from pyface import qt
+
+            txt_ctrl = ui.control.findChild(qt.QtGui.QPlainTextEdit)
+            return txt_ctrl.line_number_widget.isVisible()
+
+        def test_line_numbers_visibility(show=True):
+            with store_exceptions_on_all_threads():
+                code_model = CodeModel()
+                code_view = CodeView(model=code_model, show_line_numbers=show)
+                ui = code_view.edit_traits()
+                self.assertEqual(is_line_numbers_visible(ui), show)
+                ui.control.close()
+
+        test_line_numbers_visibility(True)
+        test_line_numbers_visibility(False)
+
+    @skip_if_not_qt4
+    def test_code_editor_readonly(self):
+        """ Test readonly editor style for CodeEditor
+        """
         from pyface import qt
 
-        txt_ctrl = ui.control.findChild(qt.QtGui.QPlainTextEdit)
-        return txt_ctrl.line_number_widget.isVisible()
-
-    def test_line_numbers_visibility(show=True):
         with store_exceptions_on_all_threads():
             code_model = CodeModel()
-            code_view = CodeView(model=code_model, show_line_numbers=show)
+            code_view = CodeView(model=code_model, style="readonly")
             ui = code_view.edit_traits()
-            nose.tools.assert_equal(is_line_numbers_visible(ui), show)
+            txt_ctrl = ui.control.findChild(qt.QtGui.QPlainTextEdit)
+            self.assertTrue(txt_ctrl.isReadOnly())
+
+            # Test changing the object's text
+            self.assertEqual(txt_ctrl.toPlainText(), code_model.code)
+            code_model.code += "some more code"
+            self.assertTrue(txt_ctrl.isReadOnly())
+            self.assertEqual(txt_ctrl.toPlainText(), code_model.code)
+
+            # Test changing the underlying object
+            code_model2 = CodeModel(code=code_model.code * 2)
+            code_view.model = code_model2
+            self.assertTrue(txt_ctrl.isReadOnly())
+            self.assertEqual(txt_ctrl.toPlainText(), code_model.code)
+
             ui.control.close()
-
-    test_line_numbers_visibility(True)
-    test_line_numbers_visibility(False)
-
-
-@skip_if_not_qt4
-def test_code_editor_readonly():
-    """ Test readonly editor style for CodeEditor
-    """
-    from pyface import qt
-
-    with store_exceptions_on_all_threads():
-        code_model = CodeModel()
-        code_view = CodeView(model=code_model, style="readonly")
-        ui = code_view.edit_traits()
-        txt_ctrl = ui.control.findChild(qt.QtGui.QPlainTextEdit)
-        nose.tools.assert_true(txt_ctrl.isReadOnly())
-
-        # Test changing the object's text
-        nose.tools.assert_equal(txt_ctrl.toPlainText(), code_model.code)
-        code_model.code += "some more code"
-        nose.tools.assert_true(txt_ctrl.isReadOnly())
-        nose.tools.assert_equal(txt_ctrl.toPlainText(), code_model.code)
-
-        # Test changing the underlying object
-        code_model2 = CodeModel(code=code_model.code * 2)
-        code_view.model = code_model2
-        nose.tools.assert_true(txt_ctrl.isReadOnly())
-        nose.tools.assert_equal(txt_ctrl.toPlainText(), code_model.code)
-
-        ui.control.close()
-
-
-if __name__ == "__main__":
-    nose.main()

--- a/traitsui/tests/editors/test_csv_editor.py
+++ b/traitsui/tests/editors/test_csv_editor.py
@@ -14,7 +14,7 @@
 # ------------------------------------------------------------------------------
 
 
-import nose
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Float, List, Instance
@@ -24,7 +24,13 @@ from traitsui.item import Item
 from traitsui.editors.csv_list_editor import CSVListEditor
 import traitsui.editors.csv_list_editor as csv_list_editor
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    is_current_backend_wx,
+    is_current_backend_qt4,
+    press_ok_button,
+    skip_if_null,
+    store_exceptions_on_all_threads,
+)
 
 
 class ListOfFloats(HasTraits):
@@ -41,60 +47,61 @@ class ListOfFloatsWithCSVEditor(ModelView):
     )
 
 
-@skip_if_null
-def test_csv_editor_disposal():
-    # Bug: CSVListEditor does not un-hook the traits notifications after its
-    # disposal, causing errors when the hooked data is accessed after
-    # the window is closed (Issue #48)
+class TestCSVEditor(unittest.TestCase):
 
-    try:
+    @skip_if_null
+    def test_csv_editor_disposal(self):
+        # Bug: CSVListEditor does not un-hook the traits notifications after
+        # its disposal, causing errors when the hooked data is accessed after
+        # the window is closed (Issue #48)
+
+        try:
+            with store_exceptions_on_all_threads():
+                list_of_floats = ListOfFloats(data=[1, 2, 3])
+                csv_view = ListOfFloatsWithCSVEditor(model=list_of_floats)
+                ui = csv_view.edit_traits()
+                press_ok_button(ui)
+
+                # raise an exception if still hooked
+                list_of_floats.data.append(2)
+
+        except AttributeError:
+            # if all went well, we should not be here
+            self.fail("AttributeError raised")
+
+    @skip_if_null
+    def test_csv_editor_external_append(self):
+        # Behavior: CSV editor is notified when an element is appended to the
+        # list externally
+
+        def _wx_get_text_value(ui):
+            txt_ctrl = ui.control.FindWindowByName("text", ui.control)
+            return txt_ctrl.GetValue()
+
+        def _qt_get_text_value(ui):
+            from pyface import qt
+
+            txt_ctrl = ui.control.findChild(qt.QtGui.QLineEdit)
+            return txt_ctrl.text()
+
         with store_exceptions_on_all_threads():
-            list_of_floats = ListOfFloats(data=[1, 2, 3])
+            list_of_floats = ListOfFloats(data=[1.0])
             csv_view = ListOfFloatsWithCSVEditor(model=list_of_floats)
             ui = csv_view.edit_traits()
+
+            # add element to list, make sure that editor knows about it
+            list_of_floats.data.append(3.14)
+
+            # get current value from editor
+            if is_current_backend_wx():
+                value_str = _wx_get_text_value(ui)
+            elif is_current_backend_qt4():
+                value_str = _qt_get_text_value(ui)
+
+            expected = csv_list_editor._format_list_str([1.0, 3.14])
+            self.assertEqual(value_str, expected)
+
             press_ok_button(ui)
-
-            # raise an exception if still hooked
-            list_of_floats.data.append(2)
-
-    except AttributeError:
-        # if all went well, we should not be here
-        assert False, "AttributeError raised"
-
-
-@skip_if_null
-def test_csv_editor_external_append():
-    # Behavior: CSV editor is notified when an element is appended to the
-    # list externally
-
-    def _wx_get_text_value(ui):
-        txt_ctrl = ui.control.FindWindowByName("text", ui.control)
-        return txt_ctrl.GetValue()
-
-    def _qt_get_text_value(ui):
-        from pyface import qt
-
-        txt_ctrl = ui.control.findChild(qt.QtGui.QLineEdit)
-        return txt_ctrl.text()
-
-    with store_exceptions_on_all_threads():
-        list_of_floats = ListOfFloats(data=[1.0])
-        csv_view = ListOfFloatsWithCSVEditor(model=list_of_floats)
-        ui = csv_view.edit_traits()
-
-        # add element to list, make sure that editor knows about it
-        list_of_floats.data.append(3.14)
-
-        # get current value from editor
-        if is_current_backend_wx():
-            value_str = _wx_get_text_value(ui)
-        elif is_current_backend_qt4():
-            value_str = _qt_get_text_value(ui)
-
-        expected = csv_list_editor._format_list_str([1.0, 3.14])
-        nose.tools.assert_equal(value_str, expected)
-
-        press_ok_button(ui)
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/editors/test_default_override.py
+++ b/traitsui/tests/editors/test_default_override.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_equal
+import unittest
 
 from traitsui.api import DefaultOverride, EditorFactory
 from traits.api import HasTraits, Int
@@ -35,53 +35,50 @@ dummy_object = Dummy()
 do = DefaultOverride(x=15, y=25, format_str="%r")
 
 
-def test_simple_override():
-    editor_name, editor, ui, obj, name, description, parent = do.simple_editor(
-        "ui", dummy_object, "x", "description", "parent"
-    )
-    assert_equal(editor_name, "simple_editor")
-    assert_equal(editor.x, 15)
-    assert_equal(editor.y, 25)
-    assert_equal(obj, dummy_object)
-    assert_equal(name, "x")
-    assert_equal(description, "description")
-    assert_equal(parent, "parent")
+class TestDefaultOverride(unittest.TestCase):
 
+    def test_simple_override(self):
+        editor_name, editor, ui, obj, name, description, parent = \
+            do.simple_editor("ui", dummy_object, "x", "description", "parent")
+        self.assertEqual(editor_name, "simple_editor")
+        self.assertEqual(editor.x, 15)
+        self.assertEqual(editor.y, 25)
+        self.assertEqual(obj, dummy_object)
+        self.assertEqual(name, "x")
+        self.assertEqual(description, "description")
+        self.assertEqual(parent, "parent")
 
-def test_text_override():
-    editor_name, editor, ui, obj, name, description, parent = do.text_editor(
-        "ui", dummy_object, "x", "description", "parent"
-    )
-    assert_equal(editor_name, "text_editor")
-    assert_equal(editor.x, 15)
-    assert_equal(editor.y, 25)
-    assert_equal(obj, dummy_object)
-    assert_equal(name, "x")
-    assert_equal(description, "description")
-    assert_equal(parent, "parent")
+    def test_text_override(self):
+        editor_name, editor, ui, obj, name, description, parent = \
+            do.text_editor("ui", dummy_object, "x", "description", "parent")
+        self.assertEqual(editor_name, "text_editor")
+        self.assertEqual(editor.x, 15)
+        self.assertEqual(editor.y, 25)
+        self.assertEqual(obj, dummy_object)
+        self.assertEqual(name, "x")
+        self.assertEqual(description, "description")
+        self.assertEqual(parent, "parent")
 
+    def test_custom_override(self):
+        editor_name, editor, ui, obj, name, description, parent = \
+            do.custom_editor("ui", dummy_object, "x", "description", "parent")
+        self.assertEqual(editor_name, "custom_editor")
+        self.assertEqual(editor.x, 15)
+        self.assertEqual(editor.y, 25)
+        self.assertEqual(obj, dummy_object)
+        self.assertEqual(name, "x")
+        self.assertEqual(description, "description")
+        self.assertEqual(parent, "parent")
 
-def test_custom_override():
-    editor_name, editor, ui, obj, name, description, parent = do.custom_editor(
-        "ui", dummy_object, "x", "description", "parent"
-    )
-    assert_equal(editor_name, "custom_editor")
-    assert_equal(editor.x, 15)
-    assert_equal(editor.y, 25)
-    assert_equal(obj, dummy_object)
-    assert_equal(name, "x")
-    assert_equal(description, "description")
-    assert_equal(parent, "parent")
-
-
-def test_readonly_override():
-    editor_name, editor, ui, obj, name, description, parent = do.readonly_editor(
-        "ui", dummy_object, "x", "description", "parent"
-    )
-    assert_equal(editor_name, "readonly_editor")
-    assert_equal(editor.x, 15)
-    assert_equal(editor.y, 25)
-    assert_equal(obj, dummy_object)
-    assert_equal(name, "x")
-    assert_equal(description, "description")
-    assert_equal(parent, "parent")
+    def test_readonly_override(self):
+        editor_name, editor, ui, obj, name, description, parent = \
+            do.readonly_editor(
+                "ui", dummy_object, "x", "description", "parent"
+            )
+        self.assertEqual(editor_name, "readonly_editor")
+        self.assertEqual(editor.x, 15)
+        self.assertEqual(editor.y, 25)
+        self.assertEqual(obj, dummy_object)
+        self.assertEqual(name, "x")
+        self.assertEqual(description, "description")
+        self.assertEqual(parent, "parent")

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,3 +1,5 @@
+import unittest
+
 from traits.api import HasTraits, Instance, Str
 from traitsui.item import Item
 from traitsui.view import View
@@ -18,32 +20,33 @@ class NonmodalInstanceEditor(HasTraits):
     traits_view = View(Item("inst", style="simple"), buttons=["OK"])
 
 
-@skip_if_not_qt4
-def test_simple_editor():
-    with store_exceptions_on_all_threads():
-        obj = NonmodalInstanceEditor()
-        ui = obj.edit_traits()
-        editor = ui.get_editors("inst")[0]
+class TestInstanceEditor(unittest.TestCase):
 
-        # make the dialog appear
-        editor._button.click()
+    @skip_if_not_qt4
+    def test_simple_editor(self):
+        with store_exceptions_on_all_threads():
+            obj = NonmodalInstanceEditor()
+            ui = obj.edit_traits()
+            editor = ui.get_editors("inst")[0]
 
-        # close the ui dialog
-        press_ok_button(editor._dialog_ui)
+            # make the dialog appear
+            editor._button.click()
 
-        # close the main ui
-        press_ok_button(ui)
+            # close the ui dialog
+            press_ok_button(editor._dialog_ui)
 
+            # close the main ui
+            press_ok_button(ui)
 
-@skip_if_not_qt4
-def test_simple_editor_parent_closed():
-    with store_exceptions_on_all_threads():
-        obj = NonmodalInstanceEditor()
-        ui = obj.edit_traits()
-        editor = ui.get_editors("inst")[0]
+    @skip_if_not_qt4
+    def test_simple_editor_parent_closed(self):
+        with store_exceptions_on_all_threads():
+            obj = NonmodalInstanceEditor()
+            ui = obj.edit_traits()
+            editor = ui.get_editors("inst")[0]
 
-        # make the dialog appear
-        editor._button.click()
+            # make the dialog appear
+            editor._button.click()
 
-        # close the main ui
-        press_ok_button(ui)
+            # close the main ui
+            press_ok_button(ui)

--- a/traitsui/tests/editors/test_liststr_editor.py
+++ b/traitsui/tests/editors/test_liststr_editor.py
@@ -15,6 +15,7 @@
 """
 Test case for ListStrEditor and ListStrAdapter
 """
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import List, Str
@@ -25,13 +26,15 @@ class TraitObject(HasTraits):
     list_str = List(Str)
 
 
-def test_list_str_adapter_length():
-    """Test the ListStringAdapter len method"""
+class TestListStrEditor(unittest.TestCase):
 
-    object = TraitObject()
-    object.list_str = ["hello"]
+    def test_list_str_adapter_length(self):
+        """Test the ListStringAdapter len method"""
 
-    adapter = ListStrAdapter()
+        object = TraitObject()
+        object.list_str = ["hello"]
 
-    assert adapter.len(object, "list_str") == 1
-    assert adapter.len(None, "list_str") == 0
+        adapter = ListStrAdapter()
+
+        self.assertEqual(adapter.len(object, "list_str"), 1)
+        self.assertEqual(adapter.len(None, "list_str"), 0)

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -19,6 +19,7 @@ Test case for bug (wx, Mac OS X)
 A ListStrEditor was not checking for valid item indexes under Wx.  This was
 most noticeable when the selected_index was set in the editor factory.
 """
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import List, Int, Str
@@ -90,93 +91,93 @@ def get_selected(control):
     return selected
 
 
-@skip_if_not_wx
-def test_wx_list_str_selected_index():
-    # behavior: when starting up, the
+class TestListStrEditorSelection(unittest.TestCase):
 
-    with store_exceptions_on_all_threads():
-        obj = ListStrEditorWithSelectedIndex(
-            values=["value1", "value2"], selected_index=1
-        )
-        ui = obj.edit_traits(view=single_select_view)
+    @skip_if_not_wx
+    def test_wx_list_str_selected_index(self):
+        # behavior: when starting up, the
 
-        # the following is equivalent to setting the text in the text control,
-        # then pressing OK
+        with store_exceptions_on_all_threads():
+            obj = ListStrEditorWithSelectedIndex(
+                values=["value1", "value2"], selected_index=1
+            )
+            ui = obj.edit_traits(view=single_select_view)
 
-        liststrctrl = ui.control.FindWindowByName("listCtrl")
-        selected_1 = get_selected(liststrctrl)
+            # the following is equivalent to setting the text in the text
+            # control, then pressing OK
 
-        obj.selected_index = 0
-        selected_2 = get_selected(liststrctrl)
+            liststrctrl = ui.control.FindWindowByName("listCtrl")
+            selected_1 = get_selected(liststrctrl)
 
-        # press the OK button and close the dialog
-        press_ok_button(ui)
+            obj.selected_index = 0
+            selected_2 = get_selected(liststrctrl)
 
-    # the number traits should be between 3 and 8
-    assert selected_1 == [1]
-    assert selected_2 == [0]
-
-
-@skip_if_not_wx
-def test_wx_list_str_multi_selected_index():
-    # behavior: when starting up, the
-
-    with store_exceptions_on_all_threads():
-        obj = ListStrEditorWithSelectedIndex(
-            values=["value1", "value2"], selected_indices=[1]
-        )
-        ui = obj.edit_traits(view=multi_select_view)
-
-        # the following is equivalent to setting the text in the text control,
-        # then pressing OK
-
-        liststrctrl = ui.control.FindWindowByName("listCtrl", ui.control)
-        selected_1 = get_selected(liststrctrl)
-
-        obj.selected_indices = [0]
-        selected_2 = get_selected(liststrctrl)
-
-        # press the OK button and close the dialog
-        press_ok_button(ui)
-
-    # the number traits should be between 3 and 8
-    assert selected_1 == [1]
-    assert selected_2 == [0]
-
-
-@skip_if_not_qt4
-def test_selection_listener_disconnected():
-    """ Check that selection listeners get correctly disconnected """
-    from pyface.api import GUI
-    from pyface.qt.QtGui import QApplication, QItemSelectionModel
-    from pyface.ui.qt4.util.event_loop_helper import EventLoopHelper
-    from pyface.ui.qt4.util.testing import event_loop
-
-    obj = ListStrEditorWithSelectedIndex(values=["value1", "value2"])
-
-    with store_exceptions_on_all_threads():
-        qt_app = QApplication.instance()
-        if qt_app is None:
-            qt_app = QApplication([])
-        helper = EventLoopHelper(gui=GUI(), qt_app=qt_app)
-
-        # open the UI and run until the dialog is closed
-        ui = obj.edit_traits(view=single_select_item_view)
-        with helper.delete_widget(ui.control):
+            # press the OK button and close the dialog
             press_ok_button(ui)
 
-        # now run again and change the selection
-        ui = obj.edit_traits(view=single_select_item_view)
-        with event_loop():
-            editor = ui.get_editors("values")[0]
+        # the number traits should be between 3 and 8
+        self.assertEqual(selected_1, [1])
+        self.assertEqual(selected_2, [0])
 
-            list_view = editor.list_view
-            mi = editor.model.index(1)
-            list_view.selectionModel().select(
-                mi, QItemSelectionModel.ClearAndSelect
+    @skip_if_not_wx
+    def test_wx_list_str_multi_selected_index(self):
+        # behavior: when starting up, the
+
+        with store_exceptions_on_all_threads():
+            obj = ListStrEditorWithSelectedIndex(
+                values=["value1", "value2"], selected_indices=[1]
             )
+            ui = obj.edit_traits(view=multi_select_view)
 
-    obj.selected = "value2"
+            # the following is equivalent to setting the text in the text
+            # control, then pressing OK
+
+            liststrctrl = ui.control.FindWindowByName("listCtrl", ui.control)
+            selected_1 = get_selected(liststrctrl)
+
+            obj.selected_indices = [0]
+            selected_2 = get_selected(liststrctrl)
+
+            # press the OK button and close the dialog
+            press_ok_button(ui)
+
+        # the number traits should be between 3 and 8
+        self.assertEqual(selected_1, [1])
+        self.assertEqual(selected_2, [0])
+
+    @skip_if_not_qt4
+    def test_selection_listener_disconnected(self):
+        """ Check that selection listeners get correctly disconnected """
+        from pyface.api import GUI
+        from pyface.qt.QtGui import QApplication, QItemSelectionModel
+        from pyface.ui.qt4.util.event_loop_helper import EventLoopHelper
+        from pyface.ui.qt4.util.testing import event_loop
+
+        obj = ListStrEditorWithSelectedIndex(values=["value1", "value2"])
+
+        with store_exceptions_on_all_threads():
+            qt_app = QApplication.instance()
+            if qt_app is None:
+                qt_app = QApplication([])
+            helper = EventLoopHelper(gui=GUI(), qt_app=qt_app)
+
+            # open the UI and run until the dialog is closed
+            ui = obj.edit_traits(view=single_select_item_view)
+            with helper.delete_widget(ui.control):
+                press_ok_button(ui)
+
+            # now run again and change the selection
+            ui = obj.edit_traits(view=single_select_item_view)
+            with event_loop():
+                editor = ui.get_editors("values")[0]
+
+                list_view = editor.list_view
+                mi = editor.model.index(1)
+                list_view.selectionModel().select(
+                    mi, QItemSelectionModel.ClearAndSelect
+                )
+
+        obj.selected = "value2"
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -126,7 +126,6 @@ class TestRangeEditorSpinner(unittest.TestCase):
 
             # if all went well, the number traits has been updated and its
             # value is 4
-            print(num.number)
             self.assertEqual(num.number, 4)
 
     @skip_if_not_qt4

--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -24,6 +24,7 @@ without de-focusing raises an AttributeError::
         self.value = self.control.GetValue()
     AttributeError: 'NoneType' object has no attribute 'GetValue'
 """
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Int
@@ -31,7 +32,12 @@ from traitsui.item import Item
 from traitsui.view import View
 from traitsui.editors.range_editor import RangeEditor
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    press_ok_button,
+    skip_if_not_wx,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
 
 
 class NumberWithSpinnerEditor(HasTraits):
@@ -47,104 +53,108 @@ class NumberWithSpinnerEditor(HasTraits):
     )
 
 
-@skip_if_not_wx
-def test_wx_spin_control_editing_should_not_crash():
-    # Bug: when editing the text part of a spin control box, pressing
-    # the OK button raises an AttributeError on Mac OS X
+class TestRangeEditorSpinner(unittest.TestCase):
 
-    try:
+    @skip_if_not_wx
+    def test_wx_spin_control_editing_should_not_crash(self):
+        # Bug: when editing the text part of a spin control box, pressing
+        # the OK button raises an AttributeError on Mac OS X
+
+        try:
+            with store_exceptions_on_all_threads():
+                num = NumberWithSpinnerEditor()
+                ui = num.edit_traits()
+
+                # the following is equivalent to clicking in the text control
+                # of the range editor, enter a number, and clicking ok without
+                # defocusing
+
+                # SpinCtrl object
+                spin = ui.control.FindWindowByName("wxSpinCtrl", ui.control)
+                spin.SetFocusFromKbd()
+
+                # on Windows, a wxSpinCtrl does not have children, and we
+                # cannot do the more fine-grained testing below
+                if len(spin.GetChildren()) == 0:
+                    spin.SetValue("4")
+                else:
+                    # TextCtrl object of the spin control
+                    spintxt = spin.FindWindowByName("text", spin)
+                    spintxt.SetValue("4")
+
+                # press the OK button and close the dialog
+                press_ok_button(ui)
+        except AttributeError:
+            # if all went well, we should not be here
+            self.fail("AttributeError raised")
+
+    @skip_if_not_wx
+    def test_wx_spin_control_editing_does_not_update(self):
+        # Bug: when editing the text part of a spin control box, pressing
+        # the OK button does not update the value of the HasTraits class
+        # on Mac OS X
+
+        # But under wx >= 3.0 this has been resolved
+        import wx
+
+        if wx.VERSION >= (3, 0):
+            return
+
         with store_exceptions_on_all_threads():
             num = NumberWithSpinnerEditor()
             ui = num.edit_traits()
 
-            # the following is equivalent to clicking in the text control of the
-            # range editor, enter a number, and clicking ok without defocusing
+            # the following is equivalent to clicking in the text control of
+            # the range editor, enter a number, and clicking ok without
+            # defocusing
 
             # SpinCtrl object
-            spin = ui.control.FindWindowByName("wxSpinCtrl", ui.control)
+            spin = ui.control.FindWindowByName("wxSpinCtrl")
             spin.SetFocusFromKbd()
 
             # on Windows, a wxSpinCtrl does not have children, and we cannot do
             # the more fine-grained testing below
             if len(spin.GetChildren()) == 0:
-                spin.SetValue("4")
+                spin.SetValueString("4")
             else:
                 # TextCtrl object of the spin control
-                spintxt = spin.FindWindowByName("text", spin)
+                spintxt = spin.FindWindowByName("text")
                 spintxt.SetValue("4")
 
             # press the OK button and close the dialog
             press_ok_button(ui)
-    except AttributeError:
-        # if all went well, we should not be here
-        assert False, "AttributeError raised"
 
+            # if all went well, the number traits has been updated and its
+            # value is 4
+            print(num.number)
+            self.assertEqual(num.number, 4)
 
-@skip_if_not_wx
-def test_wx_spin_control_editing_does_not_update():
-    # Bug: when editing the text part of a spin control box, pressing
-    # the OK button does not update the value of the HasTraits class
-    # on Mac OS X
+    @skip_if_not_qt4
+    def test_qt_spin_control_editing(self):
+        # Behavior: when editing the text part of a spin control box, pressing
+        # the OK button updates the value of the HasTraits class
 
-    # But under wx >= 3.0 this has been resolved
-    import wx
+        from pyface import qt
 
-    if wx.VERSION >= (3, 0):
-        return
+        with store_exceptions_on_all_threads():
+            num = NumberWithSpinnerEditor()
+            ui = num.edit_traits()
 
-    with store_exceptions_on_all_threads():
-        num = NumberWithSpinnerEditor()
-        ui = num.edit_traits()
+            # the following is equivalent to clicking in the text control of
+            # the range editor, enter a number, and clicking ok without
+            # defocusing
 
-        # the following is equivalent to clicking in the text control of the
-        # range editor, enter a number, and clicking ok without defocusing
+            # text element inside the spin control
+            lineedit = ui.control.findChild(qt.QtGui.QLineEdit)
+            lineedit.setFocus()
+            lineedit.setText("4")
 
-        # SpinCtrl object
-        spin = ui.control.FindWindowByName("wxSpinCtrl")
-        spin.SetFocusFromKbd()
-
-        # on Windows, a wxSpinCtrl does not have children, and we cannot do
-        # the more fine-grained testing below
-        if len(spin.GetChildren()) == 0:
-            spin.SetValueString("4")
-        else:
-            # TextCtrl object of the spin control
-            spintxt = spin.FindWindowByName("text")
-            spintxt.SetValue("4")
-
-        # press the OK button and close the dialog
-        press_ok_button(ui)
+            # press the OK button and close the dialog
+            press_ok_button(ui)
 
         # if all went well, the number traits has been updated and its value is
         # 4
-        print(num.number)
-        assert num.number == 4
-
-
-@skip_if_not_qt4
-def test_qt_spin_control_editing():
-    # Behavior: when editing the text part of a spin control box, pressing
-    # the OK button updates the value of the HasTraits class
-
-    from pyface import qt
-
-    with store_exceptions_on_all_threads():
-        num = NumberWithSpinnerEditor()
-        ui = num.edit_traits()
-
-        # the following is equivalent to clicking in the text control of the
-        # range editor, enter a number, and clicking ok without defocusing
-
-        # text element inside the spin control
-        lineedit = ui.control.findChild(qt.QtGui.QLineEdit)
-        lineedit.setFocus()
-        lineedit.setText("4")
-
-        # press the OK button and close the dialog
-        press_ok_button(ui)
-
-    # if all went well, the number traits has been updated and its value is 4
-    assert num.number == 4
+        self.assertEqual(num.number, 4)
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/editors/test_range_editor_text.py
+++ b/traitsui/tests/editors/test_range_editor_text.py
@@ -80,7 +80,6 @@ class TestRangeEditorText(unittest.TestCase):
             press_ok_button(ui)
 
         # the number traits should be between 3 and 8
-        print("Actual value:", num.number)
         self.assertTrue(3 <= num.number <= 8)
 
     @skip_if_not_qt4
@@ -104,7 +103,6 @@ class TestRangeEditorText(unittest.TestCase):
             press_ok_button(ui)
 
         # the number trait should be 4 extactly
-        print(num.number)
         self.assertEqual(num.number, 4.0)
 
 

--- a/traitsui/tests/editors/test_range_editor_text.py
+++ b/traitsui/tests/editors/test_range_editor_text.py
@@ -18,7 +18,7 @@ Test case for bug (wx, Mac OS X)
 
 A RangeEditor in mode 'text' for an Int allows values out of range.
 """
-
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Float, Int
@@ -26,7 +26,12 @@ from traitsui.item import Item
 from traitsui.view import View
 from traitsui.editors.range_editor import RangeEditor
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    press_ok_button,
+    skip_if_not_wx,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
 
 
 class NumberWithRangeEditor(HasTraits):
@@ -53,53 +58,54 @@ class FloatWithRangeEditor(HasTraits):
     )
 
 
-@skip_if_not_wx
-def test_wx_text_editing():
-    # behavior: when editing the text part of a spin control box, pressing
-    # the OK button should update the value of the HasTraits class
-    # (tests a bug where this fails with an AttributeError)
+class TestRangeEditorText(unittest.TestCase):
 
-    with store_exceptions_on_all_threads():
-        num = NumberWithRangeEditor()
-        ui = num.edit_traits()
+    @skip_if_not_wx
+    def test_wx_text_editing(self):
+        # behavior: when editing the text part of a spin control box, pressing
+        # the OK button should update the value of the HasTraits class
+        # (tests a bug where this fails with an AttributeError)
 
-        # the following is equivalent to setting the text in the text control,
-        # then pressing OK
+        with store_exceptions_on_all_threads():
+            num = NumberWithRangeEditor()
+            ui = num.edit_traits()
 
-        textctrl = ui.control.FindWindowByName("text")
-        textctrl.SetValue("1")
+            # the following is equivalent to setting the text in the text
+            # control, then pressing OK
 
-        # press the OK button and close the dialog
-        press_ok_button(ui)
+            textctrl = ui.control.FindWindowByName("text")
+            textctrl.SetValue("1")
 
-    # the number traits should be between 3 and 8
-    print("Actual value:", num.number)
-    assert 3 <= num.number <= 8
+            # press the OK button and close the dialog
+            press_ok_button(ui)
 
+        # the number traits should be between 3 and 8
+        print("Actual value:", num.number)
+        self.assertTrue(3 <= num.number <= 8)
 
-@skip_if_not_qt4
-def test_avoid_slider_feedback():
-    # behavior: when editing the text box part of a range editor, the value
-    # should not be adjusted by the slider part of the range editor
-    from pyface import qt
+    @skip_if_not_qt4
+    def test_avoid_slider_feedback(self):
+        # behavior: when editing the text box part of a range editor, the value
+        # should not be adjusted by the slider part of the range editor
+        from pyface import qt
 
-    with store_exceptions_on_all_threads():
-        num = FloatWithRangeEditor()
-        ui = num.edit_traits()
+        with store_exceptions_on_all_threads():
+            num = FloatWithRangeEditor()
+            ui = num.edit_traits()
 
-        # the following is equivalent to setting the text in the text control,
-        # then pressing OK
-        lineedit = ui.control.findChild(qt.QtGui.QLineEdit)
-        lineedit.setFocus()
-        lineedit.setText("4")
-        lineedit.editingFinished.emit()
+            # the following is equivalent to setting the text in the text
+            # control, then pressing OK
+            lineedit = ui.control.findChild(qt.QtGui.QLineEdit)
+            lineedit.setFocus()
+            lineedit.setText("4")
+            lineedit.editingFinished.emit()
 
-        # press the OK button and close the dialog
-        press_ok_button(ui)
+            # press the OK button and close the dialog
+            press_ok_button(ui)
 
-    # the number trait should be 4 extactly
-    print(num.number)
-    assert num.number == 4.0
+        # the number trait should be 4 extactly
+        print(num.number)
+        self.assertEqual(num.number, 4.0)
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -1,3 +1,4 @@
+import unittest
 
 from pyface.gui import GUI
 from traits.api import HasTraits, Instance, Int, List, Str, Tuple
@@ -257,347 +258,335 @@ select_cell_indices_view = View(
 )
 
 
-@skip_if_null
-def test_table_editor():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=simple_view)
-        gui.process_events()
-        press_ok_button(ui)
-        gui.process_events()
-
-
-@skip_if_null
-def test_filtered_table_editor():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=filtered_view)
-        gui.process_events()
-
-        filter = ui.get_editors("values")[0].filter
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert filter is not None
-
-
-@skip_if_null
-def test_table_editor_select_row():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected = object_list.values[5]
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_row_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected
-        elif is_current_backend_wx():
-            selected = editor.selected_row
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected is object_list.values[5]
-
-
-@skip_if_null
-def test_table_editor_select_rows():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selections = object_list.values[5:7]
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_rows_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected
-        elif is_current_backend_wx():
-            selected = editor.selected_rows
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == object_list.values[5:7]
-
-
-@skip_if_null
-def test_table_editor_select_row_index():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_index = 5
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_row_index_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected_indices
-        elif is_current_backend_wx():
-            selected = editor.selected_row_index
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == 5
-
-
-@skip_if_null
-def test_table_editor_select_row_indices():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_indices = [5, 7, 8]
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_row_indices_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected_indices
-        elif is_current_backend_wx():
-            selected = editor.selected_row_indices
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == [5, 7, 8]
-
-
-@skip_if_null
-def test_table_editor_select_column():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_column = "value"
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_column_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected
-        elif is_current_backend_wx():
-            selected = editor.selected_column
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == "value"
-
-
-@skip_if_null
-def test_table_editor_select_columns():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_columns = ["value", "other_value"]
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_columns_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected
-        elif is_current_backend_wx():
-            selected = editor.selected_columns
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == ["value", "other_value"]
-
-
-@skip_if_null
-def test_table_editor_select_column_index():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_index = 1
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_column_index_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected_indices
-        elif is_current_backend_wx():
-            selected = editor.selected_column_index
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == 1
-
-
-@skip_if_null
-def test_table_editor_select_column_indices():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_indices = [0, 1]
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_column_indices_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected_indices
-        elif is_current_backend_wx():
-            selected = editor.selected_column_indices
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == [0, 1]
-
-
-@skip_if_null
-def test_table_editor_select_cell():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_cell = (object_list.values[5], "value")
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_cell_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected
-        elif is_current_backend_wx():
-            selected = editor.selected_cell
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == (object_list.values[5], "value")
-
-
-@skip_if_null
-def test_table_editor_select_cells():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_cells = [
-        (object_list.values[5], "value"),
-        (object_list.values[6], "other value"),
-        (object_list.values[8], "value"),
-    ]
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_cells_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected
-        elif is_current_backend_wx():
-            selected = editor.selected_cells
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == [
-        (object_list.values[5], "value"),
-        (object_list.values[6], "other value"),
-        (object_list.values[8], "value"),
-    ]
-
-
-@skip_if_null
-def test_table_editor_select_cell_index():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_cell_index = (5, 1)
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_cell_index_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected_indices
-        elif is_current_backend_wx():
-            selected = editor.selected_cell_index
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == (5, 1)
-
-
-@skip_if_null
-def test_table_editor_select_cell_indices():
-    gui = GUI()
-    object_list = ObjectListWithSelection(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
-    object_list.selected_cell_indices = [(5, 0), (6, 1), (8, 0)]
-
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=select_cell_indices_view)
-        editor = ui.get_editors("values")[0]
-        gui.process_events()
-        if is_current_backend_qt4():
-            selected = editor.selected_indices
-        elif is_current_backend_wx():
-            selected = editor.selected_cell_indices
-
-        press_ok_button(ui)
-        gui.process_events()
-
-    assert selected == [(5, 0), (6, 1), (8, 0)]
-
-
-@skip_if_not_qt4
-def test_progress_column():
-    from traitsui.extras.progress_column import ProgressColumn
-
-    progress_view = View(
-        Item(
-            "values",
-            show_label=False,
-            editor=TableEditor(
-                columns=[
-                    ObjectColumn(name="value"),
-                    ProgressColumn(name="other_value"),
-                ]
+class TestTableEditor(unittest.TestCase):
+
+    @skip_if_null
+    def test_table_editor(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=simple_view)
+            gui.process_events()
+            press_ok_button(ui)
+            gui.process_events()
+
+    @skip_if_null
+    def test_filtered_table_editor(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=filtered_view)
+            gui.process_events()
+
+            filter = ui.get_editors("values")[0].filter
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertIsNotNone(filter)
+
+    @skip_if_null
+    def test_table_editor_select_row(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected = object_list.values[5]
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_row_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected
+            elif is_current_backend_wx():
+                selected = editor.selected_row
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertIs(selected, object_list.values[5])
+
+    @skip_if_null
+    def test_table_editor_select_rows(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selections = object_list.values[5:7]
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_rows_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected
+            elif is_current_backend_wx():
+                selected = editor.selected_rows
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, object_list.values[5:7])
+
+    @skip_if_null
+    def test_table_editor_select_row_index(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_index = 5
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_row_index_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected_indices
+            elif is_current_backend_wx():
+                selected = editor.selected_row_index
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, 5)
+
+    @skip_if_null
+    def test_table_editor_select_row_indices(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_indices = [5, 7, 8]
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_row_indices_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected_indices
+            elif is_current_backend_wx():
+                selected = editor.selected_row_indices
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, [5, 7, 8])
+
+    @skip_if_null
+    def test_table_editor_select_column(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_column = "value"
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_column_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected
+            elif is_current_backend_wx():
+                selected = editor.selected_column
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, "value")
+
+    @skip_if_null
+    def test_table_editor_select_columns(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_columns = ["value", "other_value"]
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_columns_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected
+            elif is_current_backend_wx():
+                selected = editor.selected_columns
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, ["value", "other_value"])
+
+    @skip_if_null
+    def test_table_editor_select_column_index(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_index = 1
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_column_index_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected_indices
+            elif is_current_backend_wx():
+                selected = editor.selected_column_index
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, 1)
+
+    @skip_if_null
+    def test_table_editor_select_column_indices(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_indices = [0, 1]
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_column_indices_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected_indices
+            elif is_current_backend_wx():
+                selected = editor.selected_column_indices
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, [0, 1])
+
+    @skip_if_null
+    def test_table_editor_select_cell(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_cell = (object_list.values[5], "value")
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_cell_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected
+            elif is_current_backend_wx():
+                selected = editor.selected_cell
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, (object_list.values[5], "value"))
+
+    @skip_if_null
+    def test_table_editor_select_cells(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_cells = [
+            (object_list.values[5], "value"),
+            (object_list.values[6], "other value"),
+            (object_list.values[8], "value"),
+        ]
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_cells_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected
+            elif is_current_backend_wx():
+                selected = editor.selected_cells
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, [
+            (object_list.values[5], "value"),
+            (object_list.values[6], "other value"),
+            (object_list.values[8], "value"),
+        ])
+
+    @skip_if_null
+    def test_table_editor_select_cell_index(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_cell_index = (5, 1)
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_cell_index_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected_indices
+            elif is_current_backend_wx():
+                selected = editor.selected_cell_index
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, (5, 1))
+
+    @skip_if_null
+    def test_table_editor_select_cell_indices(self):
+        gui = GUI()
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        object_list.selected_cell_indices = [(5, 0), (6, 1), (8, 0)]
+
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=select_cell_indices_view)
+            editor = ui.get_editors("values")[0]
+            gui.process_events()
+            if is_current_backend_qt4():
+                selected = editor.selected_indices
+            elif is_current_backend_wx():
+                selected = editor.selected_cell_indices
+
+            press_ok_button(ui)
+            gui.process_events()
+
+        self.assertEqual(selected, [(5, 0), (6, 1), (8, 0)])
+
+    @skip_if_not_qt4
+    def test_progress_column(self):
+        from traitsui.extras.progress_column import ProgressColumn
+
+        progress_view = View(
+            Item(
+                "values",
+                show_label=False,
+                editor=TableEditor(
+                    columns=[
+                        ObjectColumn(name="value"),
+                        ProgressColumn(name="other_value"),
+                    ]
+                ),
             ),
-        ),
-        buttons=["OK"],
-    )
-    gui = GUI()
-    object_list = ObjectList(
-        values=[ListItem(value=str(i ** 2)) for i in range(10)]
-    )
+            buttons=["OK"],
+        )
+        gui = GUI()
+        object_list = ObjectList(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
 
-    with store_exceptions_on_all_threads():
-        ui = object_list.edit_traits(view=progress_view)
-        gui.process_events()
-        press_ok_button(ui)
-        gui.process_events()
+        with store_exceptions_on_all_threads():
+            ui = object_list.edit_traits(view=progress_view)
+            gui.process_events()
+            press_ok_button(ui)
+            gui.process_events()

--- a/traitsui/tests/editors/test_tuple_editor.py
+++ b/traitsui/tests/editors/test_tuple_editor.py
@@ -4,15 +4,18 @@ Created on Fri Sep 20 13:17:20 2013
 
 @author: yves
 """
-
-from contextlib import contextmanager
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Int, Tuple
 from traitsui.item import Item
 from traitsui.view import View
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    press_ok_button,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
 
 
 class TupleEditor(HasTraits):
@@ -26,34 +29,38 @@ class TupleEditor(HasTraits):
     )
 
 
-@skip_if_not_qt4
-def test_qt_tuple_editor():
-    # Behavior: when editing the text of a tuple editor,
-    # value get updated immediately.
+class TestTupleEditor(unittest.TestCase):
 
-    from pyface import qt
+    @skip_if_not_qt4
+    def test_qt_tuple_editor(self):
+        # Behavior: when editing the text of a tuple editor,
+        # value get updated immediately.
 
-    with store_exceptions_on_all_threads():
-        val = TupleEditor()
-        ui = val.edit_traits()
+        from pyface import qt
 
-        # the following is equivalent to clicking in the text control of the
-        # range editor, enter a number, and clicking ok without defocusing
+        with store_exceptions_on_all_threads():
+            val = TupleEditor()
+            ui = val.edit_traits()
 
-        # text element inside the spin control
-        lineedits = ui.control.findChildren(qt.QtGui.QLineEdit)
-        lineedits[0].setFocus()
-        lineedits[0].clear()
-        lineedits[0].insert("4")
-        lineedits[1].setFocus()
-        lineedits[1].clear()
-        lineedits[1].insert("6")
+            # the following is equivalent to clicking in the text control of
+            # the range editor, enter a number, and clicking ok without
+            # defocusing
 
-        # if all went well, the tuple trait has been updated and its value is 4
-        assert val.tup == (4, 6)
+            # text element inside the spin control
+            lineedits = ui.control.findChildren(qt.QtGui.QLineEdit)
+            lineedits[0].setFocus()
+            lineedits[0].clear()
+            lineedits[0].insert("4")
+            lineedits[1].setFocus()
+            lineedits[1].clear()
+            lineedits[1].insert("6")
 
-        # press the OK button and close the dialog
-        press_ok_button(ui)
+            # if all went well, the tuple trait has been updated and its value
+            # is 4
+            self.assertEqual(val.tup, (4, 6))
+
+            # press the OK button and close the dialog
+            press_ok_button(ui)
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/null_backend/test_font_trait.py
+++ b/traitsui/tests/null_backend/test_font_trait.py
@@ -1,50 +1,51 @@
-from nose.tools import assert_equals
+import unittest
 
 from traits.api import HasTraits
 
 from traitsui.toolkit_traits import Font
-from traitsui.tests._tools import *
+from traitsui.tests._tools import skip_if_not_null
 
 
-@skip_if_not_null
-def test_font_trait_default():
-    class Foo(HasTraits):
-        font = Font()
+class TestFontTrait(unittest.TestCase):
 
-    f = Foo()
-    assert_equals(f.font, "10 pt Arial")
+    @skip_if_not_null
+    def test_font_trait_default(self):
+        class Foo(HasTraits):
+            font = Font()
 
+        f = Foo()
+        self.assertEquals(f.font, "10 pt Arial")
 
-@skip_if_not_null
-def test_font_trait_examples():
-    """
-    An assigned font string is parsed, and the substrings are
-    put in the order: point size, family, style, weight, underline, facename
+    @skip_if_not_null
+    def test_font_trait_examples(self):
+        """
+        An assigned font string is parsed, and the substrings are put
+        in the order: point size, family, style, weight, underline, facename
 
-    The words 'pt, 'point' and 'family' are ignored.
+        The words 'pt, 'point' and 'family' are ignored.
 
-    """
+        """
 
-    class Foo(HasTraits):
-        font = Font
+        class Foo(HasTraits):
+            font = Font
 
-    f = Foo(font="Qwerty 10")
-    assert_equals(f.font, "10 pt Qwerty")
+        f = Foo(font="Qwerty 10")
+        self.assertEquals(f.font, "10 pt Qwerty")
 
-    f = Foo(font="nothing")
-    assert_equals(f.font, "nothing")
+        f = Foo(font="nothing")
+        self.assertEquals(f.font, "nothing")
 
-    f = Foo(font="swiss family arial")
-    assert_equals(f.font, "swiss arial")
+        f = Foo(font="swiss family arial")
+        self.assertEquals(f.font, "swiss arial")
 
-    f = Foo(font="12 pt bold italic")
-    assert_equals(f.font, "12 pt italic bold")
+        f = Foo(font="12 pt bold italic")
+        self.assertEquals(f.font, "12 pt italic bold")
 
-    f = Foo(font="123 Foo bar slant")
-    assert_equals(f.font, "123 pt slant Foo bar")
+        f = Foo(font="123 Foo bar slant")
+        self.assertEquals(f.font, "123 pt slant Foo bar")
 
-    f = Foo(font="123 point Foo family bar slant")
-    assert_equals(f.font, "123 pt slant Foo bar")
+        f = Foo(font="123 point Foo family bar slant")
+        self.assertEquals(f.font, "123 pt slant Foo bar")
 
-    f = Foo(font="16 xyzzy underline slant")
-    assert_equals(f.font, "16 pt slant underline xyzzy")
+        f = Foo(font="16 xyzzy underline slant")
+        self.assertEquals(f.font, "16 pt slant underline xyzzy")

--- a/traitsui/tests/null_backend/test_font_trait.py
+++ b/traitsui/tests/null_backend/test_font_trait.py
@@ -14,7 +14,7 @@ class TestFontTrait(unittest.TestCase):
             font = Font()
 
         f = Foo()
-        self.assertEquals(f.font, "10 pt Arial")
+        self.assertEqual(f.font, "10 pt Arial")
 
     @skip_if_not_null
     def test_font_trait_examples(self):
@@ -30,22 +30,22 @@ class TestFontTrait(unittest.TestCase):
             font = Font
 
         f = Foo(font="Qwerty 10")
-        self.assertEquals(f.font, "10 pt Qwerty")
+        self.assertEqual(f.font, "10 pt Qwerty")
 
         f = Foo(font="nothing")
-        self.assertEquals(f.font, "nothing")
+        self.assertEqual(f.font, "nothing")
 
         f = Foo(font="swiss family arial")
-        self.assertEquals(f.font, "swiss arial")
+        self.assertEqual(f.font, "swiss arial")
 
         f = Foo(font="12 pt bold italic")
-        self.assertEquals(f.font, "12 pt italic bold")
+        self.assertEqual(f.font, "12 pt italic bold")
 
         f = Foo(font="123 Foo bar slant")
-        self.assertEquals(f.font, "123 pt slant Foo bar")
+        self.assertEqual(f.font, "123 pt slant Foo bar")
 
         f = Foo(font="123 point Foo family bar slant")
-        self.assertEquals(f.font, "123 pt slant Foo bar")
+        self.assertEqual(f.font, "123 pt slant Foo bar")
 
         f = Foo(font="16 xyzzy underline slant")
-        self.assertEquals(f.font, "16 pt slant underline xyzzy")
+        self.assertEqual(f.font, "16 pt slant underline xyzzy")

--- a/traitsui/tests/null_backend/test_null_toolkit.py
+++ b/traitsui/tests/null_backend/test_null_toolkit.py
@@ -1,17 +1,19 @@
-from nose.tools import assert_raises
+import unittest
 
 from traits.api import HasTraits, Int
 from traitsui.tests._tools import skip_if_not_null
 
 
-@skip_if_not_null
-def test_configure_traits_error():
-    """ Verify that configure_traits fails with NotImplementedError. """
+class TestNullToolkit(unittest.TestCase):
 
-    class Test(HasTraits):
-        x = Int()
+    @skip_if_not_null
+    def test_configure_traits_error(self):
+        """ Verify that configure_traits fails with NotImplementedError. """
 
-    t = Test()
+        class Test(HasTraits):
+            x = Int()
 
-    with assert_raises(NotImplementedError):
-        t.configure_traits()
+        t = Test()
+
+        with self.assertRaises(NotImplementedError):
+            t.configure_traits()

--- a/traitsui/tests/test_actions.py
+++ b/traitsui/tests/test_actions.py
@@ -17,7 +17,7 @@
 Test that menu and toolbar actions are triggered.
 """
 
-import nose
+from functools import partial
 import pyface
 import unittest
 
@@ -27,11 +27,16 @@ from traitsui.menu import Action, ActionGroup, Menu, MenuBar, ToolBar
 from traitsui.item import Item
 from traitsui.view import View
 
-from traitsui.tests._tools import *
-from traitsui.tests._tools import _is_current_backend
+from traitsui.tests._tools import (
+    is_current_backend_null,
+    is_mac_os,
+    skip_if_not_qt4,
+    skip_if_not_wx,
+    store_exceptions_on_all_threads,
+)
 
-if _is_current_backend("null"):
-    raise nose.SkipTest("Not supported using the null backend")
+if is_current_backend_null():
+    raise unittest.SkipTest("Not supported using the null backend")
 
 
 TestAction = Action(
@@ -64,26 +69,7 @@ class DialogWithToolbar(HasTraits):
     )
 
 
-def _test_actions(trigger_action_func):
-    """Template test for wx, qt4, menu, and toolbar testing.
-    """
-    # Behavior: when clicking on a menu or toolbar action,
-    # the corresponding function should be executed
-
-    with store_exceptions_on_all_threads():
-        # create dialog with toolbar adn menu
-        dialog = DialogWithToolbar()
-        ui = dialog.edit_traits()
-
-        # press toolbar or menu button
-        trigger_action_func(ui)
-
-        # verify that the action was triggered
-        nose.tools.assert_true(dialog.action_successful)
-
-
-# ----- Qt4 tests
-
+# ----- qt4 helper functions
 
 def _qt_trigger_action(container_class, ui):
     toolbar = ui.control.findChild(container_class)
@@ -100,108 +86,123 @@ def _qt_click_button(ui):
     button.click()
 
 
-@skip_if_not_qt4
-def test_qt_toolbar_action():
-    # Behavior: when clicking on a toolbar action, the corresponding function
-    # should be executed
+class TestActions(unittest.TestCase):
 
-    # Bug: in the Qt4 backend, a
-    # TypeError: perform() takes exactly 2 arguments (1 given) was raised
-    # instead
+    def _test_actions(self, trigger_action_func):
+        """Template test for wx, qt4, menu, and toolbar testing.
+        """
+        # Behavior: when clicking on a menu or toolbar action,
+        # the corresponding function should be executed
 
-    qt_trigger_toolbar_action = partial(
-        _qt_trigger_action, pyface.ui.qt4.action.tool_bar_manager._ToolBar
-    )
+        with store_exceptions_on_all_threads():
+            # create dialog with toolbar adn menu
+            dialog = DialogWithToolbar()
+            ui = dialog.edit_traits()
 
-    _test_actions(qt_trigger_toolbar_action)
+            # press toolbar or menu button
+            trigger_action_func(ui)
 
+            # verify that the action was triggered
+            self.assertTrue(dialog.action_successful)
 
-@skip_if_not_qt4
-def test_qt_menu_action():
-    # Behavior: when clicking on a menu action, the corresponding function
-    # should be executed
+    # ----- Qt4 tests
 
-    # Bug: in the Qt4 backend, a
-    # TypeError: perform() takes exactly 2 arguments (1 given) was raised
-    # instead
+    @skip_if_not_qt4
+    def test_qt_toolbar_action(self):
+        # Behavior: when clicking on a toolbar action, the corresponding
+        # function should be executed
 
-    qt_trigger_menu_action = partial(
-        _qt_trigger_action, pyface.ui.qt4.action.menu_manager._Menu
-    )
+        # Bug: in the Qt4 backend, a
+        # TypeError: perform() takes exactly 2 arguments (1 given) was raised
+        # instead
 
-    _test_actions(qt_trigger_menu_action)
-
-
-@skip_if_not_qt4
-def test_qt_button_action():
-    # Behavior: when clicking on a button action, the corresponding function
-    # should be executed
-
-    # Bug: in the Qt4 backend, a
-    # TypeError: perform() takes exactly 2 arguments (1 given) was raised
-    # instead
-
-    _test_actions(_qt_click_button)
-
-
-# ----- wx tests
-
-
-@unittest.skipIf(
-    not is_mac_os,
-    "Problem with triggering toolbar actions on Linux and Windows. Issue #428.",
-)
-@skip_if_not_wx
-def test_wx_toolbar_action():
-    # Behavior: when clicking on a toolbar action, the corresponding function
-    # should be executed
-
-    import wx
-
-    def _wx_trigger_toolbar_action(ui):
-        # long road to get at the Id of the toolbar button
-        toolbar_item = ui.view.toolbar.groups[0].items[0]
-        toolbar_item_wrapper = toolbar_item._wrappers[0]
-        control_id = toolbar_item_wrapper.control_id
-
-        # build event that clicks the button
-        click_event = wx.CommandEvent(
-            wx.wxEVT_COMMAND_TOOL_CLICKED, control_id
+        qt_trigger_toolbar_action = partial(
+            _qt_trigger_action, pyface.ui.qt4.action.tool_bar_manager._ToolBar
         )
 
-        # send the event to the toolbar
-        toolbar = ui.control.FindWindowByName("toolbar")
-        toolbar.ProcessEvent(click_event)
+        self._test_actions(qt_trigger_toolbar_action)
 
-    _test_actions(_wx_trigger_toolbar_action)
+    @skip_if_not_qt4
+    def test_qt_menu_action(self):
+        # Behavior: when clicking on a menu action, the corresponding function
+        # should be executed
 
+        # Bug: in the Qt4 backend, a
+        # TypeError: perform() takes exactly 2 arguments (1 given) was raised
+        # instead
 
-@skip_if_not_wx
-def test_wx_button_action():
-    # Behavior: when clicking on a button action, the corresponding function
-    # should be executed
-
-    import wx
-
-    def _wx_trigger_button_action(ui):
-        # long road to get at the Id of the toolbar button
-        button_sizer = ui.control.GetSizer().GetChildren()[2].GetSizer()
-        button = button_sizer.GetChildren()[0].GetWindow()
-
-        control_id = button.GetId()
-
-        # build event that clicks the button
-        click_event = wx.CommandEvent(
-            wx.wxEVT_COMMAND_BUTTON_CLICKED, control_id
+        qt_trigger_menu_action = partial(
+            _qt_trigger_action, pyface.ui.qt4.action.menu_manager._Menu
         )
 
-        # send the event to the toolbar
-        ui.control.ProcessEvent(click_event)
+        self._test_actions(qt_trigger_menu_action)
 
-    _test_actions(_wx_trigger_button_action)
+    @skip_if_not_qt4
+    def test_qt_button_action(self):
+        # Behavior: when clicking on a button action, the corresponding
+        # function should be executed
 
+        # Bug: in the Qt4 backend, a
+        # TypeError: perform() takes exactly 2 arguments (1 given) was raised
+        # instead
 
-# TODO: I couldn't find a way to press menu items programmatically for wx
+        self._test_actions(_qt_click_button)
+
+    # ----- wx tests
+
+    @unittest.skipIf(
+        not is_mac_os,
+        "Problem with triggering toolbar actions on Linux and Windows. Issue #428.",  # noqa: E501
+    )
+    @skip_if_not_wx
+    def test_wx_toolbar_action(self):
+        # Behavior: when clicking on a toolbar action, the corresponding
+        # function should be executed
+
+        import wx
+
+        def _wx_trigger_toolbar_action(ui):
+            # long road to get at the Id of the toolbar button
+            toolbar_item = ui.view.toolbar.groups[0].items[0]
+            toolbar_item_wrapper = toolbar_item._wrappers[0]
+            control_id = toolbar_item_wrapper.control_id
+
+            # build event that clicks the button
+            click_event = wx.CommandEvent(
+                wx.wxEVT_COMMAND_TOOL_CLICKED, control_id
+            )
+
+            # send the event to the toolbar
+            toolbar = ui.control.FindWindowByName("toolbar")
+            toolbar.ProcessEvent(click_event)
+
+        self._test_actions(_wx_trigger_toolbar_action)
+
+    @skip_if_not_wx
+    def test_wx_button_action(self):
+        # Behavior: when clicking on a button action, the corresponding
+        # function should be executed
+
+        import wx
+
+        def _wx_trigger_button_action(ui):
+            # long road to get at the Id of the toolbar button
+            button_sizer = ui.control.GetSizer().GetChildren()[2].GetSizer()
+            button = button_sizer.GetChildren()[0].GetWindow()
+
+            control_id = button.GetId()
+
+            # build event that clicks the button
+            click_event = wx.CommandEvent(
+                wx.wxEVT_COMMAND_BUTTON_CLICKED, control_id
+            )
+
+            # send the event to the toolbar
+            ui.control.ProcessEvent(click_event)
+
+        self._test_actions(_wx_trigger_button_action)
+
+    # TODO: I couldn't find a way to press menu items programmatically for wx
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/test_actions.py
+++ b/traitsui/tests/test_actions.py
@@ -50,7 +50,6 @@ class DialogWithToolbar(HasTraits):
     action_successful = Bool(False)
 
     def test_clicked(self):
-        print("perform action")
         self.action_successful = True
 
     menubar = MenuBar(Menu(ActionGroup(TestAction), name="&Test menu"))
@@ -82,7 +81,6 @@ def _qt_click_button(ui):
 
     bbox = ui.control.findChild(QDialogButtonBox)
     button = bbox.buttons()[1]
-    print((button.text()))
     button.click()
 
 

--- a/traitsui/tests/test_controller.py
+++ b/traitsui/tests/test_controller.py
@@ -15,7 +15,7 @@
 Test cases for the Controller class.
 """
 
-import nose
+import unittest
 
 from traits.api import HasTraits, Instance, Str
 from traitsui.api import Controller
@@ -34,13 +34,15 @@ class FooController(Controller):
         return FooModel(my_str="meh")
 
 
-def test_construction():
-    # check default constructor.
-    dialog = FooController()
-    nose.tools.assert_is_not_none(dialog.model)
-    nose.tools.assert_equal(dialog.model.my_str, "meh")
+class TestController(unittest.TestCase):
 
-    # check initialization when `model` is explcitly passed in.
-    new_model = FooModel()
-    dialog = FooController(model=new_model)
-    nose.tools.assert_is(dialog.model, new_model)
+    def test_construction(self):
+        # check default constructor.
+        dialog = FooController()
+        self.assertIsNotNone(dialog.model)
+        self.assertEqual(dialog.model.my_str, "meh")
+
+        # check initialization when `model` is explcitly passed in.
+        new_model = FooModel()
+        dialog = FooController(model=new_model)
+        self.assertIs(dialog.model, new_model)

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -16,7 +16,7 @@
 """
 Test the creation and layout of labels.
 """
-import nose
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Bool, Str
@@ -24,7 +24,22 @@ from traitsui.view import View
 from traitsui.item import Item
 from traitsui.group import VGroup, HGroup
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    is_current_backend_qt4,
+    is_current_backend_wx,
+    skip_if_not_qt4,
+    skip_if_null,
+    store_exceptions_on_all_threads,
+)
+
+
+def is_enabled(control):
+    if is_current_backend_qt4():
+        return control.isEnabled()
+    elif is_current_backend_wx():
+        return control.IsEnabled()
+    else:
+        raise NotImplementedError()
 
 
 _DIALOG_WIDTH = 500
@@ -118,124 +133,112 @@ class EnableWhenDialog(HasTraits):
     )
 
 
-@skip_if_not_qt4
-def test_qt_show_labels_right_without_colon():
-    # Behavior: traitsui should not append a colon ':' to labels
-    # that are shown to the *right* of the corresponding elements
+class TestLabels(unittest.TestCase):
 
-    from pyface import qt
+    @skip_if_not_qt4
+    def test_qt_show_labels_right_without_colon(self):
+        # Behavior: traitsui should not append a colon ':' to labels
+        # that are shown to the *right* of the corresponding elements
 
-    with store_exceptions_on_all_threads():
-        dialog = ShowRightLabelsDialog()
-        ui = dialog.edit_traits()
+        from pyface import qt
 
-        # get reference to label objects
-        labels = ui.control.findChildren(qt.QtGui.QLabel)
+        with store_exceptions_on_all_threads():
+            dialog = ShowRightLabelsDialog()
+            ui = dialog.edit_traits()
 
-        # the first is shown to the right, so no colon
-        nose.tools.assert_false(labels[0].text().endswith(":"))
+            # get reference to label objects
+            labels = ui.control.findChildren(qt.QtGui.QLabel)
 
-        # the second is shown to the right, it should have a colon
-        nose.tools.assert_true(labels[1].text().endswith(":"))
+            # the first is shown to the right, so no colon
+            self.assertFalse(labels[0].text().endswith(":"))
 
+            # the second is shown to the right, it should have a colon
+            self.assertTrue(labels[1].text().endswith(":"))
 
-def _test_qt_labels_right_resizing(dialog_class):
-    # Bug: In the Qt backend, resizing a checkbox element with a label on the
-    # right resizes the checkbox, even though it cannot be.
-    # The final effect is that the label remains attached to the right margin,
-    # with a big gap between it and the checkbox. In this case, the label
-    # should be made resizable instead.
-    # On the other hand, a text element should keep the current behavior and
-    # resize.
+    def _test_qt_labels_right_resizing(self, dialog_class):
+        # Bug: In the Qt backend, resizing a checkbox element with a label on
+        # the right resizes the checkbox, even though it cannot be.
+        # The final effect is that the label remains attached to the right
+        # margin, with a big gap between it and the checkbox. In this case, the
+        # label should be made resizable instead.
+        # On the other hand, a text element should keep the current behavior
+        # and resize.
 
-    from pyface import qt
+        from pyface import qt
 
-    with store_exceptions_on_all_threads():
-        dialog = dialog_class()
-        ui = dialog.edit_traits()
+        with store_exceptions_on_all_threads():
+            dialog = dialog_class()
+            ui = dialog.edit_traits()
 
-        # all labels
-        labels = ui.control.findChildren(qt.QtGui.QLabel)
+            # all labels
+            labels = ui.control.findChildren(qt.QtGui.QLabel)
 
-        # the checkbox and its label should be close to one another; the
-        # size of the checkbox should be small
-        checkbox_label = labels[0]
-        checkbox = ui.control.findChild(qt.QtGui.QCheckBox)
+            # the checkbox and its label should be close to one another; the
+            # size of the checkbox should be small
+            checkbox_label = labels[0]
+            checkbox = ui.control.findChild(qt.QtGui.QCheckBox)
 
-        # horizontal space between checkbox and label should be small
-        h_space = checkbox_label.x() - checkbox.x()
-        nose.tools.assert_less(h_space, 100)
-        # and the checkbox size should also be small
-        nose.tools.assert_less(checkbox.width(), 100)
+            # horizontal space between checkbox and label should be small
+            h_space = checkbox_label.x() - checkbox.x()
+            self.assertLess(h_space, 100)
+            # and the checkbox size should also be small
+            self.assertLess(checkbox.width(), 100)
 
-        # the text item and its label should be close to one another; the
-        # size of the text item should be large
-        text_label = labels[0]
-        text = ui.control.findChild(qt.QtGui.QLineEdit)
+            # the text item and its label should be close to one another; the
+            # size of the text item should be large
+            text_label = labels[0]
+            text = ui.control.findChild(qt.QtGui.QLineEdit)
 
-        # horizontal space between text and label should be small
-        h_space = text_label.x() - text.x()
-        nose.tools.assert_less(h_space, 100)
-        # and the text item size should be large
-        nose.tools.assert_greater(text.width(), _DIALOG_WIDTH - 200)
+            # horizontal space between text and label should be small
+            h_space = text_label.x() - text.x()
+            self.assertLess(h_space, 100)
+            # and the text item size should be large
+            self.assertGreater(text.width(), _DIALOG_WIDTH - 200)
 
-        # the size of the window should still be 500
-        nose.tools.assert_equal(ui.control.width(), _DIALOG_WIDTH)
+            # the size of the window should still be 500
+            self.assertEqual(ui.control.width(), _DIALOG_WIDTH)
 
+    @skip_if_not_qt4
+    def test_qt_labels_right_resizing_vertical(self):
+        self._test_qt_labels_right_resizing(VResizeTestDialog)
 
-@skip_if_not_qt4
-def test_qt_labels_right_resizing_vertical():
-    _test_qt_labels_right_resizing(VResizeTestDialog)
+    @skip_if_not_qt4
+    def test_qt_labels_right_resizing_horizontal(self):
+        self._test_qt_labels_right_resizing(HResizeTestDialog)
 
+    @skip_if_not_qt4
+    def test_qt_no_labels_on_the_right_bug(self):
+        # Bug: If one set show_left=False, show_label=False on a non-resizable
+        # item like a checkbox, the Qt backend tried to set the label's size
+        # policy and failed because label=None.
 
-@skip_if_not_qt4
-def test_qt_labels_right_resizing_horizontal():
-    _test_qt_labels_right_resizing(HResizeTestDialog)
+        with store_exceptions_on_all_threads():
+            dialog = NoLabelResizeTestDialog()
+            ui = dialog.edit_traits()
 
+    @skip_if_null
+    def test_labels_enabled_when(self):
+        # Behaviour: label should enable/disable along with editor
 
-@skip_if_not_qt4
-def test_qt_no_labels_on_the_right_bug():
-    # Bug: If one set show_left=False, show_label=False on a non-resizable
-    # item like a checkbox, the Qt backend tried to set the label's size
-    # policy and failed because label=None.
+        with store_exceptions_on_all_threads():
+            dialog = EnableWhenDialog()
+            ui = dialog.edit_traits()
 
-    with store_exceptions_on_all_threads():
-        dialog = NoLabelResizeTestDialog()
-        ui = dialog.edit_traits()
+            labelled_editor = ui.get_editors("labelled_item")[0]
 
+            if is_current_backend_qt4():
+                unlabelled_editor = ui.get_editors("unlabelled_item")[0]
+                self.assertIsNone(unlabelled_editor.label_control)
 
-def is_enabled(control):
-    if is_current_backend_qt4():
-        return control.isEnabled()
-    elif is_current_backend_wx():
-        return control.IsEnabled()
-    else:
-        raise NotImplementedError()
+            self.assertTrue(is_enabled(labelled_editor.label_control))
 
+            dialog.bool_item = False
 
-@skip_if_null
-def test_labels_enabled_when():
-    # Behaviour: label should enable/disable along with editor
+            self.assertFalse(is_enabled(labelled_editor.label_control))
 
-    with store_exceptions_on_all_threads():
-        dialog = EnableWhenDialog()
-        ui = dialog.edit_traits()
+            dialog.bool_item = True
 
-        labelled_editor = ui.get_editors("labelled_item")[0]
-
-        if is_current_backend_qt4():
-            unlabelled_editor = ui.get_editors("unlabelled_item")[0]
-            nose.tools.assert_is_none(unlabelled_editor.label_control)
-
-        nose.tools.assert_true(is_enabled(labelled_editor.label_control))
-
-        dialog.bool_item = False
-
-        nose.tools.assert_false(is_enabled(labelled_editor.label_control))
-
-        dialog.bool_item = True
-
-        ui.dispose()
+            ui.dispose()
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/test_layout.py
+++ b/traitsui/tests/test_layout.py
@@ -17,7 +17,7 @@
 Test the layout of elements is consistent with the layout parameters.
 """
 
-import nose
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Str
@@ -26,7 +26,10 @@ from traitsui.item import Item
 from traitsui.view import View
 from traitsui.group import HGroup, VGroup
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
 
 
 _DIALOG_WIDTH = 500
@@ -58,48 +61,49 @@ class HResizeDialog(HasTraits):
     )
 
 
-@skip_if_not_qt4
-def test_qt_resizable_in_vgroup():
-    # Behavior: Item.resizable controls whether a component can resize along
-    # the non-layout axis of its group. In a VGroup, resizing should work
-    # only in the horizontal direction.
+class TestLayout(unittest.TestCase):
 
-    from pyface import qt
+    @skip_if_not_qt4
+    def test_qt_resizable_in_vgroup(self):
+        # Behavior: Item.resizable controls whether a component can resize
+        # along the non-layout axis of its group. In a VGroup, resizing should
+        # work only in the horizontal direction.
 
-    with store_exceptions_on_all_threads():
-        dialog = VResizeDialog()
-        ui = dialog.edit_traits()
+        from pyface import qt
 
-        text = ui.control.findChild(qt.QtGui.QLineEdit)
+        with store_exceptions_on_all_threads():
+            dialog = VResizeDialog()
+            ui = dialog.edit_traits()
 
-        # horizontal size should be large
-        nose.tools.assert_greater(text.width(), _DIALOG_WIDTH - 100)
+            text = ui.control.findChild(qt.QtGui.QLineEdit)
 
-        # vertical size should be unchanged
-        nose.tools.assert_less(text.height(), 100)
+            # horizontal size should be large
+            self.assertGreater(text.width(), _DIALOG_WIDTH - 100)
 
+            # vertical size should be unchanged
+            self.assertLess(text.height(), 100)
 
-@skip_if_not_qt4
-def test_qt_resizable_in_hgroup():
-    # Behavior: Item.resizable controls whether a component can resize along
-    # the non-layout axis of its group. In a HGroup, resizing should work
-    # only in the vertical direction.
+    @skip_if_not_qt4
+    def test_qt_resizable_in_hgroup(self):
+        # Behavior: Item.resizable controls whether a component can resize
+        # along the non-layout axis of its group. In a HGroup, resizing should
+        # work only in the vertical direction.
 
-    from pyface import qt
+        from pyface import qt
 
-    with store_exceptions_on_all_threads():
-        dialog = HResizeDialog()
-        ui = dialog.edit_traits()
+        with store_exceptions_on_all_threads():
+            dialog = HResizeDialog()
+            ui = dialog.edit_traits()
 
-        text = ui.control.findChild(qt.QtGui.QLineEdit)
+            text = ui.control.findChild(qt.QtGui.QLineEdit)
 
-        # vertical size should be large
-        nose.tools.assert_greater(text.height(), _DIALOG_HEIGHT - 100)
+            # vertical size should be large
+            self.assertGreater(text.height(), _DIALOG_HEIGHT - 100)
 
-        # horizontal size should be unchanged
-        # ??? maybe not: some elements (e.g., the text field) have
-        # 'Expanding' as their default behavior
-        # nose.tools.assert_less(text.width(), _TXT_WIDTH+100)
+            # horizontal size should be unchanged
+            # ??? maybe not: some elements (e.g., the text field) have
+            # 'Expanding' as their default behavior
+            # self.assertLess(text.width(), _TXT_WIDTH+100)
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -172,7 +172,7 @@ class TestUI(unittest.TestCase):
 
         # press the OK button and close the dialog
         okbutton = ui.control.FindWindowByName("button", ui.control)
-        assert okbutton.Label == 'OK'
+        self.assertEqual(okbutton.Label, 'OK')
 
         click_event = wx.CommandEvent(
             wx.wxEVT_COMMAND_BUTTON_CLICKED, okbutton.GetId()

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -17,7 +17,7 @@
 Test cases for the UI object.
 """
 
-import nose
+import unittest
 
 from traits.has_traits import HasTraits, HasStrictTraits
 from traits.trait_types import Str, Int
@@ -25,7 +25,12 @@ import traitsui
 from traitsui.item import Item, spring
 from traitsui.view import View
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    count_calls,
+    skip_if_not_qt4,
+    skip_if_not_wx,
+    skip_if_null,
+)
 
 
 class FooDialog(HasTraits):
@@ -46,168 +51,164 @@ class DisallowNewTraits(HasStrictTraits):
     traits_view = View(Item("x"), spring)
 
 
-@skip_if_not_wx
-def test_reset_with_destroy_wx():
-    # Characterization test:
-    # UI.reset(destroy=True) destroys all ui children of the top control
+class TestUI(unittest.TestCase):
 
-    foo = FooDialog()
-    ui = foo.edit_traits()
+    @skip_if_not_wx
+    def test_reset_with_destroy_wx(self):
+        # Characterization test:
+        # UI.reset(destroy=True) destroys all ui children of the top control
 
-    ui.reset(destroy=True)
+        foo = FooDialog()
+        ui = foo.edit_traits()
 
-    # the top control is still there
-    nose.tools.assert_is_not_none(ui.control)
-    # but its children are gone
-    nose.tools.assert_equal(len(ui.control.GetChildren()), 0)
+        ui.reset(destroy=True)
 
+        # the top control is still there
+        self.assertIsNotNone(ui.control)
+        # but its children are gone
+        self.assertEqual(len(ui.control.GetChildren()), 0)
 
-@skip_if_not_qt4
-def test_reset_with_destroy_qt():
-    # Characterization test:
-    # UI.reset(destroy=True) destroys all ui children of the top control
+    @skip_if_not_qt4
+    def test_reset_with_destroy_qt(self):
+        # Characterization test:
+        # UI.reset(destroy=True) destroys all ui children of the top control
 
-    from pyface import qt
+        from pyface import qt
 
-    foo = FooDialog()
-    ui = foo.edit_traits()
+        foo = FooDialog()
+        ui = foo.edit_traits()
 
-    # decorate children's `deleteLater` function to check that it is called
-    # on `reset`. check only with the editor parts (only widgets are scheduled,
-    # see traitsui.qt4.toolkit.GUIToolkit.destroy_children)
-    for c in ui.control.children():
-        c.deleteLater = count_calls(c.deleteLater)
+        # decorate children's `deleteLater` function to check that it is called
+        # on `reset`. check only with the editor parts (only widgets are
+        # scheduled, see traitsui.qt4.toolkit.GUIToolkit.destroy_children)
+        for c in ui.control.children():
+            c.deleteLater = count_calls(c.deleteLater)
 
-    ui.reset(destroy=True)
+        ui.reset(destroy=True)
 
-    # the top control is still there
-    nose.tools.assert_is_not_none(ui.control)
+        # the top control is still there
+        self.assertIsNotNone(ui.control)
 
-    # but its children are scheduled for removal
-    for c in ui.control.children():
-        if isinstance(c, qt.QtGui.QWidget):
-            nose.tools.assert_equal(c.deleteLater._n_calls, 1)
+        # but its children are scheduled for removal
+        for c in ui.control.children():
+            if isinstance(c, qt.QtGui.QWidget):
+                self.assertEqual(c.deleteLater._n_calls, 1)
 
+    @skip_if_not_wx
+    def test_reset_without_destroy_wx(self):
+        # Characterization test:
+        # UI.reset(destroy=False) destroys all editor controls, but leaves
+        # editors and ui children intact
 
-@skip_if_not_wx
-def test_reset_without_destroy_wx():
-    # Characterization test:
-    # UI.reset(destroy=False) destroys all editor controls, but leaves editors
-    # and ui children intact
+        import wx
 
-    import wx
+        foo = FooDialog()
+        ui = foo.edit_traits()
 
-    foo = FooDialog()
-    ui = foo.edit_traits()
+        self.assertEqual(len(ui._editors), 2)
+        self.assertIsInstance(
+            ui._editors[0], traitsui.wx.text_editor.SimpleEditor
+        )
+        self.assertIsInstance(
+            ui._editors[0].control, wx.TextCtrl
+        )
 
-    nose.tools.assert_equal(len(ui._editors), 2)
-    nose.tools.assert_is_instance(
-        ui._editors[0], traitsui.wx.text_editor.SimpleEditor
-    )
-    nose.tools.assert_is_instance(
-        ui._editors[0].control, wx.TextCtrl
-    )
+        ui.reset(destroy=False)
 
-    ui.reset(destroy=False)
+        self.assertEqual(len(ui._editors), 2)
+        self.assertIsInstance(
+            ui._editors[0], traitsui.wx.text_editor.SimpleEditor
+        )
+        self.assertIsNone(ui._editors[0].control)
 
-    nose.tools.assert_equal(len(ui._editors), 2)
-    nose.tools.assert_is_instance(
-        ui._editors[0], traitsui.wx.text_editor.SimpleEditor
-    )
-    nose.tools.assert_is_none(ui._editors[0].control)
+        # children are still there: check first text control
+        text_ctrl = ui.control.FindWindowByName("text")
+        self.assertIsNotNone(text_ctrl)
 
-    # children are still there: check first text control
-    text_ctrl = ui.control.FindWindowByName("text")
-    nose.tools.assert_is_not_none(text_ctrl)
+    @skip_if_not_qt4
+    def test_reset_without_destroy_qt(self):
+        # Characterization test:
+        # UI.reset(destroy=False) destroys all editor controls, but leaves
+        # editors and ui children intact
 
+        from pyface import qt
 
-@skip_if_not_qt4
-def test_reset_without_destroy_qt():
-    # Characterization test:
-    # UI.reset(destroy=False) destroys all editor controls, but leaves editors
-    # and ui children intact
+        foo = FooDialog()
+        ui = foo.edit_traits()
 
-    from pyface import qt
+        self.assertEqual(len(ui._editors), 2)
+        self.assertIsInstance(
+            ui._editors[0], traitsui.qt4.text_editor.SimpleEditor
+        )
+        self.assertIsInstance(ui._editors[0].control, qt.QtGui.QLineEdit)
 
-    foo = FooDialog()
-    ui = foo.edit_traits()
+        ui.reset(destroy=False)
 
-    nose.tools.assert_equal(len(ui._editors), 2)
-    nose.tools.assert_is_instance(
-        ui._editors[0], traitsui.qt4.text_editor.SimpleEditor
-    )
-    nose.tools.assert_is_instance(ui._editors[0].control, qt.QtGui.QLineEdit)
+        self.assertEqual(len(ui._editors), 2)
+        self.assertIsInstance(
+            ui._editors[0], traitsui.qt4.text_editor.SimpleEditor
+        )
+        self.assertIsNone(ui._editors[0].control)
 
-    ui.reset(destroy=False)
+        # children are still there: check first text control
+        text_ctrl = ui.control.findChild(qt.QtGui.QLineEdit)
+        self.assertIsNotNone(text_ctrl)
 
-    nose.tools.assert_equal(len(ui._editors), 2)
-    nose.tools.assert_is_instance(
-        ui._editors[0], traitsui.qt4.text_editor.SimpleEditor
-    )
-    nose.tools.assert_is_none(ui._editors[0].control)
+    @skip_if_not_wx
+    def test_destroy_after_ok_wx(self):
+        # Behavior: after pressing 'OK' in a dialog, the method UI.finish is
+        # called and the view control and its children are destroyed
 
-    # children are still there: check first text control
-    text_ctrl = ui.control.findChild(qt.QtGui.QLineEdit)
-    nose.tools.assert_is_not_none(text_ctrl)
+        import wx
 
+        foo = FooDialog()
+        ui = foo.edit_traits()
 
-@skip_if_not_wx
-def test_destroy_after_ok_wx():
-    # Behavior: after pressing 'OK' in a dialog, the method UI.finish is
-    # called and the view control and its children are destroyed
+        # keep reference to the control to check that it was destroyed
+        control = ui.control
 
-    import wx
+        # decorate control's `Destroy` function to check that it is called
+        control.Destroy = count_calls(control.Destroy)
 
-    foo = FooDialog()
-    ui = foo.edit_traits()
+        # press the OK button and close the dialog
+        okbutton = ui.control.FindWindowByName("button", ui.control)
+        assert okbutton.Label == 'OK'
 
-    # keep reference to the control to check that it was destroyed
-    control = ui.control
+        click_event = wx.CommandEvent(
+            wx.wxEVT_COMMAND_BUTTON_CLICKED, okbutton.GetId()
+        )
+        okbutton.ProcessEvent(click_event)
 
-    # decorate control's `Destroy` function to check that it is called
-    control.Destroy = count_calls(control.Destroy)
+        self.assertIsNone(ui.control)
+        self.assertEqual(control.Destroy._n_calls, 1)
 
-    # press the OK button and close the dialog
-    okbutton = ui.control.FindWindowByName("button", ui.control)
-    assert okbutton.Label == 'OK'
+    @skip_if_not_qt4
+    def test_destroy_after_ok_qt(self):
+        # Behavior: after pressing 'OK' in a dialog, the method UI.finish is
+        # called and the view control and its children are destroyed
 
-    click_event = wx.CommandEvent(
-        wx.wxEVT_COMMAND_BUTTON_CLICKED, okbutton.GetId()
-    )
-    okbutton.ProcessEvent(click_event)
+        from pyface import qt
 
-    nose.tools.assert_is_none(ui.control)
-    nose.tools.assert_equal(control.Destroy._n_calls, 1)
+        foo = FooDialog()
+        ui = foo.edit_traits()
 
+        # keep reference to the control to check that it was deleted
+        control = ui.control
 
-@skip_if_not_qt4
-def test_destroy_after_ok_qt():
-    # Behavior: after pressing 'OK' in a dialog, the method UI.finish is
-    # called and the view control and its children are destroyed
+        # decorate control's `deleteLater` function to check that it is called
+        control.deleteLater = count_calls(control.deleteLater)
 
-    from pyface import qt
+        # press the OK button and close the dialog
+        okb = control.findChild(qt.QtGui.QPushButton)
+        okb.click()
 
-    foo = FooDialog()
-    ui = foo.edit_traits()
+        self.assertIsNone(ui.control)
+        self.assertEqual(control.deleteLater._n_calls, 1)
 
-    # keep reference to the control to check that it was deleted
-    control = ui.control
+    @skip_if_null
+    def test_no_spring_trait(self):
+        obj = DisallowNewTraits()
+        ui = obj.edit_traits()
+        ui.dispose()
 
-    # decorate control's `deleteLater` function to check that it is called
-    control.deleteLater = count_calls(control.deleteLater)
-
-    # press the OK button and close the dialog
-    okb = control.findChild(qt.QtGui.QPushButton)
-    okb.click()
-
-    nose.tools.assert_is_none(ui.control)
-    nose.tools.assert_equal(control.deleteLater._n_calls, 1)
-
-
-@skip_if_null
-def test_no_spring_trait():
-    obj = DisallowNewTraits()
-    ui = obj.edit_traits()
-    ui.dispose()
-
-    nose.tools.assert_true("spring" not in obj.traits())
+        self.assertTrue("spring" not in obj.traits())

--- a/traitsui/tests/test_visible_when_layout.py
+++ b/traitsui/tests/test_visible_when_layout.py
@@ -17,7 +17,7 @@
 Test the layout when element appear and disappear with visible_when.
 """
 
-import nose
+import unittest
 
 from traits.has_traits import HasTraits
 from traits.trait_types import Enum, Bool, Str
@@ -27,7 +27,11 @@ from traitsui.include import Include
 from traitsui.item import Item
 from traitsui.view import View
 
-from traitsui.tests._tools import *
+from traitsui.tests._tools import (
+    get_dialog_size,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
 
 _TEXT_WIDTH = 200
 _TEXT_HEIGHT = 100
@@ -71,29 +75,31 @@ class VisibleWhenProblem(HasTraits):
 # there are no current plans to work on this.
 
 
-@skip_if_not_qt4
-def test_visible_when_layout():
-    # Bug: The size of a dialog that contains elements that are activated
-    # by "visible_when" can end up being the *sum* of the sizes of the
-    # elements, even though the elements are mutually exclusive (e.g.,
-    # a typical case is a dropbox that lets you select different cases).
-    # The expected behavior is that the size of the dialog should be at most
-    # the size of the largest combination of elements.
+class TestVisibleWhenLayout(unittest.TestCase):
 
-    with store_exceptions_on_all_threads():
-        dialog = VisibleWhenProblem()
-        ui = dialog.edit_traits()
+    @skip_if_not_qt4
+    def test_visible_when_layout(self):
+        # Bug: The size of a dialog that contains elements that are activated
+        # by "visible_when" can end up being the *sum* of the sizes of the
+        # elements, even though the elements are mutually exclusive (e.g.,
+        # a typical case is a dropbox that lets you select different cases).
+        # The expected behavior is that the size of the dialog should be at
+        # most the size of the largest combination of elements.
 
-        # have the dialog switch from group one to two and back to one
-        dialog.which = "two"
-        dialog.which = "one"
+        with store_exceptions_on_all_threads():
+            dialog = VisibleWhenProblem()
+            ui = dialog.edit_traits()
 
-        # the size of the window should not be larger than the largest
-        # combination (in this case, the `text_group` plus the `which` item
-        size = get_dialog_size(ui.control)
-        # leave some margin for labels, dropbox, etc
-        nose.tools.assert_less(size[0], _TEXT_WIDTH + 100)
-        nose.tools.assert_less(size[1], _TEXT_HEIGHT + 150)
+            # have the dialog switch from group one to two and back to one
+            dialog.which = "two"
+            dialog.which = "one"
+
+            # the size of the window should not be larger than the largest
+            # combination (in this case, the `text_group` plus the `which` item
+            size = get_dialog_size(ui.control)
+            # leave some margin for labels, dropbox, etc
+            self.assertLess(size[0], _TEXT_WIDTH + 100)
+            self.assertLess(size[1], _TEXT_HEIGHT + 150)
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -6,16 +6,15 @@
 #  under the conditions described in the aforementioned license.  The license
 #  is also available online at http://www.enthought.com/licenses/BSD.txt
 
-import nose
+import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
 
 try:
     from pandas import DataFrame
-except ImportError as exc:
-    print("Can't import Pandas: skipping")
-    raise nose.SkipTest
+except ImportError:
+    raise unittest.SkipTest("Can't import Pandas: skipping")
 
 from traits.api import Event, HasTraits, Instance
 
@@ -88,411 +87,409 @@ def sample_text_data():
     return viewer
 
 
-@skip_if_null
-def test_adapter_get_item():
-    viewer = sample_data()
-    adapter = DataFrameAdapter()
+class TestDataFrameEditor(unittest.TestCase):
 
-    item_0_df = adapter.get_item(viewer, "data", 0)
+    @skip_if_null
+    def test_adapter_get_item(self):
+        viewer = sample_data()
+        adapter = DataFrameAdapter()
 
-    assert_array_equal(item_0_df.values, [[0, 1, 2]])
-    assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
-    assert item_0_df.index[0] == "one"
+        item_0_df = adapter.get_item(viewer, "data", 0)
 
+        assert_array_equal(item_0_df.values, [[0, 1, 2]])
+        assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
+        assert item_0_df.index[0] == "one"
 
-@skip_if_null
-def test_adapter_empty_dataframe():
-    data = DataFrame()
-    viewer = DataFrameViewer(data=data)
-    adapter = DataFrameAdapter()
+    @skip_if_null
+    def test_adapter_empty_dataframe(self):
+        data = DataFrame()
+        viewer = DataFrameViewer(data=data)
+        adapter = DataFrameAdapter()
 
-    item_0_df = adapter.get_item(viewer, "data", 0)
+        item_0_df = adapter.get_item(viewer, "data", 0)
 
-    assert_array_equal(item_0_df.values, np.array([]).reshape(0, 0))
-    assert_array_equal(item_0_df.columns, [])
+        assert_array_equal(item_0_df.values, np.array([]).reshape(0, 0))
+        assert_array_equal(item_0_df.columns, [])
 
+    @skip_if_null
+    def test_adapter_no_rows(self):
+        data = DataFrame(columns=["X", "Y", "Z"])
+        viewer = DataFrameViewer(data=data)
+        adapter = DataFrameAdapter()
 
-@skip_if_null
-def test_adapter_no_rows():
-    data = DataFrame(columns=["X", "Y", "Z"])
-    viewer = DataFrameViewer(data=data)
-    adapter = DataFrameAdapter()
+        item_0_df = adapter.get_item(viewer, "data", 0)
 
-    item_0_df = adapter.get_item(viewer, "data", 0)
+        assert_array_equal(item_0_df.values, np.array([]).reshape(0, 3))
+        assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
 
-    assert_array_equal(item_0_df.values, np.array([]).reshape(0, 3))
-    assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
+    @skip_if_null
+    def test_adapter_get_item_numerical(self):
+        viewer = sample_data_numerical_index()
+        adapter = DataFrameAdapter()
 
+        item_0_df = adapter.get_item(viewer, "data", 0)
 
-@skip_if_null
-def test_adapter_get_item_numerical():
-    viewer = sample_data_numerical_index()
-    adapter = DataFrameAdapter()
+        assert_array_equal(item_0_df.values, [[0, 1, 2]])
+        assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
+        assert item_0_df.index[0] == 1
 
-    item_0_df = adapter.get_item(viewer, "data", 0)
+    @skip_if_null
+    def test_adapter_delete_start(self):
+        viewer = sample_data()
+        adapter = DataFrameAdapter()
 
-    assert_array_equal(item_0_df.values, [[0, 1, 2]])
-    assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
-    assert item_0_df.index[0] == 1
+        adapter.delete(viewer, "data", 0)
+        data = viewer.data
 
+        assert_array_equal(data.values, [[3, 4, 5], [6, 7, 8], [9, 10, 11]])
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, ["two", "three", "four"])
 
-@skip_if_null
-def test_adapter_delete_start():
-    viewer = sample_data()
-    adapter = DataFrameAdapter()
+    @skip_if_null
+    def test_adapter_delete_start_numerical_index(self):
+        viewer = sample_data_numerical_index()
+        adapter = DataFrameAdapter()
 
-    adapter.delete(viewer, "data", 0)
-    data = viewer.data
+        adapter.delete(viewer, "data", 0)
+        data = viewer.data
 
-    assert_array_equal(data.values, [[3, 4, 5], [6, 7, 8], [9, 10, 11]])
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, ["two", "three", "four"])
+        assert_array_equal(data.values, [[3, 4, 5], [6, 7, 8], [9, 10, 11]])
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, [2, 3, 4])
 
+    @skip_if_null
+    def test_adapter_delete_middle(self):
+        viewer = sample_data()
+        adapter = DataFrameAdapter()
 
-@skip_if_null
-def test_adapter_delete_start_numerical_index():
-    viewer = sample_data_numerical_index()
-    adapter = DataFrameAdapter()
+        adapter.delete(viewer, "data", 1)
+        data = viewer.data
 
-    adapter.delete(viewer, "data", 0)
-    data = viewer.data
+        assert_array_equal(data.values, [[0, 1, 2], [6, 7, 8], [9, 10, 11]])
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, ["one", "three", "four"])
 
-    assert_array_equal(data.values, [[3, 4, 5], [6, 7, 8], [9, 10, 11]])
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, [2, 3, 4])
+    @skip_if_null
+    def test_adapter_delete_middle_numerical_index(self):
+        viewer = sample_data_numerical_index()
+        adapter = DataFrameAdapter()
 
+        adapter.delete(viewer, "data", 1)
+        data = viewer.data
 
-@skip_if_null
-def test_adapter_delete_middle():
-    viewer = sample_data()
-    adapter = DataFrameAdapter()
+        assert_array_equal(data.values, [[0, 1, 2], [6, 7, 8], [9, 10, 11]])
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, [1, 3, 4])
 
-    adapter.delete(viewer, "data", 1)
-    data = viewer.data
+    @skip_if_null
+    def test_adapter_delete_end(self):
+        viewer = sample_data()
+        adapter = DataFrameAdapter()
 
-    assert_array_equal(data.values, [[0, 1, 2], [6, 7, 8], [9, 10, 11]])
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, ["one", "three", "four"])
-
-
-@skip_if_null
-def test_adapter_delete_middle_numerical_index():
-    viewer = sample_data_numerical_index()
-    adapter = DataFrameAdapter()
-
-    adapter.delete(viewer, "data", 1)
-    data = viewer.data
-
-    assert_array_equal(data.values, [[0, 1, 2], [6, 7, 8], [9, 10, 11]])
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, [1, 3, 4])
-
-
-@skip_if_null
-def test_adapter_delete_end():
-    viewer = sample_data()
-    adapter = DataFrameAdapter()
-
-    adapter.delete(viewer, "data", 3)
-    data = viewer.data
-
-    assert_array_equal(data.values, [[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, ["one", "two", "three"])
-
-
-@skip_if_null
-def test_adapter_delete_end_numerical_index():
-    viewer = sample_data_numerical_index()
-    adapter = DataFrameAdapter()
-
-    adapter.delete(viewer, "data", 3)
-    data = viewer.data
-
-    assert_array_equal(data.values, [[0, 1, 2], [3, 4, 5], [6, 7, 8]])
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, [1, 2, 3])
-
-
-@skip_if_null
-def test_adapter_insert_start():
-    viewer = sample_data()
-    adapter = DataFrameAdapter()
-    item = DataFrame([[-3, -2, -1]], index=["new"], columns=["X", "Y", "Z"])
-
-    adapter.insert(viewer, "data", 0, item)
-    data = viewer.data
-
-    assert_array_equal(
-        data.values,
-        [[-3, -2, -1], [0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
-    )
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, ["new", "one", "two", "three", "four"])
-
-
-@skip_if_null
-def test_adapter_insert_start_numerical_index():
-    viewer = sample_data_numerical_index()
-    adapter = DataFrameAdapter()
-    item = DataFrame([[-3, -2, -1]], index=[0], columns=["X", "Y", "Z"])
-
-    adapter.insert(viewer, "data", 0, item)
-    data = viewer.data
-
-    assert_array_equal(
-        data.values,
-        [[-3, -2, -1], [0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
-    )
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, [0, 1, 2, 3, 4])
-
-
-@skip_if_null
-def test_adapter_insert_middle():
-    viewer = sample_data()
-    adapter = DataFrameAdapter()
-    item = DataFrame([[-3, -2, -1]], index=["new"], columns=["X", "Y", "Z"])
-
-    adapter.insert(viewer, "data", 1, item)
-    data = viewer.data
-
-    assert_array_equal(
-        data.values,
-        [[0, 1, 2], [-3, -2, -1], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
-    )
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, ["one", "new", "two", "three", "four"])
-
-
-@skip_if_null
-def test_adapter_insert_middle_numerical_index():
-    viewer = sample_data_numerical_index()
-    adapter = DataFrameAdapter()
-    item = DataFrame([[-3, -2, -1]], index=[0], columns=["X", "Y", "Z"])
-
-    adapter.insert(viewer, "data", 1, item)
-    data = viewer.data
-
-    assert_array_equal(
-        data.values,
-        [[0, 1, 2], [-3, -2, -1], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
-    )
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, [1, 0, 2, 3, 4])
-
-
-@skip_if_null
-def test_adapter_insert_end():
-    viewer = sample_data()
-    adapter = DataFrameAdapter()
-    item = DataFrame([[-3, -2, -1]], index=["new"], columns=["X", "Y", "Z"])
-
-    adapter.insert(viewer, "data", 5, item)
-    data = viewer.data
-
-    assert_array_equal(
-        data.values,
-        [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [-3, -2, -1]],
-    )
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, ["one", "two", "three", "four", "new"])
-
-
-@skip_if_null
-def test_adapter_insert_end_numerical_index():
-    viewer = sample_data_numerical_index()
-    adapter = DataFrameAdapter()
-    item = DataFrame([[-3, -2, -1]], index=[0], columns=["X", "Y", "Z"])
-
-    adapter.insert(viewer, "data", 5, item)
-    data = viewer.data
-
-    assert_array_equal(
-        data.values,
-        [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [-3, -2, -1]],
-    )
-    assert_array_equal(data.columns, ["X", "Y", "Z"])
-    assert_array_equal(data.index, [1, 2, 3, 4, 0])
-
-
-@skip_if_null
-def test_data_frame_editor():
-    viewer = sample_data()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits()
-        ui.dispose()
-
-
-@skip_if_null
-def test_data_frame_editor_alternate_adapter():
-    class AlternateAdapter(DataFrameAdapter):
-        pass
-
-    alternate_adapter_view = View(
-        Item(
-            "data",
-            editor=DataFrameEditor(adapter=AlternateAdapter()),
-            width=400,
+        adapter.delete(viewer, "data", 3)
+        data = viewer.data
+
+        assert_array_equal(data.values, [[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, ["one", "two", "three"])
+
+    @skip_if_null
+    def test_adapter_delete_end_numerical_index(self):
+        viewer = sample_data_numerical_index()
+        adapter = DataFrameAdapter()
+
+        adapter.delete(viewer, "data", 3)
+        data = viewer.data
+
+        assert_array_equal(data.values, [[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, [1, 2, 3])
+
+    @skip_if_null
+    def test_adapter_insert_start(self):
+        viewer = sample_data()
+        adapter = DataFrameAdapter()
+        item = DataFrame(
+            [[-3, -2, -1]], index=["new"], columns=["X", "Y", "Z"]
         )
-    )
-    viewer = sample_data()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits(view=alternate_adapter_view)
-        ui.dispose()
 
+        adapter.insert(viewer, "data", 0, item)
+        data = viewer.data
 
-@skip_if_null
-def test_data_frame_editor_numerical_index():
-    viewer = sample_data_numerical_index()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits()
-        ui.dispose()
+        assert_array_equal(
+            data.values,
+            [[-3, -2, -1], [0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
+        )
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, ["new", "one", "two", "three", "four"])
 
+    @skip_if_null
+    def test_adapter_insert_start_numerical_index(self):
+        viewer = sample_data_numerical_index()
+        adapter = DataFrameAdapter()
+        item = DataFrame([[-3, -2, -1]], index=[0], columns=["X", "Y", "Z"])
 
-@skip_if_null
-def test_data_frame_editor_text_data():
-    viewer = sample_text_data()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits()
-        ui.dispose()
+        adapter.insert(viewer, "data", 0, item)
+        data = viewer.data
 
+        assert_array_equal(
+            data.values,
+            [[-3, -2, -1], [0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
+        )
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, [0, 1, 2, 3, 4])
 
-@skip_if_null
-def test_data_frame_editor_format_mapping():
-    viewer = sample_data()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits(view=format_mapping_view)
-        ui.dispose()
+    @skip_if_null
+    def test_adapter_insert_middle(self):
+        viewer = sample_data()
+        adapter = DataFrameAdapter()
+        item = DataFrame(
+            [[-3, -2, -1]], index=["new"], columns=["X", "Y", "Z"]
+        )
 
+        adapter.insert(viewer, "data", 1, item)
+        data = viewer.data
 
-@skip_if_null
-def test_data_frame_editor_font_mapping():
-    viewer = sample_data()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits(view=font_mapping_view)
-        ui.dispose()
+        assert_array_equal(
+            data.values,
+            [[0, 1, 2], [-3, -2, -1], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
+        )
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, ["one", "new", "two", "three", "four"])
 
+    @skip_if_null
+    def test_adapter_insert_middle_numerical_index(self):
+        viewer = sample_data_numerical_index()
+        adapter = DataFrameAdapter()
+        item = DataFrame([[-3, -2, -1]], index=[0], columns=["X", "Y", "Z"])
 
-@skip_if_null
-def test_data_frame_editor_columns():
-    viewer = sample_data()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits(view=columns_view)
-        ui.dispose()
+        adapter.insert(viewer, "data", 1, item)
+        data = viewer.data
 
+        assert_array_equal(
+            data.values,
+            [[0, 1, 2], [-3, -2, -1], [3, 4, 5], [6, 7, 8], [9, 10, 11]],
+        )
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, [1, 0, 2, 3, 4])
 
-@skip_if_null
-def test_data_frame_editor_with_update_refresh():
-    class DataFrameViewer(HasTraits):
-        data = Instance(DataFrame)
-        df_updated = Event()
-        view = View(Item("data", editor=DataFrameEditor(update="df_updated")))
+    @skip_if_null
+    def test_adapter_insert_end(self):
+        viewer = sample_data()
+        adapter = DataFrameAdapter()
+        item = DataFrame(
+            [[-3, -2, -1]], index=["new"], columns=["X", "Y", "Z"]
+        )
 
-    df = DataFrame(
-        DATA, index=["one", "two", "three", "four"], columns=["X", "Y", "Z"]
-    )
-    viewer = DataFrameViewer(data=df)
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits()
-        viewer.df_updated = True
-        ui.dispose()
+        adapter.insert(viewer, "data", 5, item)
+        data = viewer.data
 
+        assert_array_equal(
+            data.values,
+            [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [-3, -2, -1]],
+        )
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, ["one", "two", "three", "four", "new"])
 
-@skip_if_null
-def test_data_frame_editor_with_refresh():
-    class DataFrameViewer(HasTraits):
-        data = Instance(DataFrame)
-        df_refreshed = Event()
+    @skip_if_null
+    def test_adapter_insert_end_numerical_index(self):
+        viewer = sample_data_numerical_index()
+        adapter = DataFrameAdapter()
+        item = DataFrame([[-3, -2, -1]], index=[0], columns=["X", "Y", "Z"])
+
+        adapter.insert(viewer, "data", 5, item)
+        data = viewer.data
+
+        assert_array_equal(
+            data.values,
+            [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [-3, -2, -1]],
+        )
+        assert_array_equal(data.columns, ["X", "Y", "Z"])
+        assert_array_equal(data.index, [1, 2, 3, 4, 0])
+
+    @skip_if_null
+    def test_data_frame_editor(self):
+        viewer = sample_data()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits()
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_alternate_adapter(self):
+        class AlternateAdapter(DataFrameAdapter):
+            pass
+
+        alternate_adapter_view = View(
+            Item(
+                "data",
+                editor=DataFrameEditor(adapter=AlternateAdapter()),
+                width=400,
+            )
+        )
+        viewer = sample_data()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits(view=alternate_adapter_view)
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_numerical_index(self):
+        viewer = sample_data_numerical_index()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits()
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_text_data(self):
+        viewer = sample_text_data()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits()
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_format_mapping(self):
+        viewer = sample_data()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits(view=format_mapping_view)
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_font_mapping(self):
+        viewer = sample_data()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits(view=font_mapping_view)
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_columns(self):
+        viewer = sample_data()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits(view=columns_view)
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_with_update_refresh(self):
+        class DataFrameViewer(HasTraits):
+            data = Instance(DataFrame)
+            df_updated = Event()
+            view = View(
+                Item("data", editor=DataFrameEditor(update="df_updated"))
+            )
+
+        df = DataFrame(
+            DATA,
+            index=["one", "two", "three", "four"],
+            columns=["X", "Y", "Z"]
+        )
+        viewer = DataFrameViewer(data=df)
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits()
+            viewer.df_updated = True
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_with_refresh(self):
+        class DataFrameViewer(HasTraits):
+            data = Instance(DataFrame)
+            df_refreshed = Event()
+            view = View(
+                Item("data", editor=DataFrameEditor(refresh="df_refreshed"))
+            )
+
+        df = DataFrame(
+            DATA,
+            index=["one", "two", "three", "four"],
+            columns=["X", "Y", "Z"]
+        )
+        viewer = DataFrameViewer(data=df)
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits()
+            viewer.df_refreshed = True
+            ui.dispose()
+
+    @skip_if_null
+    def test_data_frame_editor_multi_select(self):
         view = View(
-            Item("data", editor=DataFrameEditor(refresh="df_refreshed"))
+            Item("data", editor=DataFrameEditor(multi_select=True), width=400)
         )
+        viewer = sample_data()
+        with store_exceptions_on_all_threads():
+            ui = viewer.edit_traits(view=view)
+            ui.dispose()
 
-    df = DataFrame(
-        DATA, index=["one", "two", "three", "four"], columns=["X", "Y", "Z"]
-    )
-    viewer = DataFrameViewer(data=df)
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits()
-        viewer.df_refreshed = True
-        ui.dispose()
+    @skip_if_null
+    def test_adapter_set_text(self):
+        viewer = sample_data()
+        columns = [(column, column) for column in viewer.data.columns]
+        adapter = DataFrameAdapter(columns=columns)
 
+        adapter.set_text(viewer, 'data', 0, 0, '10')
 
-@skip_if_null
-def test_data_frame_editor_multi_select():
-    view = View(
-        Item("data", editor=DataFrameEditor(multi_select=True), width=400)
-    )
-    viewer = sample_data()
-    with store_exceptions_on_all_threads():
-        ui = viewer.edit_traits(view=view)
-        ui.dispose()
+        item_0_df = adapter.get_item(viewer, 'data', 0)
 
-@skip_if_null
-def test_adapter_set_text():
-    viewer = sample_data()
-    columns = [(column, column) for column in viewer.data.columns]
-    adapter = DataFrameAdapter(columns=columns)
+        assert_array_equal(item_0_df.values, [[10, 1, 2]])
+        assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
 
-    adapter.set_text(viewer, 'data', 0, 0, '10')
+    @skip_if_null
+    def test_adapter_set_text_invalid(self):
+        viewer = sample_data()
+        columns = [(column, column) for column in viewer.data.columns]
+        adapter = DataFrameAdapter(columns=columns)
 
-    item_0_df = adapter.get_item(viewer, 'data', 0)
+        adapter.set_text(viewer, 'data', 0, 0, 'invalid')
 
-    assert_array_equal(item_0_df.values, [[10, 1, 2]])
-    assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
+        # expect no error, and values unchanged
+        item_0_df = adapter.get_item(viewer, 'data', 0)
 
-@skip_if_null
-def test_adapter_set_text_invalid():
-    viewer = sample_data()
-    columns = [(column, column) for column in viewer.data.columns]
-    adapter = DataFrameAdapter(columns=columns)
+        assert_array_equal(item_0_df.values, [[0, 1, 2]])
+        assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
 
-    adapter.set_text(viewer, 'data', 0, 0, 'invalid')
+    @skip_if_null
+    def test_adapter_set_index_text(self):
+        viewer = sample_data()
+        columns = (
+            [('', 'index')] +
+            [(column, column) for column in viewer.data.columns]
+        )
+        adapter = DataFrameAdapter(columns=columns)
 
-    # expect no error, and values unchanged
-    item_0_df = adapter.get_item(viewer, 'data', 0)
+        adapter.set_text(viewer, 'data', 0, 0, 'NewIndex')
 
-    assert_array_equal(item_0_df.values, [[0, 1, 2]])
-    assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
+        item_0_df = adapter.get_item(viewer, 'data', 0)
 
-@skip_if_null
-def test_adapter_set_index_text():
-    viewer = sample_data()
-    columns = [('', 'index')] + [(column, column) for column in viewer.data.columns]
-    adapter = DataFrameAdapter(columns=columns)
+        assert_array_equal(item_0_df.values, [[0, 1, 2]])
+        assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
+        assert item_0_df.index[0] == 'NewIndex'
 
-    adapter.set_text(viewer, 'data', 0, 0, 'NewIndex')
+    @skip_if_null
+    def test_adapter_set_index_text_numeric(self):
+        viewer = sample_data_numerical_index()
+        columns = (
+            [('', 'index')] +
+            [(column, column) for column in viewer.data.columns]
+        )
+        adapter = DataFrameAdapter(columns=columns)
 
-    item_0_df = adapter.get_item(viewer, 'data', 0)
+        adapter.set_text(viewer, 'data', 0, 0, 100)
 
-    assert_array_equal(item_0_df.values, [[0, 1, 2]])
-    assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
-    assert item_0_df.index[0] == 'NewIndex'
+        item_0_df = adapter.get_item(viewer, 'data', 0)
 
-@skip_if_null
-def test_adapter_set_index_text_numeric():
-    viewer = sample_data_numerical_index()
-    columns = [('', 'index')] + [(column, column) for column in viewer.data.columns]
-    adapter = DataFrameAdapter(columns=columns)
+        assert_array_equal(item_0_df.values, [[0, 1, 2]])
+        assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
+        assert item_0_df.index[0] == 100
 
-    adapter.set_text(viewer, 'data', 0, 0, 100)
+    @skip_if_null
+    def test_adapter_set_index_text_numeric_invalid(self):
+        viewer = sample_data_numerical_index()
+        columns = (
+            [('', 'index')] +
+            [(column, column) for column in viewer.data.columns]
+        )
+        adapter = DataFrameAdapter(columns=columns)
 
-    item_0_df = adapter.get_item(viewer, 'data', 0)
+        adapter.set_text(viewer, 'data', 0, 0, 'invalid')
 
-    assert_array_equal(item_0_df.values, [[0, 1, 2]])
-    assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
-    assert item_0_df.index[0] == 100
+        item_0_df = adapter.get_item(viewer, 'data', 0)
 
-@skip_if_null
-def test_adapter_set_index_text_numeric_invalid():
-    viewer = sample_data_numerical_index()
-    columns = [('', 'index')] + [(column, column) for column in viewer.data.columns]
-    adapter = DataFrameAdapter(columns=columns)
-
-    adapter.set_text(viewer, 'data', 0, 0, 'invalid')
-
-    item_0_df = adapter.get_item(viewer, 'data', 0)
-
-    assert_array_equal(item_0_df.values, [[0, 1, 2]])
-    assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
-    assert item_0_df.index[0] == 1
+        assert_array_equal(item_0_df.values, [[0, 1, 2]])
+        assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
+        assert item_0_df.index[0] == 1

--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -98,7 +98,7 @@ class TestDataFrameEditor(unittest.TestCase):
 
         assert_array_equal(item_0_df.values, [[0, 1, 2]])
         assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
-        assert item_0_df.index[0] == "one"
+        self.assertEqual(item_0_df.index[0], "one")
 
     @skip_if_null
     def test_adapter_empty_dataframe(self):
@@ -131,7 +131,7 @@ class TestDataFrameEditor(unittest.TestCase):
 
         assert_array_equal(item_0_df.values, [[0, 1, 2]])
         assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
-        assert item_0_df.index[0] == 1
+        self.assertEqual(item_0_df.index[0], 1)
 
     @skip_if_null
     def test_adapter_delete_start(self):
@@ -458,7 +458,7 @@ class TestDataFrameEditor(unittest.TestCase):
 
         assert_array_equal(item_0_df.values, [[0, 1, 2]])
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
-        assert item_0_df.index[0] == 'NewIndex'
+        self.assertEqual(item_0_df.index[0], 'NewIndex')
 
     @skip_if_null
     def test_adapter_set_index_text_numeric(self):
@@ -475,7 +475,7 @@ class TestDataFrameEditor(unittest.TestCase):
 
         assert_array_equal(item_0_df.values, [[0, 1, 2]])
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
-        assert item_0_df.index[0] == 100
+        self.assertEqual(item_0_df.index[0], 100)
 
     @skip_if_null
     def test_adapter_set_index_text_numeric_invalid(self):
@@ -492,4 +492,4 @@ class TestDataFrameEditor(unittest.TestCase):
 
         assert_array_equal(item_0_df.values, [[0, 1, 2]])
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
-        assert item_0_df.index[0] == 1
+        self.assertEqual(item_0_df.index[0], 1)


### PR DESCRIPTION
Addresses #613 

All unit test functions have been added to `unittest.TestCase`s. Nose and bare asserts have been replace with unittest assertion methods. All tests are now compatible to be run with unittest test runner.