### PR TITLE
Allow Travis failures with pyqt5 on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=3.6 TOOLKITS="null pyqt pyside2"
+    - env: RUNTIME=3.6 TOOLKITS="null pyside2"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt"
     - env: RUNTIME=3.6 TOOLKITS="wx"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="null pyqt pyside2"
@@ -18,6 +19,7 @@ matrix:
       env: RUNTIME=3.6 TOOLKITS="wx"
   allow_failures:
     - env: RUNTIME=3.6 TOOLKITS="wx"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true


### PR DESCRIPTION
Follows a comment on another PR: https://github.com/enthought/traitsui/pull/809#issuecomment-627398753

Sets up a separate test run for pyqt5 tests on linux that are allowed to fail.