### PR TITLE
TST: Test demo examples can be run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ dist: xenial
 services:
   - xvfb
 
+addons:
+  apt:
+    packages:
+    - libglu1-mesa-dev
+
 env:
   global:
     - INSTALL_EDM_VERSION=2.0.0

--- a/etstool.py
+++ b/etstool.py
@@ -222,7 +222,7 @@ def test(runtime, toolkit, environment):
         environ["EXCLUDE_TESTS"] = "(wx|qt)"
 
     commands = [
-        #"edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
+        "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
         "edm run -e {environment} -- coverage run -p -m unittest -v integrationtests.test_all_examples",
     ]
 

--- a/etstool.py
+++ b/etstool.py
@@ -221,9 +221,10 @@ def test(runtime, toolkit, environment):
     else:
         environ["EXCLUDE_TESTS"] = "(wx|qt)"
 
+    parameters["integrationtests"] = os.path.abspath("integrationtests")
     commands = [
         "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
-        "edm run -e {environment} -- coverage run -p -m unittest -v integrationtests.test_all_examples",
+        "edm run -e {environment} -- coverage run -p -m unittest discover -v {integrationtests}",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui

--- a/etstool.py
+++ b/etstool.py
@@ -109,7 +109,7 @@ dependencies = {
     "docutils"
 }
 
-# Additional toolkit-independent dependencies for testing
+# Additional toolkit-independent dependencies for demo testing
 test_dependencies = {
     "apptools",
     "chaco",

--- a/etstool.py
+++ b/etstool.py
@@ -213,7 +213,8 @@ def test(runtime, toolkit, environment):
         environ["EXCLUDE_TESTS"] = "(wx|qt)"
 
     commands = [
-        "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui"
+        "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
+        "edm run -e {environment} -- coverage run -p -m unittest -v integrationtests.test_all_examples",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui

--- a/etstool.py
+++ b/etstool.py
@@ -109,6 +109,14 @@ dependencies = {
     "docutils"
 }
 
+# Additional toolkit-independent dependencies for testing
+test_dependencies = {
+    "apptools",
+    "chaco",
+    "h5py",
+    "pytables",
+}
+
 extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
@@ -156,6 +164,7 @@ def install(runtime, toolkit, environment, editable):
         dependencies
         | extra_dependencies.get(toolkit, set())
         | runtime_dependencies.get(runtime, set())
+        | test_dependencies
     )
 
     install_traitsui = "edm run -e {environment} -- pip install "
@@ -213,7 +222,7 @@ def test(runtime, toolkit, environment):
         environ["EXCLUDE_TESTS"] = "(wx|qt)"
 
     commands = [
-        "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
+        #"edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
         "edm run -e {environment} -- coverage run -p -m unittest -v integrationtests.test_all_examples",
     ]
 

--- a/etstool.py
+++ b/etstool.py
@@ -224,7 +224,10 @@ def test(runtime, toolkit, environment):
     parameters["integrationtests"] = os.path.abspath("integrationtests")
     commands = [
         "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
-        "edm run -e {environment} -- coverage run -p -m unittest discover -v {integrationtests}",
+        # coverage run prevents local images to be loaded for demo examples
+        # which are not defined in Python packages. Run with python directly
+        # instead.
+        "edm run -e {environment} -- python -m unittest discover -v {integrationtests}",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -218,7 +218,7 @@ def run_file(file_path):
         content = f.read()
 
     globals = {
-        "__name__": "traitsui",   # as long as it is not __main__
+        "__name__": "__main__",
         "__file__": file_path,
     }
     with replace_configure_traits(), \

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -73,11 +73,11 @@ skip_file_if(
     os.path.join(DEMO, "demo.py"),
 )
 skip_file_if(
-    is_current_backend_wx(), "ProgressRenderer is not implemented in wx.",
+    is_current_backend_wx, "ProgressRenderer is not implemented in wx.",
     os.path.join(DEMO, "Advanced", "Table_editor_with_progress_column.py"),
 )
 skip_file_if(
-    is_current_backend_qt4(), "ScrubberEditor is not implemented in qt.",
+    is_current_backend_qt4, "ScrubberEditor is not implemented in qt.",
     os.path.join(DEMO, "Advanced", "Scrubber_editor_demo.py"),
 )
 skip_file_if(

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -73,7 +73,7 @@ skip_file_if(
     os.path.join(DEMO, "Advanced", "Table_editor_with_progress_column.py"),
 )
 skip_file_if(
-    lambda: not is_current_backend_wx(), "Require wx",
+    lambda: not is_current_backend_wx(), "Only support wx",
     os.path.join(DEMO, "Extras", "animated_GIF.py"),
 )
 skip_file_if(
@@ -81,11 +81,11 @@ skip_file_if(
     os.path.join(DEMO, "Extras", "Tree_editor_with_TreeNodeRenderer.py"),
 )
 skip_file_if(
-    lambda: not is_current_backend_wx(), "Require wx",
+    lambda: not is_current_backend_wx(), "Only support wx",
     os.path.join(DEMO, "Extras", "windows", "flash.py"),
 )
 skip_file_if(
-    lambda: not is_current_backend_wx(), "Require wx",
+    lambda: not is_current_backend_wx(), "Only support wx",
     os.path.join(DEMO, "Extras", "windows", "internet_explorer.py"),
 )
 skip_file_if(

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -218,7 +218,6 @@ def run_file(file_path):
         content = f.read()
 
     globals = {
-        "__package__": __package__,
         "__name__": "traitsui",   # as long as it is not __main__
         "__file__": file_path,
     }

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -112,7 +112,7 @@ skip_file_if(
     os.path.join(TUTORIALS, "view_standalone.py"),
 )
 skip_file_if(
-    is_current_backend_qt4, "Failing on Qt, need fixing",
+    is_current_backend_qt4, "Failing on Qt, see enthought/traitsui#773",
     os.path.join(TUTORIALS, "wizard.py"),
 )
 

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -1,0 +1,260 @@
+#  Copyright (c) 2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+
+""" Tests for demo and tutorial examples.
+"""
+
+import contextlib
+from itertools import chain
+import os
+import unittest
+
+from traits.api import HasTraits
+
+from traitsui.tests._tools import (
+    is_current_backend_wx,
+    is_current_backend_qt4,
+    skip_if_null,
+)
+
+
+# This test file is not distributed nor is it in a package.
+HERE = os.path.dirname(__file__)
+
+EXAMPLES = os.path.join(HERE, "..", "examples")
+DEMO = os.path.join(EXAMPLES, "demo")
+TUTORIALS = os.path.join(EXAMPLES, "tutorials", "doc_examples", "examples")
+
+#: Explicitly include folders from which example files should be found
+#: recursively.
+SOURCE_DIRS = [
+    DEMO,
+    TUTORIALS,
+]
+
+
+#: Mapping from filepath to a callable() -> (skipped: bool, reason: str)
+FILES_MAY_BE_SKIPPED = {}
+
+
+def skip_file_if(condition, reason, filepath):
+    """ Mark a file to be skipped for a given condition.
+
+    Parameters
+    ----------
+    condition: callable() -> bool
+        The condition for skipping a file.
+    reason : str
+        Reason for skipping the file.
+    filepath : str
+        Path of the file which may be skipped from tests.
+    """
+    def wrapped():
+        return condition(), reason
+
+    filepath = os.path.abspath(filepath)
+    FILES_MAY_BE_SKIPPED[filepath] = wrapped
+
+
+skip_file_if(
+    lambda: True, "Not a target file to be tested",
+    os.path.join(DEMO, "demo.py"),
+)
+skip_file_if(
+    lambda: True, "Missing dependency: apptools",
+    os.path.join(DEMO, "Advanced", "Adapted_tree_editor_demo.py"),
+)
+skip_file_if(
+    lambda: True, "Missing dependency: h5py",
+    os.path.join(DEMO, "Advanced", "HDF5_tree_demo.py"),
+)
+skip_file_if(
+    lambda: True, "Missing dependency: h5py",
+    os.path.join(DEMO, "Advanced", "HDF5_tree_demo2.py"),
+)
+skip_file_if(
+    is_current_backend_wx, "ProgressRenderer is not implemented in wx.",
+    os.path.join(DEMO, "Advanced", "Table_editor_with_progress_column.py"),
+)
+skip_file_if(
+    lambda: not is_current_backend_wx(), "Require wx",
+    os.path.join(DEMO, "Extras", "animated_GIF.py"),
+)
+skip_file_if(
+    lambda: not is_current_backend_qt4(), "Only support Qt",
+    os.path.join(DEMO, "Extras", "Tree_editor_with_TreeNodeRenderer.py"),
+)
+skip_file_if(
+    lambda: not is_current_backend_wx(), "Require wx",
+    os.path.join(DEMO, "Extras", "windows", "flash.py"),
+)
+skip_file_if(
+    lambda: not is_current_backend_wx(), "Require wx",
+    os.path.join(DEMO, "Extras", "windows", "internet_explorer.py"),
+)
+skip_file_if(
+    lambda: True, "Missing dependency: chaco",
+    os.path.join(DEMO, "Useful", "demo_group_size.py"),
+)
+skip_file_if(
+    lambda: True, "Require wx and is blocking.",
+    os.path.join(TUTORIALS, "view_multi_object.py"),
+)
+skip_file_if(
+    lambda: True, "Require wx and is blocking.",
+    os.path.join(TUTORIALS, "view_standalone.py"),
+)
+skip_file_if(
+    is_current_backend_qt4, "Failing on Qt, need fixing",
+    os.path.join(TUTORIALS, "wizard.py"),
+)
+
+
+def check_special_files():
+    """ Check all files that may be skipped still exist."""
+    for filepath in FILES_MAY_BE_SKIPPED:
+        if not os.path.exists(filepath):
+            raise RuntimeError("{} does not exist.".format(filepath))
+
+
+def is_python_file(path):
+    """ Return true if the given path is (public) Python file."""
+    _, basename = os.path.split(path)
+    _, ext = os.path.splitext(basename)
+    return (
+        ext == ".py"
+        and not basename.startswith("_")
+    )
+
+
+def is_skipped(path):
+    """ Return if the Python file should be skipped in test.
+
+    Parameters
+    ----------
+    path : str
+        Path to a file.
+
+    Returns
+    -------
+    skipped : bool
+    reason : str
+    """
+    if path not in FILES_MAY_BE_SKIPPED:
+        return False, ""
+    skipped, reason = FILES_MAY_BE_SKIPPED[path]()
+    return skipped, reason
+
+
+def get_python_files(directory):
+    """ Recursively walk a directory and report Python files to be tested.
+
+    Parameters
+    ----------
+    directory : str
+        Path of the directory to be walked.
+
+    Returns
+    -------
+    paths : list of str
+        List of Python file paths.
+    """
+    paths = []
+    for root, _, files in os.walk(directory):
+        for filename in files:
+            path = os.path.abspath(os.path.join(root, filename))
+            if is_python_file(path):
+                paths.append(path)
+    return sorted(paths)
+
+
+def replaced_configure_traits(
+        instance,
+        filename=None,
+        view=None,
+        kind=None,
+        edit=True,
+        context=None,
+        handler=None,
+        id="",
+        scrollable=None,
+        **args
+):
+    """ Mocked configure_traits to launch then close the GUI.
+    """
+    ui = instance.edit_traits(
+        view=view,
+        parent=None,
+        kind="live",  # other options may block the test
+        context=context,
+        handler=handler,
+        id=id,
+        scrollable=scrollable,
+        **args,
+    )
+    ui.dispose()
+
+
+@contextlib.contextmanager
+def replace_configure_traits():
+    """ Context manager to temporarily replace HasTraits.configure_traits
+    with a mocked version such that GUI launched are closed soon after they
+    are open.
+    """
+    original_func = HasTraits.configure_traits
+    HasTraits.configure_traits = replaced_configure_traits
+    try:
+        yield
+    finally:
+        HasTraits.configure_traits = original_func
+
+
+def run_file(file_path):
+    """ Execute a given Python file.
+
+    Parameters
+    ----------
+    file_path : str
+        File path to be tested.
+    """
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    globals = {
+        "__package__": __package__,
+        "__name__": "traitsui",   # as long as it is not __main__
+        "__file__": file_path,
+    }
+    with replace_configure_traits():
+        exec(content, globals)
+
+
+@skip_if_null
+class TestExample(unittest.TestCase):
+
+    def test_run(self):
+        check_special_files()
+        file_paths = chain.from_iterable(
+            get_python_files(source_dir) for source_dir in SOURCE_DIRS
+        )
+        for file_path in file_paths:
+            with self.subTest(file_path=file_path):
+                skipped, reason = is_skipped(file_path)
+                if skipped:
+                    raise unittest.SkipTest(reason)
+
+                try:
+                    run_file(file_path)
+                except Exception as exc:
+                    self.fail(
+                        "Executing {} failed with exception {}".format(
+                            file_path, exc
+                        )
+                    )

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -14,10 +14,8 @@
 import contextlib
 from itertools import chain
 import os
-import shutil
-import subprocess
 import sys
-import tempfile
+import traceback
 import unittest
 from unittest import mock
 
@@ -252,10 +250,12 @@ class TestExample(unittest.TestCase):
 
                 try:
                     run_file(file_path)
-                except subprocess.CalledProcessError as exc:
+                except Exception as exc:
+                    message = "".join(
+                        traceback.format_exception(*sys.exc_info())
+                    )
                     self.fail(
-                        "Executing {} failed with exception {}.\n"
-                        "Output: {}".format(
-                            file_path, exc, exc.output
+                        "Executing {} failed with exception {}\n {}".format(
+                            file_path, exc, message
                         )
                     )

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -15,6 +15,7 @@ import contextlib
 from itertools import chain
 import os
 import unittest
+from unittest import mock
 
 from traits.api import HasTraits
 
@@ -68,18 +69,6 @@ skip_file_if(
     os.path.join(DEMO, "demo.py"),
 )
 skip_file_if(
-    lambda: True, "Missing dependency: apptools",
-    os.path.join(DEMO, "Advanced", "Adapted_tree_editor_demo.py"),
-)
-skip_file_if(
-    lambda: True, "Missing dependency: h5py",
-    os.path.join(DEMO, "Advanced", "HDF5_tree_demo.py"),
-)
-skip_file_if(
-    lambda: True, "Missing dependency: h5py",
-    os.path.join(DEMO, "Advanced", "HDF5_tree_demo2.py"),
-)
-skip_file_if(
     is_current_backend_wx, "ProgressRenderer is not implemented in wx.",
     os.path.join(DEMO, "Advanced", "Table_editor_with_progress_column.py"),
 )
@@ -100,7 +89,8 @@ skip_file_if(
     os.path.join(DEMO, "Extras", "windows", "internet_explorer.py"),
 )
 skip_file_if(
-    lambda: True, "Missing dependency: chaco",
+    is_current_backend_wx,
+    "enable tries to import a missing constant. See enthought/enable#307",
     os.path.join(DEMO, "Useful", "demo_group_size.py"),
 )
 skip_file_if(
@@ -232,7 +222,11 @@ def run_file(file_path):
         "__name__": "traitsui",   # as long as it is not __main__
         "__file__": file_path,
     }
-    with replace_configure_traits():
+    with replace_configure_traits(), \
+            mock.patch("sys.argv", [file_path]):
+        # Some example reads sys.argv to allow more arguments
+        # But all examples should support being run without additional
+        # arguments.
         exec(content, globals)
 
 

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -276,6 +276,10 @@ def run_file(file_path):
         exec(content, globals)
 
 
+# =============================================================================
+# Test cases
+# =============================================================================
+
 @skip_if_null
 class TestExample(unittest.TestCase):
 

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -46,7 +46,7 @@ SOURCE_DIRS = [
 ]
 
 
-#: Mapping from filepath to a callable() -> (skipped: bool, reason: str)
+#: Mapping from filepath to tuple(condition: callable -> bool, reason: str)
 FILES_MAY_BE_SKIPPED = {}
 
 
@@ -62,11 +62,11 @@ def skip_file_if(condition, reason, filepath):
     filepath : str
         Path of the file which may be skipped from tests.
     """
-    def wrapped():
-        return condition(), reason
-
     filepath = os.path.abspath(filepath)
-    FILES_MAY_BE_SKIPPED[filepath] = wrapped
+    FILES_MAY_BE_SKIPPED[filepath] = (
+        condition,
+        "{reason} (File: {filepath})".format(reason=reason, filepath=filepath)
+    )
 
 
 skip_file_if(
@@ -148,8 +148,8 @@ def is_skipped(path):
     """
     if path not in FILES_MAY_BE_SKIPPED:
         return False, ""
-    skipped, reason = FILES_MAY_BE_SKIPPED[path]()
-    return skipped, reason
+    condition, reason = FILES_MAY_BE_SKIPPED[os.path.abspath(path)]
+    return condition(), reason
 
 
 def get_python_files(directory):

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -20,12 +20,12 @@ import traceback
 import unittest
 from unittest import mock
 
-from pyface.api import GUI
 from traits.api import HasTraits
 
 from traitsui.tests._tools import (
     is_current_backend_wx,
     is_current_backend_qt4,
+    process_cascade_events,
     skip_if_null,
     store_exceptions_on_all_threads,
 )
@@ -199,7 +199,7 @@ def replaced_configure_traits(
         **args,
     )
     with store_exceptions_on_all_threads():
-        GUI.process_events()
+        process_cascade_events()
 
         # Temporary fix for enthought/traitsui#907
         if is_current_backend_qt4():
@@ -208,7 +208,7 @@ def replaced_configure_traits(
             ui.control.Hide()
 
         ui.dispose()
-        GUI.process_events()
+        process_cascade_events()
 
 
 @contextlib.contextmanager
@@ -278,4 +278,4 @@ class TestExample(unittest.TestCase):
                 finally:
                     # Whatever failure, always flush the GUI event queue
                     # before running the next one.
-                    GUI.process_events()
+                    process_cascade_events()

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -13,7 +13,6 @@
 
 import contextlib
 import io
-from itertools import chain
 import os
 import sys
 import traceback

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -130,9 +130,10 @@ class ExampleSearcher:
         return sorted(accepted_files), sorted(skipped_files)
 
 
-# -----------------------------------------------------------------------------
+# =============================================================================
 # Configuration
-# -----------------------------------------------------------------------------
+# =============================================================================
+
 EXAMPLES = os.path.join(HERE, "..", "examples")
 DEMO = os.path.join(EXAMPLES, "demo")
 TUTORIALS = os.path.join(EXAMPLES, "tutorials", "doc_examples", "examples")

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -12,6 +12,7 @@
 """
 
 import contextlib
+import io
 from itertools import chain
 import os
 import sys
@@ -227,8 +228,11 @@ def run_file(file_path):
         "__file__": file_path,
     }
     with replace_configure_traits(), \
+            mock.patch("sys.stdout", new_callable=io.StringIO), \
             mock.patch("sys.argv", [file_path]):
-        # Some example reads sys.argv to allow more arguments
+        # Mock stdout: Examples typically print educational information.
+        # They are expected but they should not pollute test output.
+        # Move argv: Some example reads sys.argv to allow more arguments
         # But all examples should support being run without additional
         # arguments.
         exec(content, globals)

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -198,6 +198,13 @@ def replaced_configure_traits(
         **args,
     )
     GUI.process_events()
+
+    # Temporary fix for enthought/traitsui#907
+    if is_current_backend_qt4():
+        ui.control.hide()
+    if is_current_backend_wx():
+        ui.control.Hide()
+
     ui.dispose()
     GUI.process_events()
 

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -27,6 +27,7 @@ from traitsui.tests._tools import (
     is_current_backend_wx,
     is_current_backend_qt4,
     skip_if_null,
+    store_exceptions_on_all_threads,
 )
 
 
@@ -197,16 +198,17 @@ def replaced_configure_traits(
         scrollable=scrollable,
         **args,
     )
-    GUI.process_events()
+    with store_exceptions_on_all_threads():
+        GUI.process_events()
 
-    # Temporary fix for enthought/traitsui#907
-    if is_current_backend_qt4():
-        ui.control.hide()
-    if is_current_backend_wx():
-        ui.control.Hide()
+        # Temporary fix for enthought/traitsui#907
+        if is_current_backend_qt4():
+            ui.control.hide()
+        if is_current_backend_wx():
+            ui.control.Hide()
 
-    ui.dispose()
-    GUI.process_events()
+        ui.dispose()
+        GUI.process_events()
 
 
 @contextlib.contextmanager

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -275,3 +275,7 @@ class TestExample(unittest.TestCase):
                             file_path, exc, message
                         )
                     )
+                finally:
+                    # Whatever failure, always flush the GUI event queue
+                    # before running the next one.
+                    GUI.process_events()

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -20,6 +20,7 @@ import traceback
 import unittest
 from unittest import mock
 
+from pyface.api import GUI
 from traits.api import HasTraits
 
 from traitsui.tests._tools import (
@@ -196,7 +197,9 @@ def replaced_configure_traits(
         scrollable=scrollable,
         **args,
     )
+    GUI.process_events()
     ui.dispose()
+    GUI.process_events()
 
 
 @contextlib.contextmanager

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -46,17 +46,17 @@ class ExampleSearcher:
         self.source_dirs = source_dirs
         self.files_may_be_skipped = {}
 
-    def skip_file_if(self, condition, reason, filepath):
+    def skip_file_if(self, filepath, condition, reason):
         """ Mark a file to be skipped for a given condition.
 
         Parameters
         ----------
+        filepath : str
+            Path of the file which may be skipped from tests.
         condition: callable() -> bool
             The condition for skipping a file.
         reason : str
             Reason for skipping the file.
-        filepath : str
-            Path of the file which may be skipped from tests.
         """
         filepath = os.path.abspath(filepath)
         self.files_may_be_skipped[filepath] = (condition, reason)
@@ -146,49 +146,49 @@ SOURCE_DIRS = [
 
 SEARCHER = ExampleSearcher(source_dirs=SOURCE_DIRS)
 SEARCHER.skip_file_if(
-    lambda: True, "Not a target file to be tested",
     os.path.join(DEMO, "demo.py"),
+    lambda: True, "Not a target file to be tested",
 )
 SEARCHER.skip_file_if(
-    is_current_backend_wx, "ProgressRenderer is not implemented in wx.",
     os.path.join(DEMO, "Advanced", "Table_editor_with_progress_column.py"),
+    is_current_backend_wx, "ProgressRenderer is not implemented in wx.",
 )
 SEARCHER.skip_file_if(
-    is_current_backend_qt4, "ScrubberEditor is not implemented in qt.",
     os.path.join(DEMO, "Advanced", "Scrubber_editor_demo.py"),
+    is_current_backend_qt4, "ScrubberEditor is not implemented in qt.",
 )
 SEARCHER.skip_file_if(
-    lambda: not is_current_backend_wx(), "Only support wx",
     os.path.join(DEMO, "Extras", "animated_GIF.py"),
+    lambda: not is_current_backend_wx(), "Only support wx",
 )
 SEARCHER.skip_file_if(
-    lambda: not is_current_backend_qt4(), "Only support Qt",
     os.path.join(DEMO, "Extras", "Tree_editor_with_TreeNodeRenderer.py"),
+    lambda: not is_current_backend_qt4(), "Only support Qt",
 )
 SEARCHER.skip_file_if(
-    lambda: not is_current_backend_wx(), "Only support wx",
     os.path.join(DEMO, "Extras", "windows", "flash.py"),
-)
-SEARCHER.skip_file_if(
     lambda: not is_current_backend_wx(), "Only support wx",
-    os.path.join(DEMO, "Extras", "windows", "internet_explorer.py"),
 )
 SEARCHER.skip_file_if(
+    os.path.join(DEMO, "Extras", "windows", "internet_explorer.py"),
+    lambda: not is_current_backend_wx(), "Only support wx",
+)
+SEARCHER.skip_file_if(
+    os.path.join(DEMO, "Useful", "demo_group_size.py"),
     is_current_backend_wx,
     "enable tries to import a missing constant. See enthought/enable#307",
-    os.path.join(DEMO, "Useful", "demo_group_size.py"),
 )
 SEARCHER.skip_file_if(
-    lambda: True, "Require wx and is blocking.",
     os.path.join(TUTORIALS, "view_multi_object.py"),
-)
-SEARCHER.skip_file_if(
     lambda: True, "Require wx and is blocking.",
-    os.path.join(TUTORIALS, "view_standalone.py"),
 )
 SEARCHER.skip_file_if(
-    is_current_backend_qt4, "Failing on Qt, see enthought/traitsui#773",
+    os.path.join(TUTORIALS, "view_standalone.py"),
+    lambda: True, "Require wx and is blocking.",
+)
+SEARCHER.skip_file_if(
     os.path.join(TUTORIALS, "wizard.py"),
+    is_current_backend_qt4, "Failing on Qt, see enthought/traitsui#773",
 )
 
 # Validate configuration.


### PR DESCRIPTION
This PR adds a test case to ensure demo examples can be run to the extent that a GUI can be opened and then closed. Unfortunately some of them have to be skipped, see inlined reasons.

Since `examples` is not a package (though included in source distribution), the tests are added to `integrationtests` folder, which isn't distributed.

A few dependencies are added for testing some of the examples. If that's too much, then we can only skip those examples in the tests (or evaluate if those examples should be removed?).

One downside is that these tests are rather noisy on wx due to DeprecationWarnings. These warnings should be fixed, see https://github.com/enthought/traitsui/issues/579

See #623 for behavioural issues on the demo examples.