### PR TITLE
Maint: Normalize row index in TabularModel

### DIFF
--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -277,6 +277,9 @@ class TabularModel(QtCore.QAbstractTableModel):
         if action == QtCore.Qt.IgnoreAction:
             return False
 
+        # If dropped directly onto the parent, both row and column are -1.
+        # See https://doc.qt.io/qt-5/qabstractitemmodel.html#dropMimeData
+        # When dropped below the list, the "parent" is invalid.
         if row == -1:
             if parent.isValid():
                 row = parent.row()

--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -352,7 +352,7 @@ class TabularModel(QtCore.QAbstractTableModel):
             # This is a last resort to prevent segmentation faults.
             logger.debug(
                 "Received invalid row %d. Adjusting to the last row.", new_row)
-            new_row = self.rowCount(None) - 1
+            new_row = max(0, self.rowCount(None) - 1)
 
         # Sort rows in descending order so they can be removed without
         # invalidating the indices.

--- a/traitsui/qt4/tabular_model.py
+++ b/traitsui/qt4/tabular_model.py
@@ -20,7 +20,7 @@
 
 
 
-
+import logging
 
 from pyface.qt import QtCore, QtGui
 
@@ -38,6 +38,8 @@ alignment_map = {
 
 # MIME type for internal table drag/drop operations
 tabular_mime_type = "traits-ui-tabular-editor"
+
+logger = logging.getLogger(__name__)
 
 
 class TabularModel(QtCore.QAbstractTableModel):
@@ -275,6 +277,12 @@ class TabularModel(QtCore.QAbstractTableModel):
         if action == QtCore.Qt.IgnoreAction:
             return False
 
+        if row == -1:
+            if parent.isValid():
+                row = parent.row()
+            else:
+                row = max(0, self.rowCount(None) - 1)
+
         # this is a drag from a tabular model
         data = mime_data.data(tabular_mime_type)
         if not data.isNull() and action == QtCore.Qt.MoveAction:
@@ -285,7 +293,7 @@ class TabularModel(QtCore.QAbstractTableModel):
             # is it from ourself?
             if table_id == id(self):
                 current_rows = id_and_rows[1:]
-                self.moveRows(current_rows, parent.row())
+                self.moveRows(current_rows, row)
                 return True
 
         # this is an external drag
@@ -297,12 +305,6 @@ class TabularModel(QtCore.QAbstractTableModel):
             object = editor.object
             name = editor.name
             adapter = editor.adapter
-            if row == -1 and parent.isValid():
-                # find correct row number
-                row = parent.row()
-            if row == -1 and adapter.len(object, name) == 0:
-                # if empty list, target is after end of list
-                row = 0
             if all(
                 adapter.get_can_drop(object, name, row, item) for item in data
             ):
@@ -345,11 +347,13 @@ class TabularModel(QtCore.QAbstractTableModel):
         editor = self._editor
 
         if new_row == -1:
-            # In some cases, the new row may be reported as -1 (e.g. when
-            # dragging and dropping a row at the bottom of existing rows). In
-            # that case, adjust to the number of existing rows.
-            new_row = self.rowCount(None)
-        
+            # row should be nonnegative and less than the row count for this
+            # model. See ``QAbstractItemModel.checkIndex``` for Qt 5.11+
+            # This is a last resort to prevent segmentation faults.
+            logger.debug(
+                "Received invalid row %d. Adjusting to the last row.", new_row)
+            new_row = self.rowCount(None) - 1
+
         # Sort rows in descending order so they can be removed without
         # invalidating the indices.
         current_rows.sort()

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -40,14 +40,15 @@ class DummyHasTraits(HasTraits):
     names = List(Str)
 
 
-view = View(
-    Item(
-        "names",
-        editor=TabularEditor(
-            adapter=TabularAdapter(columns=["Name"]),
-        ),
+def get_view(adapter):
+    return View(
+        Item(
+            "names",
+            editor=TabularEditor(
+                adapter=adapter,
+            ),
+        )
     )
-)
 
 
 @skip_if_not_qt4
@@ -56,7 +57,7 @@ class TestTabularModel(unittest.TestCase):
     def test_drop_mime_data_below_list(self):
 
         obj = DummyHasTraits(names=["A", "B", "C"])
-
+        view = get_view(TabularAdapter(columns=["Name"]))
         with store_exceptions_on_all_threads(), \
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
@@ -71,8 +72,6 @@ class TestTabularModel(unittest.TestCase):
             mime_data = model.mimeData([index])
             content = mime_data.instance()   # content should be 'B'
 
-            # If dropped directly onto the parent, both row and column are -1.
-            # See https://doc.qt.io/qt-5/qabstractitemmodel.html#dropMimeData
             # When dropped below the list, the "parent" is invalid.
             parent = QtCore.QModelIndex()   # invalid index object
             model.dropMimeData(mime_data, QtCore.Qt.MoveAction, -1, -1, parent)
@@ -86,6 +85,7 @@ class TestTabularModel(unittest.TestCase):
     def test_drop_mime_data_within_list(self):
 
         obj = DummyHasTraits(names=["A", "B", "C"])
+        view = get_view(TabularAdapter(columns=["Name"]))
 
         with store_exceptions_on_all_threads(), \
                 create_ui(obj, dict(view=view)) as ui:
@@ -112,9 +112,40 @@ class TestTabularModel(unittest.TestCase):
             # Same content as the one dragged.
             self.assertEqual(mime_data.instance(), content)
 
+    def test_copy_item(self):
+        # Test copy 'A' to the row after 'C'
+        obj = DummyHasTraits(names=["A", "B", "C"])
+        view = get_view(TabularAdapter(columns=["Name"], can_drop=True))
+
+        with store_exceptions_on_all_threads(), \
+                create_ui(obj, dict(view=view)) as ui:
+            editor, = ui.get_editors("names")
+
+            model =  editor.model
+            # sanity check
+            self.assertEqual(model.rowCount(None), 3)
+
+            # drag and drop from within the table for copy action.
+            index = model.createIndex(0, 0)  # row = 0, column=0
+            mime_data = model.mimeData([index])
+            content = mime_data.instance()   # content should be 'A'
+
+            # when
+            parent = model.createIndex(2, 0)  # the location of 'C'
+            model.dropMimeData(mime_data, QtCore.Qt.CopyAction, -1, -1, parent)
+
+            # then
+            self.assertEqual(model.rowCount(None), 4)
+
+            index = model.createIndex(3, 0)
+            mime_data = model.mimeData([index])
+            # Same content as the one dragged.
+            self.assertEqual(mime_data.instance(), content)
+
     def test_move_rows_invalid_index(self):
 
         obj = DummyHasTraits(names=["A", "B", "C"])
+        view = get_view(TabularAdapter(columns=["Name"]))
 
         with store_exceptions_on_all_threads(), \
                 create_ui(obj, dict(view=view)) as ui:

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -79,6 +79,7 @@ class TestTabularModel(unittest.TestCase):
             )
             content = mime_data.instance()
             self.assertEqual(content, ["A", "C", "D", "B"])
+            self.assertEqual(obj.names, content)
 
     def test_drop_mime_data_within_list(self):
         # Test dragging an item in the list and drop it somewhere within the
@@ -110,6 +111,7 @@ class TestTabularModel(unittest.TestCase):
             )
             content = mime_data.instance()
             self.assertEqual(content, ["B", "C", "A", "D"])
+            self.assertEqual(obj.names, content)
 
     def test_copy_item(self):
         # Test copy 'A' to the row after 'C'
@@ -141,6 +143,7 @@ class TestTabularModel(unittest.TestCase):
             )
             content = mime_data.instance()
             self.assertEqual(content, ["A", "B", "C", "A"])
+            self.assertEqual(obj.names, content)
 
     def test_move_rows_invalid_index(self):
         # Test the last resort to prevent segfault
@@ -166,3 +169,4 @@ class TestTabularModel(unittest.TestCase):
             )
             content = mime_data.instance()
             self.assertEqual(content, ["A", "C", "B"])
+            self.assertEqual(obj.names, content)

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -13,7 +13,6 @@
 """
 
 import unittest
-from unittest import mock
 
 from traits.api import HasTraits, List, Str
 from traitsui.api import Item, TabularEditor, View
@@ -26,9 +25,7 @@ from traitsui.tests._tools import (
     store_exceptions_on_all_threads,
 )
 try:
-    from pyface.qt import QtCore, QtGui
-    from traitsui.qt4.tabular_model import TabularModel
-    from traitsui.qt4.tabular_editor import TabularEditor as QtTabularEditor
+    from pyface.qt import QtCore
 except ImportError:
     # The entire test case should be skipped if the current backend is not Qt
     # But if it is Qt, then re-raise
@@ -62,7 +59,7 @@ class TestTabularModel(unittest.TestCase):
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 
-            model =  editor.model
+            model = editor.model
             # sanity check
             self.assertEqual(model.rowCount(None), 3)
 
@@ -91,7 +88,7 @@ class TestTabularModel(unittest.TestCase):
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 
-            model =  editor.model
+            model = editor.model
             # sanity check
             self.assertEqual(model.rowCount(None), 3)
 
@@ -121,7 +118,7 @@ class TestTabularModel(unittest.TestCase):
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 
-            model =  editor.model
+            model = editor.model
             # sanity check
             self.assertEqual(model.rowCount(None), 3)
 
@@ -151,7 +148,7 @@ class TestTabularModel(unittest.TestCase):
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 
-            model =  editor.model
+            model = editor.model
 
             # -1 is an invalid row. This should not cause segfault.
             model.moveRows([1], -1)

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -1,0 +1,113 @@
+#  Copyright (c) 2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+""" Tests for TabularModel (an implementation of QAbstractTableModel)
+"""
+
+import unittest
+from unittest import mock
+
+from traits.api import HasTraits, List, Str
+from traitsui.api import Item, TabularEditor, View
+from traitsui.tabular_adapter import TabularAdapter
+
+from traitsui.tests._tools import (
+    create_ui,
+    is_current_backend_qt4,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
+try:
+    from pyface.qt import QtCore, QtGui
+    from traitsui.qt4.tabular_model import TabularModel
+    from traitsui.qt4.tabular_editor import TabularEditor as QtTabularEditor
+except ImportError:
+    # The entire test case should be skipped if the current backend is not Qt
+    # But if it is Qt, then re-raise
+    if is_current_backend_qt4():
+        raise
+
+
+class DummyHasTraits(HasTraits):
+    names = List(Str)
+
+
+view = View(
+    Item(
+        "names",
+        editor=TabularEditor(
+            adapter=TabularAdapter(columns=["Name"]),
+        ),
+    )
+)
+
+
+@skip_if_not_qt4
+class TestTabularModel(unittest.TestCase):
+
+    def test_drop_mime_data_below_list(self):
+
+        obj = DummyHasTraits(names=["A", "B", "C"])
+
+        with store_exceptions_on_all_threads(), \
+                create_ui(obj, dict(view=view)) as ui:
+            editor, = ui.get_editors("names")
+
+            model =  editor.model
+            # sanity check
+            self.assertEqual(model.rowCount(None), 3)
+
+            # drag and drop row=1 from within the table.
+            # drag creates a PyMimeData object for dropMimeData to consume.
+            index = model.createIndex(1, 0)
+            mime_data = model.mimeData([index])
+            content = mime_data.instance()   # content should be 'B'
+
+            # If dropped directly onto the parent, both row and column are -1.
+            # See https://doc.qt.io/qt-5/qabstractitemmodel.html#dropMimeData
+            # When dropped below the list, the "parent" is invalid.
+            parent = QtCore.QModelIndex()   # invalid index object
+            model.dropMimeData(mime_data, QtCore.Qt.MoveAction, -1, -1, parent)
+
+            # Check row index 2
+            index = model.createIndex(2, 0)
+            mime_data = model.mimeData([index])
+            # Same content as the one dragged.
+            self.assertEqual(mime_data.instance(), content)
+
+    def test_drop_mime_data_within_list(self):
+
+        obj = DummyHasTraits(names=["A", "B", "C"])
+
+        with store_exceptions_on_all_threads(), \
+                create_ui(obj, dict(view=view)) as ui:
+            editor, = ui.get_editors("names")
+
+            model =  editor.model
+            # sanity check
+            self.assertEqual(model.rowCount(None), 3)
+
+            # drag and drop from within the table.
+            # drag creates a PyMimeData object for dropMimeData to consume.
+            index = model.createIndex(1, 0)  # row = 0, column=0
+            mime_data = model.mimeData([index])
+            content = mime_data.instance()   # content should be 'B'
+
+            # when
+            # drop it to row index 0
+            parent = model.createIndex(0, 0)
+            model.dropMimeData(mime_data, QtCore.Qt.MoveAction, -1, -1, parent)
+
+            # then
+            index = model.createIndex(0, 0)  # row = 0, column = 0
+            mime_data = model.mimeData([index])
+            # Same content as the one dragged.
+            self.assertEqual(mime_data.instance(), content)

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -111,3 +111,21 @@ class TestTabularModel(unittest.TestCase):
             mime_data = model.mimeData([index])
             # Same content as the one dragged.
             self.assertEqual(mime_data.instance(), content)
+
+    def test_move_rows_invalid_index(self):
+
+        obj = DummyHasTraits(names=["A", "B", "C"])
+
+        with store_exceptions_on_all_threads(), \
+                create_ui(obj, dict(view=view)) as ui:
+            editor, = ui.get_editors("names")
+
+            model =  editor.model
+
+            # -1 is an invalid row. This should not cause segfault.
+            model.moveRows([1], -1)
+
+            # -1 is converted to the last row (index = 2)
+            mime_data = model.mimeData([model.createIndex(2, 0)])
+            content = mime_data.instance()
+            self.assertEqual(content, ["B"])

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -52,7 +52,7 @@ def get_view(adapter):
 class TestTabularModel(unittest.TestCase):
 
     def test_drop_mime_data_below_list(self):
-
+        # Test dragging an item in the list and drop it below the last item
         obj = DummyHasTraits(names=["A", "B", "C", "D"])
         view = get_view(TabularAdapter(columns=["Name"]))
         with store_exceptions_on_all_threads(), \
@@ -81,7 +81,8 @@ class TestTabularModel(unittest.TestCase):
             self.assertEqual(content, ["A", "C", "D", "B"])
 
     def test_drop_mime_data_within_list(self):
-
+        # Test dragging an item in the list and drop it somewhere within the
+        # list
         obj = DummyHasTraits(names=["A", "B", "C", "D"])
         view = get_view(TabularAdapter(columns=["Name"]))
 
@@ -142,6 +143,7 @@ class TestTabularModel(unittest.TestCase):
             self.assertEqual(content, ["A", "B", "C", "A"])
 
     def test_move_rows_invalid_index(self):
+        # Test the last resort to prevent segfault
 
         obj = DummyHasTraits(names=["A", "B", "C"])
         view = get_view(TabularAdapter(columns=["Name"]))


### PR DESCRIPTION
This PR addresses my own comment in https://github.com/enthought/traitsui/pull/871#issuecomment-639392315

The row index should always be valid, that means nonnegative and less than the row count in the model.
See https://doc.qt.io/qt-5/qabstractitemmodel.html#checkIndex
See https://doc.qt.io/qt-5/qabstractitemmodel.html#dropMimeData for the scenario where row index will be -1.

This PR normalizes the row index for TraitsUI implementation of `QAbstractItemModel.dropMimeData`.
(It seems that the model never cares about the column index.)