### PR TITLE
Move value mapping from factory to individual editors

### DIFF
--- a/traitsui/editor_factory.py
+++ b/traitsui/editor_factory.py
@@ -309,15 +309,3 @@ class EditorWithListFactory(EditorFactory):
 
     #: Name of the trait on 'object' containing the enumeration data
     name = Str()
-
-    #: Fired when the **values** trait has been updated:
-    values_modified = Event()
-
-    def _values_changed(self):
-        """ Recomputes the mappings whenever the **values** trait is changed.
-        """
-        self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            self.values, strfunc=self.string_value
-        )
-
-        self.values_modified = True

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -58,17 +58,12 @@ class BaseEditor(Editor):
     #  BaseEditor Interface
     # -------------------------------------------------------------------------
 
-    def values_changed(self, object):
+    def values_changed(self):
         """ Recomputes the cached data based on the underlying enumeration model
             or the values of the factory.
         """
-        if object is self._object:
-            values = self._value()
-        else:
-            values = self.factory.values
-
         self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            values, self.string_value
+            self._value(), self.string_value
         )
 
     def rebuild_editor(self):
@@ -92,12 +87,13 @@ class BaseEditor(Editor):
             self._object, self._name, self._value = self.parse_extended_name(
                 factory.name
             )
-            self.values_changed(self._object)
+            self.values_changed()
             self._object.on_trait_change(
                 self._values_changed, " " + self._name, dispatch="ui"
             )
         else:
-            self.values_changed(factory)
+            self._value = lambda: self.factory.values
+            self.values_changed()
             factory.on_trait_change(
                 self._values_changed, "values", dispatch="ui"
             )
@@ -139,11 +135,11 @@ class BaseEditor(Editor):
 
     # Trait change handlers --------------------------------------------------
 
-    def _values_changed(self, object, name, new):
+    def _values_changed(self):
         """ Handles the underlying object model's enumeration set or factory's
             values being changed.
         """
-        self.values_changed(object)
+        self.values_changed()
         self.rebuild_editor()
 
 

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -58,11 +58,17 @@ class BaseEditor(Editor):
     #  BaseEditor Interface
     # -------------------------------------------------------------------------
 
-    def values_changed(self):
-        """ Recomputes the cached data based on the underlying enumeration model.
+    def values_changed(self, object):
+        """ Recomputes the cached data based on the underlying enumeration model
+            or the values of the factory.
         """
+        if object is self._object:
+            values = self._value()
+        else:
+            values = self.factory.values
+
         self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            self._value(), self.string_value
+            values, self.string_value
         )
 
     def rebuild_editor(self):
@@ -86,13 +92,14 @@ class BaseEditor(Editor):
             self._object, self._name, self._value = self.parse_extended_name(
                 factory.name
             )
-            self.values_changed()
+            self.values_changed(self._object)
             self._object.on_trait_change(
                 self._values_changed, " " + self._name, dispatch="ui"
             )
         else:
+            self.values_changed(factory)
             factory.on_trait_change(
-                self.rebuild_editor, "values_modified", dispatch="ui"
+                self._values_changed, "values", dispatch="ui"
             )
 
     def dispose(self):
@@ -104,7 +111,7 @@ class BaseEditor(Editor):
             )
         else:
             self.factory.on_trait_change(
-                self.rebuild_editor, "values_modified", remove=True
+                self._values_changed, "values", remove=True
             )
 
         super(BaseEditor, self).dispose()
@@ -118,33 +125,25 @@ class BaseEditor(Editor):
     def _get_names(self):
         """ Gets the current set of enumeration names.
         """
-        if self._object is None:
-            return self.factory._names
-
         return self._names
 
     def _get_mapping(self):
         """ Gets the current mapping.
         """
-        if self._object is None:
-            return self.factory._mapping
-
         return self._mapping
 
     def _get_inverse_mapping(self):
         """ Gets the current inverse mapping.
         """
-        if self._object is None:
-            return self.factory._inverse_mapping
-
         return self._inverse_mapping
 
     # Trait change handlers --------------------------------------------------
 
-    def _values_changed(self):
-        """ Handles the underlying object model's enumeration set being changed.
+    def _values_changed(self, object, name, new):
+        """ Handles the underlying object model's enumeration set or factory's
+            values being changed.
         """
-        self.values_changed()
+        self.values_changed(object)
         self.rebuild_editor()
 
 

--- a/traitsui/qt4/image_enum_editor.py
+++ b/traitsui/qt4/image_enum_editor.py
@@ -57,6 +57,8 @@ class ReadonlyEditor(BaseEditor, BaseEnumEditor):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
+        super(ReadonlyEditor, self).init(parent)
+
         self.control = QtGui.QLabel()
         self.control.setPixmap(self.get_pixmap(self.str_value))
         self.set_tooltip()
@@ -66,6 +68,12 @@ class ReadonlyEditor(BaseEditor, BaseEnumEditor):
             editor.
         """
         self.control.setPixmap(self.get_pixmap(self.str_value))
+
+    def rebuild_editor(self):
+        """ Rebuilds the contents of the editor whenever the original factory
+            object's **values** trait changes.
+        """
+        pass
 
 
 class SimpleEditor(BaseEditor, SimpleEnumEditor):

--- a/traitsui/qt4/set_editor.py
+++ b/traitsui/qt4/set_editor.py
@@ -71,13 +71,14 @@ class SimpleEditor(Editor):
             self._object, self._name, self._value = self.parse_extended_name(
                 factory.name
             )
-            self.values_changed()
+            self.values_changed(self._object)
             self._object.on_trait_change(
                 self._values_changed, self._name, dispatch="ui"
             )
         else:
+            self.values_changed(factory)
             factory.on_trait_change(
-                self.update_editor, "values_modified", dispatch="ui"
+                self._values_changed, "values", dispatch="ui"
             )
 
         blayout = QtGui.QVBoxLayout()
@@ -120,25 +121,16 @@ class SimpleEditor(Editor):
     def _get_names(self):
         """ Gets the current set of enumeration names.
         """
-        if self._object is None:
-            return self.factory._names
-
         return self._names
 
     def _get_mapping(self):
         """ Gets the current mapping.
         """
-        if self._object is None:
-            return self.factory._mapping
-
         return self._mapping
 
     def _get_inverse_mapping(self):
         """ Gets the current inverse mapping.
         """
-        if self._object is None:
-            return self.factory._inverse_mapping
-
         return self._inverse_mapping
 
     def _create_listbox(self, col, handler1, handler2, title):
@@ -170,17 +162,24 @@ class SimpleEditor(Editor):
         layout.addWidget(button)
         return button
 
-    def values_changed(self):
-        """ Recomputes the cached data based on the underlying enumeration model.
+    def values_changed(self, object):
+        """ Recomputes the cached data based on the underlying enumeration model
+            or the values of the factory.
         """
+        if object is self._object:
+            values = self._value()
+        else:
+            values = self.factory.values
+
         self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            self._value(), self.string_value
+            values, self.string_value
         )
 
-    def _values_changed(self):
-        """ Handles the underlying object model's enumeration set being changed.
+    def _values_changed(self, object, name, new):
+        """ Handles the underlying object model's enumeration set or factory's
+            values being changed.
         """
-        self.values_changed()
+        self.values_changed(object)
         self.update_editor()
 
     def update_editor(self):
@@ -260,7 +259,7 @@ class SimpleEditor(Editor):
             )
         else:
             self.factory.on_trait_change(
-                self.update_editor, "values_modified", remove=True
+                self._values_changed, "values", remove=True
             )
 
         self.context_object.on_trait_change(

--- a/traitsui/qt4/set_editor.py
+++ b/traitsui/qt4/set_editor.py
@@ -71,12 +71,13 @@ class SimpleEditor(Editor):
             self._object, self._name, self._value = self.parse_extended_name(
                 factory.name
             )
-            self.values_changed(self._object)
+            self.values_changed()
             self._object.on_trait_change(
                 self._values_changed, self._name, dispatch="ui"
             )
         else:
-            self.values_changed(factory)
+            self._value = lambda: self.factory.values
+            self.values_changed()
             factory.on_trait_change(
                 self._values_changed, "values", dispatch="ui"
             )
@@ -162,24 +163,19 @@ class SimpleEditor(Editor):
         layout.addWidget(button)
         return button
 
-    def values_changed(self, object):
+    def values_changed(self):
         """ Recomputes the cached data based on the underlying enumeration model
             or the values of the factory.
         """
-        if object is self._object:
-            values = self._value()
-        else:
-            values = self.factory.values
-
         self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            values, self.string_value
+            self._value(), self.string_value
         )
 
-    def _values_changed(self, object, name, new):
+    def _values_changed(self):
         """ Handles the underlying object model's enumeration set or factory's
             values being changed.
         """
-        self.values_changed(object)
+        self.values_changed()
         self.update_editor()
 
     def update_editor(self):

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -196,17 +196,10 @@ class TestEnumEditorMapping(unittest.TestCase):
         with store_exceptions_on_all_threads():
             editor = self.setup_ui(IntEnumModel(), formatted_view)
 
-            # FIXME issue enthought/traitsui#782
-            with self.assertRaises(AssertionError):
-                self.assertEqual(editor.names, ["FALSE", "TRUE"])
-                self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
-                self.assertEqual(
-                    editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
-                )
-            self.assertEqual(editor.names, ["0", "1"])
-            self.assertEqual(editor.mapping, {"0": 0, "1": 1})
+            self.assertEqual(editor.names, ["FALSE", "TRUE"])
+            self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
             self.assertEqual(
-                editor.inverse_mapping, {0: "0", 1: "1"}
+                editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
             )
 
             enum_editor_factory.values = [1, 0]
@@ -238,47 +231,19 @@ class TestEnumEditorMapping(unittest.TestCase):
         with store_exceptions_on_all_threads():
             editor = self.setup_ui(model, formatted_view)
 
-            # FIXME issue enthought/traitsui#835
-            if is_current_backend_wx():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(editor.names, ["FALSE", "TRUE"])
-                    self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
-                    self.assertEqual(
-                        editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
-                    )
-                self.assertEqual(editor.names, ["0", "1"])
-                self.assertEqual(editor.mapping, {"0": 0, "1": 1})
-                self.assertEqual(
-                    editor.inverse_mapping, {0: "0", 1: "1"}
-                )
-            else:
-                self.assertEqual(editor.names, ["FALSE", "TRUE"])
-                self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
-                self.assertEqual(
-                    editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
-                )
+            self.assertEqual(editor.names, ["FALSE", "TRUE"])
+            self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
+            self.assertEqual(
+                editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
+            )
 
             model.possible_values = [1, 0]
 
-            # FIXME issue enthought/traitsui#835
-            if is_current_backend_wx():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(editor.names, ["TRUE", "FALSE"])
-                    self.assertEqual(editor.mapping, {"TRUE": 1, "FALSE": 0})
-                    self.assertEqual(
-                        editor.inverse_mapping, {1: "TRUE", 0: "FALSE"}
-                    )
-                self.assertEqual(editor.names, ["1", "0"])
-                self.assertEqual(editor.mapping, {"1": 1, "0": 0})
-                self.assertEqual(
-                    editor.inverse_mapping, {1: "1", 0: "0"}
-                )
-            else:
-                self.assertEqual(editor.names, ["TRUE", "FALSE"])
-                self.assertEqual(editor.mapping, {"TRUE": 1, "FALSE": 0})
-                self.assertEqual(
-                    editor.inverse_mapping, {1: "TRUE", 0: "FALSE"}
-                )
+            self.assertEqual(editor.names, ["TRUE", "FALSE"])
+            self.assertEqual(editor.mapping, {"TRUE": 1, "FALSE": 0})
+            self.assertEqual(
+                editor.inverse_mapping, {1: "TRUE", 0: "FALSE"}
+            )
 
     def test_simple_editor_mapping_values(self):
         self.check_enum_mappings_value_change("simple", "radio")

--- a/traitsui/tests/editors/test_image_enum_editor.py
+++ b/traitsui/tests/editors/test_image_enum_editor.py
@@ -155,25 +155,14 @@ class TestImageEnumEditorMapping(unittest.TestCase):
         with store_exceptions_on_all_threads():
             editor = self.setup_ui(EnumModel(), formatted_view)
 
-            # FIXME issue enthought/traitsui#782
-            with self.assertRaises(AssertionError):
-                self.assertEqual(editor.names, ["TOP LEFT", "TOP RIGHT"])
-                self.assertEqual(
-                    editor.mapping,
-                    {"TOP LEFT": "top left", "TOP RIGHT": "top right"}
-                )
-                self.assertEqual(
-                    editor.inverse_mapping,
-                    {"top left": "TOP LEFT", "top right": "TOP RIGHT"}
-                )
-            self.assertEqual(editor.names, ["top left", "top right"])
+            self.assertEqual(editor.names, ["TOP LEFT", "TOP RIGHT"])
             self.assertEqual(
                 editor.mapping,
-                {"top left": "top left", "top right": "top right"}
+                {"TOP LEFT": "top left", "TOP RIGHT": "top right"}
             )
             self.assertEqual(
                 editor.inverse_mapping,
-                {"top left": "top left", "top right": "top right"}
+                {"top left": "TOP LEFT", "top right": "TOP RIGHT"}
             )
 
             image_enum_editor_factory.values = ["top right", "top left"]

--- a/traitsui/tests/editors/test_set_editor.py
+++ b/traitsui/tests/editors/test_set_editor.py
@@ -170,17 +170,10 @@ class TestSetEditorMapping(unittest.TestCase):
         with store_exceptions_on_all_threads():
             editor = self.setup_ui(IntListModel(), formatted_view)
 
-            # FIXME issue enthought/traitsui#782
-            with self.assertRaises(AssertionError):
-                self.assertEqual(editor.names, ["FALSE", "TRUE"])
-                self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
-                self.assertEqual(
-                    editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
-                )
-            self.assertEqual(editor.names, ["0", "1"])
-            self.assertEqual(editor.mapping, {"0": 0, "1": 1})
+            self.assertEqual(editor.names, ["FALSE", "TRUE"])
+            self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
             self.assertEqual(
-                editor.inverse_mapping, {0: "0", 1: "1"}
+                editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
             )
 
             set_editor_factory.values = [1, 0]
@@ -211,47 +204,19 @@ class TestSetEditorMapping(unittest.TestCase):
         with store_exceptions_on_all_threads():
             editor = self.setup_ui(model, formatted_view)
 
-            # FIXME issue enthought/traitsui#835
-            if is_current_backend_wx():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(editor.names, ["FALSE", "TRUE"])
-                    self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
-                    self.assertEqual(
-                        editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
-                    )
-                self.assertEqual(editor.names, ["0", "1"])
-                self.assertEqual(editor.mapping, {"0": 0, "1": 1})
-                self.assertEqual(
-                    editor.inverse_mapping, {0: "0", 1: "1"}
-                )
-            else:
-                self.assertEqual(editor.names, ["FALSE", "TRUE"])
-                self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
-                self.assertEqual(
-                    editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
-                )
+            self.assertEqual(editor.names, ["FALSE", "TRUE"])
+            self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
+            self.assertEqual(
+                editor.inverse_mapping, {0: "FALSE", 1: "TRUE"}
+            )
 
             model.possible_values = [1, 0]
 
-            # FIXME issue enthought/traitsui#835
-            if is_current_backend_wx():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(editor.names, ["TRUE", "FALSE"])
-                    self.assertEqual(editor.mapping, {"TRUE": 1, "FALSE": 0})
-                    self.assertEqual(
-                        editor.inverse_mapping, {1: "TRUE", 0: "FALSE"}
-                    )
-                self.assertEqual(editor.names, ["1", "0"])
-                self.assertEqual(editor.mapping, {"1": 1, "0": 0})
-                self.assertEqual(
-                    editor.inverse_mapping, {1: "1", 0: "0"}
-                )
-            else:
-                self.assertEqual(editor.names, ["TRUE", "FALSE"])
-                self.assertEqual(editor.mapping, {"TRUE": 1, "FALSE": 0})
-                self.assertEqual(
-                    editor.inverse_mapping, {1: "TRUE", 0: "FALSE"}
-                )
+            self.assertEqual(editor.names, ["TRUE", "FALSE"])
+            self.assertEqual(editor.mapping, {"TRUE": 1, "FALSE": 0})
+            self.assertEqual(
+                editor.inverse_mapping, {1: "TRUE", 0: "FALSE"}
+            )
 
 
 @skip_if_null

--- a/traitsui/wx/enum_editor.py
+++ b/traitsui/wx/enum_editor.py
@@ -78,12 +78,13 @@ class BaseEditor(Editor):
             self._object, self._name, self._value = self.parse_extended_name(
                 factory.name
             )
-            self.values_changed(self._object)
+            self.values_changed()
             self._object.on_trait_change(
                 self._values_changed, " " + self._name, dispatch="ui"
             )
         else:
-            self.values_changed(factory)
+            self._value = lambda: self.factory.values
+            self.values_changed()
             factory.on_trait_change(
                 self._values_changed, "values", dispatch="ui"
             )
@@ -109,24 +110,19 @@ class BaseEditor(Editor):
         """
         raise NotImplementedError
 
-    def values_changed(self, object):
+    def values_changed(self):
         """ Recomputes the cached data based on the underlying enumeration model
             or the values of the factory.
         """
-        if object is self._object:
-            values = self._value()
-        else:
-            values = self.factory.values
-
         self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            values, self.string_value
+            self._value(), self.string_value
         )
 
-    def _values_changed(self, object, name, new):
+    def _values_changed(self):
         """ Handles the underlying object model's enumeration set or factory's
             values being changed.
         """
-        self.values_changed(object)
+        self.values_changed()
         self.rebuild_editor()
 
     def dispose(self):

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -266,41 +266,6 @@ def top_level_window_for(control):
     return control
 
 
-def enum_values_changed(values):
-    """ Recomputes the mappings for a new set of enumeration values.
-    """
-
-    if isinstance(values, dict):
-        data = [(str(v), n) for n, v in values.items()]
-        if len(data) > 0:
-            data.sort(key=itemgetter(0))
-            col = data[0][0].find(":") + 1
-            if col > 0:
-                data = [(n[col:], v) for n, v in data]
-    elif not isinstance(values, SequenceTypes):
-        handler = values
-        if isinstance(handler, CTrait):
-            handler = handler.handler
-        if not isinstance(handler, BaseTraitHandler):
-            raise TraitError("Invalid value for 'values' specified")
-        if handler.is_mapped:
-            data = [(str(n), n) for n in handler.map.keys()]
-            data.sort(key=itemgetter(0))
-        else:
-            data = [(str(v), v) for v in handler.values]
-    else:
-        data = [(str(v), v) for v in values]
-
-    names = [x[0] for x in data]
-    mapping = {}
-    inverse_mapping = {}
-    for name, value in data:
-        mapping[name] = value
-        inverse_mapping[value] = name
-
-    return (names, mapping, inverse_mapping)
-
-
 def disconnect(control, *events):
     """ Disconnects a wx event handle from its associated control.
     """

--- a/traitsui/wx/image_enum_editor.py
+++ b/traitsui/wx/image_enum_editor.py
@@ -38,7 +38,7 @@ from .constants import WindowColor
 
 from .image_control import ImageControl
 
-from .toolkit import _popEventHandlers
+from .toolkit import GUIToolkit
 
 # -------------------------------------------------------------------------
 #  'ReadonlyEditor' class:
@@ -124,17 +124,18 @@ class CustomEditor(BaseEnumEditor):
         self._create_image_grid()
 
     def rebuild_editor(self):
+        # Clear any existing content:
+        self.control.SetSizer(None)
+        GUIToolkit("traitsui", "wx", "traitsui.wx").destroy_children(
+            self.control
+        )
+
         self._create_image_grid()
 
     def _create_image_grid(self):
         """ Populates a specified window with a grid of image buttons.
         """
-        # Clear any existing content:
         panel = self.control
-        panel.SetSizer(None)
-        for child in panel.GetChildren():
-            _popEventHandlers(child)
-        panel.DestroyChildren()
 
         # Create the main sizer:
         if self.factory.cols > 1:

--- a/traitsui/wx/image_enum_editor.py
+++ b/traitsui/wx/image_enum_editor.py
@@ -38,7 +38,7 @@ from .constants import WindowColor
 
 from .image_control import ImageControl
 
-from .toolkit import GUIToolkit
+from traitsui.wx import toolkit
 
 # -------------------------------------------------------------------------
 #  'ReadonlyEditor' class:
@@ -126,9 +126,7 @@ class CustomEditor(BaseEnumEditor):
     def rebuild_editor(self):
         # Clear any existing content:
         self.control.SetSizer(None)
-        GUIToolkit("traitsui", "wx", "traitsui.wx").destroy_children(
-            self.control
-        )
+        toolkit.destroy_children(self.control)
 
         self._create_image_grid()
 

--- a/traitsui/wx/set_editor.py
+++ b/traitsui/wx/set_editor.py
@@ -31,9 +31,11 @@ from traits.api import Property
 # traitsui.editors.set_editor file.
 from traitsui.editors.set_editor import ToolkitEditorFactory
 
+from traitsui.helper import enum_values_changed
+
 from .editor import Editor
 
-from .helper import enum_values_changed, TraitsUIPanel
+from .helper import TraitsUIPanel
 
 
 # -------------------------------------------------------------------------
@@ -76,13 +78,14 @@ class SimpleEditor(Editor):
             self._object, self._name, self._value = self.parse_extended_name(
                 factory.name
             )
-            self.values_changed()
+            self.values_changed(self._object)
             self._object.on_trait_change(
                 self._values_changed, self._name, dispatch="ui"
             )
         else:
+            self.values_changed(factory)
             factory.on_trait_change(
-                self.update_editor, "values_modified", dispatch="ui"
+                self._values_changed, "values", dispatch="ui"
             )
 
         self.control = panel = TraitsUIPanel(parent, -1)
@@ -139,25 +142,16 @@ class SimpleEditor(Editor):
     def _get_names(self):
         """ Gets the current set of enumeration names.
         """
-        if self._object is None:
-            return self.factory._names
-
         return self._names
 
     def _get_mapping(self):
         """ Gets the current mapping.
         """
-        if self._object is None:
-            return self.factory._mapping
-
         return self._mapping
 
     def _get_inverse_mapping(self):
         """ Gets the current inverse mapping.
         """
-        if self._object is None:
-            return self.factory._inverse_mapping
-
         return self._inverse_mapping
 
     def _create_listbox(self, parent, sizer, handler1, handler2, title):
@@ -196,17 +190,24 @@ class SimpleEditor(Editor):
         parent.Bind(wx.EVT_BUTTON, handler, id=button.GetId())
         return button
 
-    def values_changed(self):
-        """ Recomputes the cached data based on the underlying enumeration model.
+    def values_changed(self, object):
+        """ Recomputes the cached data based on the underlying enumeration model
+            or the values of the factory.
         """
+        if object is self._object:
+            values = self._value()
+        else:
+            values = self.factory.values
+
         self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            self._value()
+            values, self.string_value
         )
 
-    def _values_changed(self):
-        """ Handles the underlying object model's enumeration set being changed.
+    def _values_changed(self, object, name, new):
+        """ Handles the underlying object model's enumeration set or factory's
+            values being changed.
         """
-        self.values_changed()
+        self.values_changed(object)
         self.update_editor()
 
     def update_editor(self):
@@ -287,7 +288,7 @@ class SimpleEditor(Editor):
             )
         else:
             self.factory.on_trait_change(
-                self.update_editor, "values_modified", remove=True
+                self._values_changed, "values", remove=True
             )
 
         self.context_object.on_trait_change(

--- a/traitsui/wx/set_editor.py
+++ b/traitsui/wx/set_editor.py
@@ -78,12 +78,13 @@ class SimpleEditor(Editor):
             self._object, self._name, self._value = self.parse_extended_name(
                 factory.name
             )
-            self.values_changed(self._object)
+            self.values_changed()
             self._object.on_trait_change(
                 self._values_changed, self._name, dispatch="ui"
             )
         else:
-            self.values_changed(factory)
+            self._value = lambda: self.factory.values
+            self.values_changed()
             factory.on_trait_change(
                 self._values_changed, "values", dispatch="ui"
             )
@@ -190,24 +191,19 @@ class SimpleEditor(Editor):
         parent.Bind(wx.EVT_BUTTON, handler, id=button.GetId())
         return button
 
-    def values_changed(self, object):
+    def values_changed(self):
         """ Recomputes the cached data based on the underlying enumeration model
             or the values of the factory.
         """
-        if object is self._object:
-            values = self._value()
-        else:
-            values = self.factory.values
-
         self._names, self._mapping, self._inverse_mapping = enum_values_changed(
-            values, self.string_value
+            self._value(), self.string_value
         )
 
-    def _values_changed(self, object, name, new):
+    def _values_changed(self):
         """ Handles the underlying object model's enumeration set or factory's
             values being changed.
         """
-        self.values_changed(object)
+        self.values_changed()
         self.update_editor()
 
     def update_editor(self):


### PR DESCRIPTION
Closes #782 
Closes #835 

Moves value mapping from factory to individual editors. Also fixes wx Enum and Set editor format_func issue by switching to general `enum_values_changed` version.