### PR TITLE
TST: Add tests for layout and labels using any non-null toolkits

### DIFF
--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -131,6 +131,30 @@ def filter_tests(test_suite, exclusion_pattern):
     return filtered_test_suite
 
 
+@contextmanager
+def create_ui(object, ui_kwargs=None):
+    """ Context manager for creating a UI and then dispose it when exiting
+    the context.
+
+    Parameters
+    ----------
+    object : HasTraits
+        An object from which ``edit_traits`` can be called to create a UI
+    ui_kwargs : dict or None
+        Keyword arguments to be provided to ``edit_traits``.
+
+    Yields
+    ------
+    ui: UI
+    """
+    ui_kwargs = {} if ui_kwargs is None else ui_kwargs
+    ui = object.edit_traits(**ui_kwargs)
+    try:
+        yield ui
+    finally:
+        ui.dispose()
+
+
 # ######### Utility tools to test on both qt4 and wx
 
 

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -25,6 +25,7 @@ from traitsui.item import Item
 from traitsui.group import VGroup, HGroup
 
 from traitsui.tests._tools import (
+    create_ui,
     is_current_backend_qt4,
     is_current_backend_wx,
     skip_if_not_qt4,
@@ -166,9 +167,8 @@ class TestLabels(unittest.TestCase):
 
         from pyface import qt
 
-        with store_exceptions_on_all_threads():
-            dialog = dialog_class()
-            ui = dialog.edit_traits()
+        with store_exceptions_on_all_threads(), \
+                create_ui(dialog_class()) as ui:
 
             # all labels
             labels = ui.control.findChildren(qt.QtGui.QLabel)
@@ -206,23 +206,13 @@ class TestLabels(unittest.TestCase):
     def test_qt_labels_right_resizing_horizontal(self):
         self._test_qt_labels_right_resizing(HResizeTestDialog)
 
-    @skip_if_not_qt4
-    def test_qt_no_labels_on_the_right_bug(self):
-        # Bug: If one set show_left=False, show_label=False on a non-resizable
-        # item like a checkbox, the Qt backend tried to set the label's size
-        # policy and failed because label=None.
-
-        with store_exceptions_on_all_threads():
-            dialog = NoLabelResizeTestDialog()
-            ui = dialog.edit_traits()
-
     @skip_if_null
     def test_labels_enabled_when(self):
         # Behaviour: label should enable/disable along with editor
 
-        with store_exceptions_on_all_threads():
-            dialog = EnableWhenDialog()
-            ui = dialog.edit_traits()
+        dialog = EnableWhenDialog()
+        with store_exceptions_on_all_threads(), \
+                create_ui(dialog) as ui:
 
             labelled_editor = ui.get_editors("labelled_item")[0]
 
@@ -239,6 +229,36 @@ class TestLabels(unittest.TestCase):
             dialog.bool_item = True
 
             ui.dispose()
+
+
+@skip_if_null
+class TestAnyToolkit(unittest.TestCase):
+    """ Toolkit-agnostic tests for labels with different orientations."""
+
+    def test_group_show_right_labels(self):
+        with store_exceptions_on_all_threads(), \
+                create_ui(ShowRightLabelsDialog()):
+            pass
+
+    def test_horizontal_resizable_and_labels(self):
+        with store_exceptions_on_all_threads(), \
+                create_ui(HResizeTestDialog()):
+            pass
+
+    def test_all_resizable_with_labels(self):
+        with store_exceptions_on_all_threads(), \
+                create_ui(VResizeTestDialog()):
+            pass
+
+    def test_show_right_with_no_label(self):
+        with store_exceptions_on_all_threads(), \
+                create_ui(NoLabelResizeTestDialog()):
+            pass
+
+    def test_enable_when_flag(self):
+        with store_exceptions_on_all_threads(), \
+                create_ui(EnableWhenDialog()):
+            pass
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -133,10 +133,9 @@ class TestLabels(unittest.TestCase):
         # that are shown to the *right* of the corresponding elements
 
         from pyface import qt
-
-        with store_exceptions_on_all_threads():
-            dialog = ShowRightLabelsDialog()
-            ui = dialog.edit_traits()
+        dialog = ShowRightLabelsDialog()
+        with store_exceptions_on_all_threads(), \
+                create_ui(dialog) as ui:
 
             # get reference to label objects
             labels = ui.control.findChildren(qt.QtGui.QLabel)

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -251,6 +251,9 @@ class TestAnyToolkit(unittest.TestCase):
             pass
 
     def test_show_right_with_no_label(self):
+        # Bug: If one set show_left=False, show_label=False on a non-resizable
+        # item like a checkbox, the Qt backend tried to set the label's size
+        # policy and failed because label=None.
         with store_exceptions_on_all_threads(), \
                 create_ui(NoLabelResizeTestDialog()):
             pass

--- a/traitsui/tests/test_layout.py
+++ b/traitsui/tests/test_layout.py
@@ -82,7 +82,8 @@ class TestLayout(unittest.TestCase):
 
         with store_exceptions_on_all_threads(), \
                 create_ui(VResizeDialog()) as ui:
-            text = ui.control.findChild(qt.QtGui.QLineEdit)
+            editor, = ui.get_editors("txt")
+            text = editor.control
 
             # horizontal size should be large
             self.assertGreater(text.width(), _DIALOG_WIDTH - 100)
@@ -101,7 +102,8 @@ class TestLayout(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(HResizeDialog()) as ui:
 
-            text = ui.control.findChild(qt.QtGui.QLineEdit)
+            editor, = ui.get_editors("txt")
+            text = editor.control
 
             # vertical size should be large
             self.assertGreater(text.height(), _DIALOG_HEIGHT - 100)

--- a/traitsui/tests/test_layout.py
+++ b/traitsui/tests/test_layout.py
@@ -27,7 +27,9 @@ from traitsui.view import View
 from traitsui.group import HGroup, VGroup
 
 from traitsui.tests._tools import (
+    create_ui,
     skip_if_not_qt4,
+    skip_if_null,
     store_exceptions_on_all_threads,
 )
 
@@ -35,6 +37,13 @@ from traitsui.tests._tools import (
 _DIALOG_WIDTH = 500
 _DIALOG_HEIGHT = 500
 _TXT_WIDTH = 100
+
+
+class MultipleTrait(HasTraits):
+    """ An object with multiple traits to test layout and alignments."""
+
+    txt1 = Str("text1")
+    txt2 = Str("text2")
 
 
 class VResizeDialog(HasTraits):
@@ -71,10 +80,8 @@ class TestLayout(unittest.TestCase):
 
         from pyface import qt
 
-        with store_exceptions_on_all_threads():
-            dialog = VResizeDialog()
-            ui = dialog.edit_traits()
-
+        with store_exceptions_on_all_threads(), \
+                create_ui(VResizeDialog()) as ui:
             text = ui.control.findChild(qt.QtGui.QLineEdit)
 
             # horizontal size should be large
@@ -91,9 +98,8 @@ class TestLayout(unittest.TestCase):
 
         from pyface import qt
 
-        with store_exceptions_on_all_threads():
-            dialog = HResizeDialog()
-            ui = dialog.edit_traits()
+        with store_exceptions_on_all_threads(), \
+                create_ui(HResizeDialog()) as ui:
 
             text = ui.control.findChild(qt.QtGui.QLineEdit)
 
@@ -104,6 +110,34 @@ class TestLayout(unittest.TestCase):
             # ??? maybe not: some elements (e.g., the text field) have
             # 'Expanding' as their default behavior
             # self.assertLess(text.width(), _TXT_WIDTH+100)
+
+
+@skip_if_null
+class TestOrientation(unittest.TestCase):
+    """ Toolkit-agnostic tests on the layout orientations."""
+
+    def test_vertical_layout(self):
+        view = View(
+            VGroup(
+                Item("txt1"),
+                Item("txt2"),
+            )
+        )
+        with store_exceptions_on_all_threads(), \
+                create_ui(MultipleTrait(), ui_kwargs=dict(view=view)):
+            pass
+
+    def test_horizontal_layout(self):
+        # layout
+        view = View(
+            HGroup(
+                Item("txt1"),
+                Item("txt2"),
+            )
+        )
+        with store_exceptions_on_all_threads(), \
+                create_ui(MultipleTrait(), ui_kwargs=dict(view=view)):
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a few simple tests to ensure that a UI can be created with various layout settings. In particular, this aims at increasing test coverage on `traitsui.wx.ui_panel` (changed from 46% to 50%...)

- Add `create_ui` context manager to `traitsui.tests._tools`.  We have seen this pattern again and again in the test suites. It is probably time to refactor this. Note that this context manager has deliberately left out the `EventLoopHelper.delete_widget` context manager. Otherwise we ~could~ would have to rely on toolkit-specific implementations of `EventLoopHelper`, which has not been implemented yet for wx.
- Drive-by changes to ensure existing tests call `ui.dispose` at the end of the test.

This was motivated by #829, e.g. the `TestOrientation.test_horizontal_layout` would fail before the fix provided by #829