### PR TITLE
Add --editable flag to etstool install command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -142,7 +142,12 @@ def cli():
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 @click.option('--environment', default=None)
-def install(runtime, toolkit, environment):
+@click.option(
+    "--editable/--not-editable",
+    default=False,
+    help="Install main package in 'editable' mode?  [default: --not-editable]",
+)
+def install(runtime, toolkit, environment, editable):
     """ Install project and dependencies into a clean EDM environment.
 
     """
@@ -152,14 +157,21 @@ def install(runtime, toolkit, environment):
         | extra_dependencies.get(toolkit, set())
         | runtime_dependencies.get(runtime, set())
     )
+
+    install_traitsui = "edm run -e {environment} -- pip install "
+    if editable:
+        install_traitsui += "--editable "
+    install_traitsui += "."
+
     # edm commands to setup the development environment
     commands = [
         "edm environments create {environment} --force --version={runtime}",
         "edm install -y -e {environment} " + packages,
         "edm run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
         "edm run -e {environment} -- python setup.py clean --all",
-        "edm run -e {environment} -- python setup.py install"
+        install_traitsui,
     ]
+
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
     if toolkit == 'pyside2':
         commands.append(


### PR DESCRIPTION
This PR adds an option to the `install` command in etstool.py for installing traitsui with editable mode switched on.  This allows developers to test the effect of their local clone of the repository immediately, especially when switching between branches.

This option is consistent with the one in traits.

The lack of --editable flag has bitten me quite a few times: I switched a branch and the new code was not actually run. That said, this would well have been my own working pattern being problematic. Given the flag is by default absent, I hope this is not going to interfere with other people's workflow, nor CI's.

