### PR TITLE
Raise exception after resetting exception hooks

### DIFF
--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -60,10 +60,10 @@ def store_exceptions_on_all_threads():
         traits.trait_notifiers.handle_exception = handle_exception
         yield
     finally:
-        if len(exceptions) > 0:
-            raise exceptions[0]
         sys.excepthook = sys.__excepthook__
         traits.trait_notifiers.handle_exception = _original_handle_exception
+        if len(exceptions) > 0:
+            raise exceptions[0]
 
 
 def _is_current_backend(backend_name=""):


### PR DESCRIPTION
`store_exceptions_on_all_threads` raises errors too early: The original exception hooks are not restored if a test should fail. This could result in unrelated exceptions being captured by a no-longer valid exception hook.

This PR moves the raise to happen after resetting the hooks,

Credit to @ievacerny having spotted this.