### PR TITLE
Remove NameError and add default root_dir to tutor.py

### DIFF
--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -43,5 +43,10 @@ if __name__ == '__main__':
         print(usage)
         sys.exit(1)
 
-    root_dir = sys.argv[1]
+    # Determine the root path to use for the tutorial files:
+    if len(sys.argv) == 2:
+        root_dir = sys.argv[1]
+    else:
+        root_dir = os.getcwd()
+
     main(root_dir)

--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -39,7 +39,7 @@ def main(root_dir):
 if __name__ == '__main__':
 
     # Validate the command line arguments:
-    if len(sys.argv) != 2:
+    if len(sys.argv) > 2:
         print(usage)
         sys.exit(1)
 

--- a/examples/tutorials/tutor.py
+++ b/examples/tutorials/tutor.py
@@ -44,8 +44,4 @@ if __name__ == '__main__':
         sys.exit(1)
 
     root_dir = sys.argv[1]
-    try:
-        main(root_dir)
-    except NameError as e:
-        print(e)
-        print(usage)
+    main(root_dir)


### PR DESCRIPTION
Closes #793 - removes the unnecessary `NameError` from `tutor.py`.

This PR also chooses the current directory as default if `root_dir` is omitted. The usage docstring was advertising this behaviour but it was not implemented before.