### PR TITLE
Fix bad TraitListEvent in ListStr and Tabular Editors

### DIFF
--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -332,7 +332,11 @@ class _ListStrEditor(Editor):
             except ValueError:
                 pass
             else:
-                event = TraitListEvent(0, added, removed)
+                event = TraitListEvent(
+                    index=0,
+                    added=added,
+                    removed=removed
+                )
                 self._multi_selected_indices_items_changed(event)
 
     def _multi_selected_indices_changed(self, selected_indices):

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -446,7 +446,11 @@ class TabularEditor(Editor):
         except:
             pass
         else:
-            list_event = TraitListEvent(0, added, removed)
+            list_event = TraitListEvent(
+                index=0,
+                added=added,
+                removed=removed
+            )
             self._multi_selected_rows_items_changed(list_event)
 
     def _multi_selected_rows_changed(self, selected_rows):

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -377,32 +377,16 @@ class TestListStrEditor(unittest.TestCase):
             editor.multi_selected[0] = "two"
             gui.process_events()
 
-            # FIXME issue enthought/traitsui#791
-            if is_current_backend_qt4():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(get_selected_indices(editor), [1, 2])
-                    self.assertEqual(editor.multi_selected_indices, [1, 2])
-                self.assertEqual(get_selected_indices(editor), [2, 0])
-                self.assertEqual(editor.multi_selected_indices, [0, 2])
-            else:
-                self.assertEqual(sorted(get_selected_indices(editor)), [1, 2])
-                self.assertEqual(sorted(editor.multi_selected_indices), [1, 2])
+            self.assertEqual(sorted(get_selected_indices(editor)), [1, 2])
+            self.assertEqual(sorted(editor.multi_selected_indices), [1, 2])
 
             # If a change in multi_selected involves an invalid value, nothing
             # is changed
             editor.multi_selected[0] = "four"
             gui.process_events()
 
-            # FIXME issue enthought/traitsui#791
-            if is_current_backend_qt4():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(get_selected_indices(editor), [1, 2])
-                    self.assertEqual(editor.multi_selected_indices, [1, 2])
-                self.assertEqual(get_selected_indices(editor), [2, 0])
-                self.assertEqual(editor.multi_selected_indices, [0, 2])
-            else:
-                self.assertEqual(sorted(get_selected_indices(editor)), [1, 2])
-                self.assertEqual(sorted(editor.multi_selected_indices), [1, 2])
+            self.assertEqual(sorted(get_selected_indices(editor)), [1, 2])
+            self.assertEqual(sorted(editor.multi_selected_indices), [1, 2])
 
     def test_list_str_editor_item_count(self):
         gui = GUI()

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -339,31 +339,15 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             report.multi_selected[0] = people[1]
             gui.process_events()
 
-            # FIXME issue enthought/traitsui#791
-            if is_current_backend_qt4():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(get_selected_rows(editor), [1, 2])
-                    self.assertEqual(report.selected_rows, [1, 2])
-                self.assertEqual(get_selected_rows(editor), [2, 0])
-                self.assertEqual(report.selected_rows, [0, 2])
-            else:
-                self.assertEqual(sorted(get_selected_rows(editor)), [1, 2])
-                self.assertEqual(sorted(report.selected_rows), [1, 2])
+            self.assertEqual(sorted(get_selected_rows(editor)), [1, 2])
+            self.assertEqual(sorted(report.selected_rows), [1, 2])
 
             # If there's a single invalid value, nothing is updated
             report.multi_selected[0] = Person(name="invalid", age=-1)
             gui.process_events()
 
-            # FIXME issue enthought/traitsui#791
-            if is_current_backend_qt4():
-                with self.assertRaises(AssertionError):
-                    self.assertEqual(get_selected_rows(editor), [1, 2])
-                    self.assertEqual(report.selected_rows, [1, 2])
-                self.assertEqual(get_selected_rows(editor), [2, 0])
-                self.assertEqual(report.selected_rows, [0, 2])
-            else:
-                self.assertEqual(sorted(get_selected_rows(editor)), [1, 2])
-                self.assertEqual(sorted(report.selected_rows), [1, 2])
+            self.assertEqual(sorted(get_selected_rows(editor)), [1, 2])
+            self.assertEqual(sorted(report.selected_rows), [1, 2])
 
     def test_selected_reacts_to_model_changes(self):
         with self.report_and_editor(get_view()) as (report, editor):

--- a/traitsui/wx/list_str_editor.py
+++ b/traitsui/wx/list_str_editor.py
@@ -408,9 +408,9 @@ class _ListStrEditor(Editor):
         try:
             self._multi_selected_indices_items_changed(
                 TraitListEvent(
-                    0,
-                    [values.index(item) for item in event.removed],
-                    [values.index(item) for item in event.added],
+                    index=0,
+                    removed=[values.index(item) for item in event.removed],
+                    added=[values.index(item) for item in event.added],
                 )
             )
         except Exception:

--- a/traitsui/wx/tabular_editor.py
+++ b/traitsui/wx/tabular_editor.py
@@ -583,9 +583,9 @@ class TabularEditor(Editor):
         try:
             self._multi_selected_rows_items_changed(
                 TraitListEvent(
-                    0,
-                    [values.index(item) for item in event.removed],
-                    [values.index(item) for item in event.added],
+                    index=0,
+                    removed=[values.index(item) for item in event.removed],
+                    added=[values.index(item) for item in event.added],
                 )
             )
         except:


### PR DESCRIPTION
Closes #791 

`TraitListEvent` in `ListStrEditor` and `TabularEditor` now gets its arguments by keyword.

The tests for this PR are in #869 and #874 