### PR TITLE
Separate wx tests in appveyor in use VS 2019 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,13 +11,15 @@ environment:
     - RUNTIME: '3.6'
       TOOLKITS: "null"
     - RUNTIME: '3.6'
-      TOOLKITS: "wx pyside2 pyqt"
+      TOOLKITS: "pyside2 pyqt"
+    - RUNTIME: '3.6'
+      TOOLKITS: "wx"
 
 matrix:
   fast_finish: true
   allow_failures:
     - RUNTIME: '3.6'
-      TOOLKITS: "wx pyside2 pyqt"
+      TOOLKITS: "wx"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 build: false
+image: Visual Studio 2019
 shallow_clone: false
 skip_branch_with_pr: true
 environment:


### PR DESCRIPTION
Creates a separate appveyor job for wx tests and switches to Visual Studio 2019 image as a workaround needed with new Qt-5.12.6 egg.