### PR TITLE
TST: Remove PySide < 2 and PyQt4 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="null pyqt pyside2"
-    - env: RUNTIME=3.6 TOOLKITS="wx pyqt5"
+    - env: RUNTIME=3.6 TOOLKITS="wx"
     - os: osx
-      env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyqt pyside2"
+      env: RUNTIME=3.6 TOOLKITS="null pyqt pyside2"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="wx"
   allow_failures:
-    - env: RUNTIME=3.6 TOOLKITS="wx pyqt5"
+    - env: RUNTIME=3.6 TOOLKITS="wx"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,15 +9,15 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "null pyqt"
+      TOOLKITS: "null"
     - RUNTIME: '3.6'
-      TOOLKITS: "wx pyside2 pyqt5"
+      TOOLKITS: "wx pyside2 pyqt"
 
 matrix:
   fast_finish: true
   allow_failures:
     - RUNTIME: '3.6'
-      TOOLKITS: "wx pyside2 pyqt5"
+      TOOLKITS: "wx pyside2 pyqt"
 
 branches:
   only:

--- a/etstool.py
+++ b/etstool.py
@@ -87,8 +87,8 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.5': {'pyside2', 'pyqt', 'pyqt5', 'null'},
-    '3.6': {'pyside2', 'pyqt', 'pyqt5', 'wx', 'null'},
+    '3.5': {'pyside2', 'pyqt', 'null'},
+    '3.6': {'pyside2', 'pyqt', 'wx', 'null'},
 }
 
 # Default Python version to use in the comamnds below if none is specified.
@@ -110,11 +110,9 @@ dependencies = {
 }
 
 extra_dependencies = {
-    'pyside': {'pyside'},
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
-    'pyqt': {'pyqt<4.12'},  # FIXME: build of 4.12-1 appears to be bad
-    'pyqt5': {'pyqt5'},
+    'pyqt': {'pyqt5'},
     # XXX once wxPython 4 is available in EDM, we will want it here
     'wx': set(),
     'null': set()
@@ -128,10 +126,8 @@ doc_dependencies = {
 }
 
 environment_vars = {
-    'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
-    'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
-    'pyqt5': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt5'},
+    'pyqt': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt5"},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null'},
 }

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -24,8 +24,7 @@ except ImportError:
 __requires__ = ["traits", "pyface>=6.0.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
-    "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt>=5", "pygments"],
-    "pyside": ["pyside>=1.2", "pygments"],
+    "pyside2": ["pyside2", "shiboken2", "pygments"],
     "demo": ["configobj", "docutils"],
 }


### PR DESCRIPTION
Following https://github.com/enthought/pyface/pull/512, traitsui can no longer test again PySide < 2 and PyQt4. New builds on CI currently fail.

This PR removes PySide <2 and PyQt4 from the CI configuration in order to be consistent with Pyface. They are also removed from extra_requires as `pyface.qt` no longer supports these backends.
