### PR TITLE
Fix Demo application description if __init__.py or traits_ui_demo.jpg are not found

### DIFF
--- a/examples/demo/Advanced/index.rst
+++ b/examples/demo/Advanced/index.rst
@@ -1,4 +1,2 @@
-"""
 These demonstrations show off some of the more advanced features of and
 TraitsUI.
-"""

--- a/examples/demo/Dynamic_Forms/__init__.py
+++ b/examples/demo/Dynamic_Forms/__init__.py
@@ -1,1 +1,0 @@
-""" Implementations of dynamic form behavior using TraitsUI """

--- a/examples/demo/Dynamic_Forms/index.rst
+++ b/examples/demo/Dynamic_Forms/index.rst
@@ -1,0 +1,1 @@
+Implementations of dynamic form behavior using TraitsUI

--- a/examples/demo/index.rst
+++ b/examples/demo/index.rst
@@ -1,0 +1,1 @@
+.. image:: traits_ui_demo.jpg

--- a/traitsui/extras/tests/test_demo.py
+++ b/traitsui/extras/tests/test_demo.py
@@ -36,9 +36,9 @@ class TestDemoPathDescription(unittest.TestCase):
             )
 
             tree = ET.fromstring(model.description)
-            body_node = next(tree.iter(get_html_tag("body")))
-            div_node, = list(body_node)
-            self.assertEqual(list(div_node), [])
+        body_node = next(tree.iter(get_html_tag("body")))
+        div_node, = list(body_node)
+        self.assertEqual(list(div_node), [])
 
     def test_use_index_rst(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -51,8 +51,8 @@ class TestDemoPathDescription(unittest.TestCase):
             )
 
             tree = ET.fromstring(model.description)
-            img_node = next(tree.iter(get_html_tag("img")))
-            self.assertEqual(img_node.attrib["src"], "any_image.jpg")
+        img_node = next(tree.iter(get_html_tag("img")))
+        self.assertEqual(img_node.attrib["src"], "any_image.jpg")
 
     def test_description_use_css(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -62,6 +62,7 @@ class TestDemoPathDescription(unittest.TestCase):
             )
 
             tree = ET.fromstring(model.description)
+
         link_node = next(tree.iter(get_html_tag("link")))
         self.assertEqual(link_node.attrib["href"], "default.css")
 

--- a/traitsui/extras/tests/test_demo.py
+++ b/traitsui/extras/tests/test_demo.py
@@ -88,6 +88,7 @@ class TestDemoPathInitLocals(unittest.TestCase):
             model = demo.DemoPath(
                 name=directory,
             )
+            self.assertIn("a", model.init_dic)
             self.assertEqual(model.init_dic["a"], 1)
             # traits api is still imported.
             self.assertIn("HasTraits", model.init_dic)

--- a/traitsui/extras/tests/test_demo.py
+++ b/traitsui/extras/tests/test_demo.py
@@ -24,18 +24,6 @@ def get_html_tag(tag):
     return HTML_NS_PREFIX + tag
 
 
-class TestDemoUtility(unittest.TestCase):
-    """ Test various utility-like functions supporting demo.
-    """
-
-    def test_user_name_for(self):
-        # Test the function that returns a nice name
-        base_name = "शुभ_प्रभात"
-        actual = demo.user_name_for(base_name)
-        expected = "शुभ प्रभात"
-        self.assertEqual(actual, expected)
-
-
 class TestDemoPathDescription(unittest.TestCase):
     """ Test ``DemoPath.description`` """
 

--- a/traitsui/extras/tests/test_demo.py
+++ b/traitsui/extras/tests/test_demo.py
@@ -54,6 +54,17 @@ class TestDemoPathDescription(unittest.TestCase):
             img_node = next(tree.iter(get_html_tag("img")))
             self.assertEqual(img_node.attrib["src"], "any_image.jpg")
 
+    def test_description_use_css(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model = demo.DemoPath(
+                name=directory,
+                css_filename="default.css",
+            )
+
+            tree = ET.fromstring(model.description)
+        link_node = next(tree.iter(get_html_tag("link")))
+        self.assertEqual(link_node.attrib["href"], "default.css")
+
 
 class TestDemoPathInitLocals(unittest.TestCase):
     """ Test ``DemoPath.init_dic`` """

--- a/traitsui/extras/tests/test_demo.py
+++ b/traitsui/extras/tests/test_demo.py
@@ -133,9 +133,9 @@ class TestDemoPathChildren(unittest.TestCase):
             # In that subdirectory, there is one Python file that is not
             # __init__.py
             subdir_node, = children
-            children = subdir_node.get_children()
-            self.assertEqual(len(children), 1)
-            example, = children
+            file_nodes = subdir_node.get_children()
+            self.assertEqual(len(file_nodes), 1)
+            example, = file_nodes
             self.assertEqual(example.name, "example.py")
 
             # This is the test objective: The __init__.py and traits api are

--- a/traitsui/extras/tests/test_demo.py
+++ b/traitsui/extras/tests/test_demo.py
@@ -1,0 +1,145 @@
+#  Copyright (c) 2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+import os
+import tempfile
+import textwrap
+import unittest
+from xml.etree import ElementTree as ET
+
+from traitsui.extras import demo
+
+HTML_NS_PREFIX = "{http://www.w3.org/1999/xhtml}"
+
+
+def get_html_tag(tag):
+    return HTML_NS_PREFIX + tag
+
+
+class TestDemoUtility(unittest.TestCase):
+    """ Test various utility-like functions supporting demo.
+    """
+
+    def test_user_name_for(self):
+        # Test the function that returns a nice name
+        base_name = "शुभ_प्रभात"
+        actual = demo.user_name_for(base_name)
+        expected = "शुभ प्रभात"
+        self.assertEqual(actual, expected)
+
+
+class TestDemoPathDescription(unittest.TestCase):
+    """ Test ``DemoPath.description`` """
+
+    def test_description_with_empty_directory(self):
+        # If the directory is empty, the content of the description should
+        # be empty.
+        with tempfile.TemporaryDirectory() as directory:
+            model = demo.DemoPath(
+                name=directory,
+            )
+
+            tree = ET.fromstring(model.description)
+            body_node = next(tree.iter(get_html_tag("body")))
+            div_node, = list(body_node)
+            self.assertEqual(list(div_node), [])
+
+    def test_use_index_rst(self):
+        with tempfile.TemporaryDirectory() as directory:
+            index_rst = os.path.join(directory, "index.rst")
+            with open(index_rst, "w", encoding="utf-8") as f:
+                f.write(".. image:: any_image.jpg\n")
+
+            model = demo.DemoPath(
+                name=directory,
+            )
+
+            tree = ET.fromstring(model.description)
+            img_node = next(tree.iter(get_html_tag("img")))
+            self.assertEqual(img_node.attrib["src"], "any_image.jpg")
+
+
+class TestDemoPathInitLocals(unittest.TestCase):
+    """ Test ``DemoPath.init_dic`` """
+
+    def test_init_dict_with_empty_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            model = demo.DemoPath(
+                name=directory,
+            )
+            # traits api is still imported.
+            init_dic = model.init_dic
+            self.assertIsInstance(init_dic, dict)
+            self.assertIn("HasTraits", init_dic)
+
+    def test_init_dict_with_init_py(self):
+        with tempfile.TemporaryDirectory() as directory:
+            init_py = os.path.join(directory, "__init__.py")
+            with open(init_py, "w", encoding="utf-8") as f:
+                f.write("a = 1\n")
+            model = demo.DemoPath(
+                name=directory,
+            )
+            self.assertEqual(model.init_dic["a"], 1)
+            # traits api is still imported.
+            self.assertIn("HasTraits", model.init_dic)
+
+
+class TestDemoPathChildren(unittest.TestCase):
+    """ Integration test with DemoPath and its children
+    """
+
+    def test_init_dict_used_by_children(self):
+        # Test the __init__.py in a directory (if exists) is visible
+        # by the example scripts in that folder.
+        # Not sure if this is really needed, but this is an existing feature.
+        with tempfile.TemporaryDirectory() as directory:
+
+            init_content = "CONSTANT = 'HELLO'"
+            example_content = textwrap.dedent(
+                """
+                from . import CONSTANT
+                from . import HasTraits
+                """
+            )
+            subdir = os.path.join(directory, "Examples")
+            os.makedirs(subdir)
+            init_py = os.path.join(subdir, "__init__.py")
+            with open(init_py, "w", encoding="utf-8") as f:
+                f.write(init_content)
+            example_py = os.path.join(subdir, "example.py")
+            with open(example_py, "w", encoding="utf-8") as f:
+                f.write(example_content)
+
+            model = demo.DemoPath(
+                name=directory,
+                use_files=False,
+            )
+
+            # sanity check:
+            # This is one subdirectory
+            children = model.get_children()
+            self.assertEqual(len(children), 1)
+
+            # In that subdirectory, there is one Python file that is not
+            # __init__.py
+            subdir_node, = children
+            children = subdir_node.get_children()
+            self.assertEqual(len(children), 1)
+            example, = children
+            self.assertEqual(example.name, "example.py")
+
+            # This is the test objective: The __init__.py and traits api are
+            # loaded and accessible by the example script.
+            # Try running the code
+            example.run_code()
+            self.assertIn("CONSTANT", example.locals)
+            self.assertIn("HasTraits", example.locals)


### PR DESCRIPTION
Closes #849 
Closes #804 too (that was what I initially set out to solve).

This PR:
- Changes the source file for loading a folder description to a single source `index.rst`. Updated the `examples` directory accordingly.
- Removes the hard-coded `traits_ui_demo.jpg`: The `index.rst` is responsible for providing a correct reference to whatever image it wants to show.
- Removes `DemoPath.source` which represents the source in `__init__.py`: This is not used.
- Adds tests (coverage on `demo.py` changed from 0% to 47%).

With this PR, these are the desirable fixes:
- If `__init__.py` is not found, we no longer see "Sorry, something went wrong...[traceback]" in the description. We just see an empty page.
- The directory containing tutorials no longer have to be Python package in order to provide a description.
