### PR TITLE
FIX: Make sure new_row is positive

### DIFF
--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -344,6 +344,12 @@ class TabularModel(QtCore.QAbstractTableModel):
         """
         editor = self._editor
 
+        if new_row == -1:
+            # In some cases, the new row may be reported as -1 (e.g. when
+            # dragging and dropping a row at the bottom of existing rows). In
+            # that case, adjust to the number of existing rows.
+            new_row = self.rowCount(None)
+        
         # Sort rows in descending order so they can be removed without
         # invalidating the indices.
         current_rows.sort()


### PR DESCRIPTION
may fix -- I think -- #870 

`QModelIndex.row()` returns -1 when trying to append a row below existing rows (I didn't find any indication in the Qt docs why that should be the case, but I observed it in practice using the example from #870). This causes `TabularModel.beginInsertRows()` to try and insert a row at index -1, which causes a segfault. The fix is to adjust the row location to be non-negative, i.e. to make it equal to the number of rows already in the table, [as per the documentation](https://doc.qt.io/qt-5/qabstractitemmodel.html#beginInsertRows).

I've based my investigation entirely on the example from #870, I'm not sure if there are other places in the codebase that are susceptible to this.

@rahulporuri Could you give this a spin?