### PR TITLE
Add more ListStrEditor tests

### DIFF
--- a/traitsui/tests/editors/test_liststr_editor.py
+++ b/traitsui/tests/editors/test_liststr_editor.py
@@ -26,7 +26,7 @@ class TraitObject(HasTraits):
     list_str = List(Str)
 
 
-class TestListStrEditor(unittest.TestCase):
+class TestListStrAdapter(unittest.TestCase):
 
     def test_list_str_adapter_length(self):
         """Test the ListStringAdapter len method"""

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -19,6 +19,7 @@ Test case for bug (wx, Mac OS X)
 A ListStrEditor was not checking for valid item indexes under Wx.  This was
 most noticeable when the selected_index was set in the editor factory.
 """
+import platform
 import unittest
 
 from pyface.gui import GUI
@@ -38,6 +39,8 @@ from traitsui.tests._tools import (
     skip_if_null,
     store_exceptions_on_all_threads,
 )
+
+is_windows = platform.system() == "Windows"
 
 
 class ListStrModel(HasTraits):
@@ -198,6 +201,10 @@ def right_click_item(control, index):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
+@unittest.skipIf(
+    is_windows and is_current_backend_qt4(),
+    "Issue enthought/traitsui#854; possible test interactions on Windows"
+)
 @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
 @skip_if_null
 class TestListStrEditor(unittest.TestCase):

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -124,7 +124,6 @@ def set_selected_single(editor, index):
     """ Selects a specified item in an editor with multi_select=False.
     """
     if is_current_backend_wx():
-        clear_selection(editor)
         editor.control.Select(index)
 
     elif is_current_backend_qt4():
@@ -150,8 +149,8 @@ def set_selected_multiple(editor, indices):
     elif is_current_backend_qt4():
         from pyface.qt.QtGui import QItemSelectionModel
 
+        clear_selection(editor)
         smodel = editor.list_view.selectionModel()
-        smodel.clearSelection()
         for index in indices:
             mi = editor.model.index(index)
             smodel.select(mi, QItemSelectionModel.Select)

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -97,7 +97,7 @@ def get_selected_indices(editor):
     """
     if is_current_backend_wx():
         import wx
-
+        # "item" in this context means "index of the item"
         item = -1
         selected = []
         while True:
@@ -118,6 +118,8 @@ def get_selected_indices(editor):
 
 
 def set_selected_single(editor, index):
+    """ Selects a specified item in an editor with multi_select=False.
+    """
     if is_current_backend_wx():
         clear_selection(editor)
         editor.control.Select(index)
@@ -134,6 +136,9 @@ def set_selected_single(editor, index):
 
 
 def set_selected_multiple(editor, indices):
+    """ Clears old selection and selects specified items in an editor with
+    multi_select=True.
+    """
     if is_current_backend_wx():
         clear_selection(editor)
         for index in indices:
@@ -153,6 +158,8 @@ def set_selected_multiple(editor, indices):
 
 
 def clear_selection(editor):
+    """ Clears existing selection.
+    """
     if is_current_backend_wx():
         import wx
 
@@ -171,6 +178,8 @@ def clear_selection(editor):
 
 
 def right_click_item(control, index):
+    """ Right clicks on the specified item.
+    """
 
     if is_current_backend_wx():
         import wx
@@ -443,7 +452,8 @@ class TestListStrEditor(unittest.TestCase):
             model.value = ["two", "three"]
             gui.process_events()
 
-            # Model selection is reset, but editor selection values are not
+            # Internal view model selection is reset, but editor selection
+            # values are not (see issue enthought/traitsui#872)
             self.assertEqual(get_selected_indices(editor), [])
             self.assertEqual(editor.selected_index, 1)
             self.assertEqual(editor.selected, "one")
@@ -474,7 +484,8 @@ class TestListStrEditor(unittest.TestCase):
             model.value = []
             gui.process_events()
 
-            # Model selection is reset, but editor selection values are not
+            # Internal view model selection is reset, but editor selection
+            # values are not (see issue enthought/traitsui#872)
             self.assertEqual(get_selected_indices(editor), [])
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "two")
@@ -506,7 +517,8 @@ class TestListStrEditor(unittest.TestCase):
             model.value = ["two", "three"]
             gui.process_events()
 
-            # Model selection is reset, but editor selection values are not
+            # Internal view model selection is reset, but editor selection
+            # values are not (see issue enthought/traitsui#872)
             self.assertEqual(get_selected_indices(editor), [])
             self.assertEqual(editor.multi_selected_indices, [1])
             self.assertEqual(editor.multi_selected, ["one"])
@@ -538,7 +550,8 @@ class TestListStrEditor(unittest.TestCase):
             model.value = []
             gui.process_events()
 
-            # Model selection is reset, but editor selection values are not
+            # Internal view model selection is reset, but editor selection
+            # values are not (see issue enthought/traitsui#872)
             self.assertEqual(get_selected_indices(editor), [])
             self.assertEqual(editor.multi_selected_indices, [0])
             self.assertEqual(editor.multi_selected, ["two"])
@@ -601,8 +614,8 @@ class TestListStrEditor(unittest.TestCase):
         with store_exceptions_on_all_threads():
             self.setup_gui(ListStrModel(), get_view(title="testing"))
 
-    @skip_if_not_wx
-    def test_list_str_editor_menu(self):
+    @skip_if_not_wx  # see `right_click_item` and issue enthought/traitsui#868
+    def test_list_str_editor_right_click(self):
         class ListStrModelRightClick(HasTraits):
             value = List(["one", "two", "three"])
             right_clicked = Str()

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -390,17 +390,20 @@ class TestListStrEditor(unittest.TestCase):
                 self.assertEqual(sorted(editor.multi_selected_indices), [1, 2])
 
     def test_list_str_editor_item_count(self):
+        gui = GUI()
         model = ListStrModel()
 
         # Without auto_add
         with store_exceptions_on_all_threads(), \
                 create_ui(model, dict(view=get_view())) as ui:
+            gui.process_events()
             editor = ui.get_editors("value")[0]
             self.assertEqual(editor.item_count, 3)
 
         # With auto_add
         with store_exceptions_on_all_threads(), \
                 create_ui(model, dict(view=get_view(auto_add=True))) as ui:
+            gui.process_events()
             editor = ui.get_editors("value")[0]
             self.assertEqual(editor.item_count, 3)
 

--- a/traitsui/wx/list_str_editor.py
+++ b/traitsui/wx/list_str_editor.py
@@ -404,7 +404,7 @@ class _ListStrEditor(Editor):
     def _multi_selected_items_changed(self, event):
         """ Handles the editor's 'multi_selected' trait being modified.
         """
-        values = self.values
+        values = self.value
         try:
             self._multi_selected_indices_items_changed(
                 TraitListEvent(


### PR DESCRIPTION
Adds more tests for ListStrEditor.

Also includes a minor bug fix in wx version of `ListStrEditor` because it was easier to fix it than to open an issue.
The bug: in `_multi_selected_items_changed` instead of `self.value` the method was trying to use `self.values` which doesn't exist.

I would also like to rename the test files `test_liststr_editor.py -> test_liststr_adapter.py` and `test_liststr_editor_selection.py -> test_liststr_editor.py` so that it's easier to find relevant tests. If nobody has any objections, I will do it just before merging to keep a nicer diff in the meantime.