### PR TITLE
Implement dispose for Qt TextEditor 

### DIFF
--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -72,17 +72,18 @@ class SimpleEditor(Editor):
 
         self._signals = []
         if wtype == QtGui.QTextEdit:
+            control.textChanged.connect(self.update_object)
             self._signals.append((control.textChanged, self.update_object))
         else:
             # QLineEdit
             if factory.auto_set and not factory.is_grid_cell:
+                control.textEdited.connect(self.update_object)
                 self._signals.append((control.textEdited, self.update_object))
             else:
+                control.editingFinished.connect(self.update_object)
                 self._signals.append(
                     (control.editingFinished, self.update_object)
                 )
-        for signal, handler in self._signals:
-            signal.connect(handler)
 
         placeholder = self.factory.placeholder
 

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -13,7 +13,6 @@
 """ Defines the various text editors for the PyQt user interface toolkit.
 """
 
-
 from pyface.qt import QtCore, QtGui
 
 from traits.api import TraitError
@@ -28,7 +27,6 @@ from .editor import Editor
 from .editor_factory import ReadonlyEditor as BaseReadonlyEditor
 
 from .constants import OKColor
-
 
 
 class SimpleEditor(Editor):
@@ -104,10 +102,9 @@ class SimpleEditor(Editor):
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
-        if self.control is not None:
-            while self._signals:
-                signal, handler = self._signals.pop()
-                signal.disconnect(handler)
+        while self._signals:
+            signal, handler = self._signals.pop()
+            signal.disconnect(handler)
 
         super().dispose()
 

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -15,7 +15,7 @@
 
 from pyface.qt import QtCore, QtGui
 
-from traits.api import TraitError
+from traits.api import Any, Callable, List, TraitError, Tuple
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
 # compatibility. The class has been moved to the
@@ -45,6 +45,13 @@ class SimpleEditor(Editor):
 
     #: Function used to evaluate textual user input:
     evaluate = evaluate_trait
+
+    # -- private trait definitions ------------------------------------------
+
+    #: A list of Qt signals connected.
+    #: First item in the tuple is the Qt signal. The second item is the event
+    #: handler.
+    _signals = List(Tuple(Any, Callable))
 
     def init(self, parent):
         """ Finishes initializing the editor by creating the underlying toolkit

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -102,6 +102,8 @@ class SimpleEditor(Editor):
         self.set_tooltip()
 
     def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
         if self.control is not None:
             while self._signals:
                 signal, handler = self._signals.pop()

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -48,9 +48,8 @@ class SimpleEditor(Editor):
 
     # -- private trait definitions ------------------------------------------
 
-    #: A list of Qt signals connected.
-    #: First item in the tuple is the Qt signal. The second item is the event
-    #: handler.
+    #: A list of tuple(Qt signal, slot) connected which need to be disconnected
+    #: in dispose.
     _signals = List(Tuple(Any, Callable))
 
     def init(self, parent):

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -50,7 +50,7 @@ class SimpleEditor(Editor):
 
     #: A list of tuple(Qt signal, slot) connected which need to be disconnected
     #: in dispose.
-    _signals = List(Tuple(Any, Callable))
+    _connections_to_remove = List(Tuple(Any, Callable))
 
     def init(self, parent):
         """ Finishes initializing the editor by creating the underlying toolkit
@@ -76,18 +76,20 @@ class SimpleEditor(Editor):
         if factory.password:
             control.setEchoMode(QtGui.QLineEdit.Password)
 
-        self._signals = []
+        self._connections_to_remove = []
         if wtype == QtGui.QTextEdit:
             control.textChanged.connect(self.update_object)
-            self._signals.append((control.textChanged, self.update_object))
+            self._connections_to_remove.append(
+                (control.textChanged, self.update_object))
         else:
             # QLineEdit
             if factory.auto_set and not factory.is_grid_cell:
                 control.textEdited.connect(self.update_object)
-                self._signals.append((control.textEdited, self.update_object))
+                self._connections_to_remove.append(
+                    (control.textEdited, self.update_object))
             else:
                 control.editingFinished.connect(self.update_object)
-                self._signals.append(
+                self._connections_to_remove.append(
                     (control.editingFinished, self.update_object)
                 )
 
@@ -109,8 +111,8 @@ class SimpleEditor(Editor):
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
-        while self._signals:
-            signal, handler = self._signals.pop()
+        while self._connections_to_remove:
+            signal, handler = self._connections_to_remove.pop()
             signal.disconnect(handler)
 
         super().dispose()

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -98,6 +98,20 @@ class SimpleEditor(Editor):
         self.set_error_state(False)
         self.set_tooltip()
 
+    def dispose(self):
+        if self.control is not None:
+            control = self.control
+            if self.factory.auto_set and not self.factory.is_grid_cell:
+                if isinstance(control, QtGui.QTextEdit):
+                    control.textChanged.disconnect(self.update_object)
+                else:
+                    control.textEdited.disconnect(self.update_object)
+
+            else:
+                control.editingFinished.disconnect(self.update_object)
+
+        super().dispose()
+
     def update_object(self):
         """ Handles the user entering input data in the edit control.
         """

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -76,7 +76,6 @@ class SimpleEditor(Editor):
         if factory.password:
             control.setEchoMode(QtGui.QLineEdit.Password)
 
-        self._connections_to_remove = []
         if wtype == QtGui.QTextEdit:
             control.textChanged.connect(self.update_object)
             self._connections_to_remove.append(

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -66,7 +66,6 @@ def set_text(editor, text):
 
     if is_current_backend_qt4():
         from pyface.qt import QtGui
-        control = editor.control
         if editor.base_style == QtGui.QLineEdit:
             editor.control.clear()
             editor.control.insert(text)

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -157,6 +157,15 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
             else:
                 self.assertEqual(placeholder, "Enter name")
 
+
+# We should be able to run this test case against wx.
+# Not running them now to avoid test interaction. See enthought/traitsui#752
+@skip_if_not_qt4
+class TestTextEditor(unittest.TestCase):
+    """ Tests that can be run with any toolkit as long as there is an
+    implementation for simulating user interactions.
+    """
+
     def check_editor_init_and_dispose(self, style, auto_set):
         # Smoke test to test setup and tear down of an editor.
         # This test can be pull out to become toolkit-agnostic once

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -101,19 +101,29 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
             else:
                 self.assertEqual(placeholder, "Enter name")
 
-    def check_editor_init_and_dispose(self, style):
+    def check_editor_init_and_dispose(self, style, auto_set):
         # Smoke test to test setup and tear down of an editor.
         # This test can be pull out to become toolkit-agnostic once
         # wx TextEditor also implements dispose.
         foo = Foo()
-        view = View(Item("name", editor=TextEditor(), style=style))
+        view = View(
+            Item("name", editor=TextEditor(auto_set=auto_set), style=style)
+        )
         with create_ui(foo, dict(view=view)):
             pass
 
     def test_simple_editor_init_and_dispose(self):
         # Smoke test to test setup and tear down of an editor.
-        self.check_editor_init_and_dispose(style="simple")
+        self.check_editor_init_and_dispose(style="simple", auto_set=True)
 
     def test_custom_editor_init_and_dispose(self):
         # Smoke test to test setup and tear down of an editor.
-        self.check_editor_init_and_dispose(style="custom")
+        self.check_editor_init_and_dispose(style="custom", auto_set=True)
+
+    def test_simple_editor_init_and_dispose_no_auto_set(self):
+        # Smoke test to test setup and tear down of an editor.
+        self.check_editor_init_and_dispose(style="simple", auto_set=False)
+
+    def test_custom_editor_init_and_dispose_no_auto_set(self):
+        # Smoke test to test setup and tear down of an editor.
+        self.check_editor_init_and_dispose(style="custom", auto_set=False)

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -18,6 +18,7 @@ from traits.api import (
 )
 from traitsui.api import TextEditor, View, Item
 from traitsui.tests._tools import (
+    create_ui,
     GuiTestAssistant,
     skip_if_not_qt4,
     no_gui_test_assistant,
@@ -99,3 +100,20 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
                 pass
             else:
                 self.assertEqual(placeholder, "Enter name")
+
+    def check_editor_init_and_dispose(self, style):
+        # Smoke test to test setup and tear down of an editor.
+        # This test can be pull out to become toolkit-agnostic once
+        # wx TextEditor also implements dispose.
+        foo = Foo()
+        view = View(Item("name", editor=TextEditor(), style=style))
+        with create_ui(foo, dict(view=view)):
+            pass
+
+    def test_simple_editor_init_and_dispose(self):
+        # Smoke test to test setup and tear down of an editor.
+        self.check_editor_init_and_dispose(style="simple")
+
+    def test_custom_editor_init_and_dispose(self):
+        # Smoke test to test setup and tear down of an editor.
+        self.check_editor_init_and_dispose(style="custom")

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -12,6 +12,8 @@
 import contextlib
 import unittest
 
+from pyface.api import GUI
+
 from traits.api import (
     HasTraits,
     Str,
@@ -20,6 +22,7 @@ from traitsui.api import TextEditor, View, Item
 from traitsui.tests._tools import (
     create_ui,
     GuiTestAssistant,
+    is_current_backend_qt4,
     skip_if_not_qt4,
     no_gui_test_assistant,
 )
@@ -38,6 +41,59 @@ def launch_ui(gui_test_case, object, view):
     finally:
         with gui_test_case.delete_widget(ui.control):
             ui.dispose()
+
+
+def get_view(style, auto_set):
+    """ Return the default view for the Foo object.
+
+    Parameters
+    ----------
+    style : str
+        e.g. 'simple', or 'custom'
+    auto_set : bool
+        To be passed directly to the editor factory.
+    """
+    return View(
+        Item("name", editor=TextEditor(auto_set=auto_set), style=style)
+    )
+
+
+def set_text(editor, text):
+    """ Imitate user changing the text on the text box to a new value. Note
+    that this is equivalent to "clear and insert", which excludes confirmation
+    via pressing a return key or causing the widget to lose focus.
+    """
+
+    if is_current_backend_qt4():
+        from pyface.qt import QtGui
+        control = editor.control
+        if editor.base_style == QtGui.QLineEdit:
+            editor.control.clear()
+            editor.control.insert(text)
+            editor.control.textEdited.emit(text)
+        else:
+            editor.control.setText(text)
+            editor.control.textChanged.emit()
+    else:
+        raise unittest.SkipTest("Not implemented for the current toolkit.")
+
+
+def key_press_return(editor):
+    """ Imitate user confirming the text by pressing the return key.
+    """
+    if is_current_backend_qt4():
+        from pyface.qt import QtGui
+        control = editor.control
+
+        # ideally we should fire keyPressEvent, but the editor does not
+        # bind to this event. Pressing return key will fire editingFinished
+        # event on a QLineEdit
+        if editor.base_style == QtGui.QLineEdit:
+            control.editingFinished.emit()
+        else:
+            editor.control.append("")
+    else:
+        raise unittest.SkipTest("Not implemented for the current toolkit.")
 
 
 # Skips tests if the backend is not either qt4 or qt5
@@ -106,9 +162,7 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
         # This test can be pull out to become toolkit-agnostic once
         # wx TextEditor also implements dispose.
         foo = Foo()
-        view = View(
-            Item("name", editor=TextEditor(auto_set=auto_set), style=style)
-        )
+        view = get_view(style=style, auto_set=auto_set)
         with create_ui(foo, dict(view=view)):
             pass
 
@@ -127,3 +181,60 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
     def test_custom_editor_init_and_dispose_no_auto_set(self):
         # Smoke test to test setup and tear down of an editor.
         self.check_editor_init_and_dispose(style="custom", auto_set=False)
+
+    def test_simple_auto_set_update_text(self):
+        foo = Foo()
+        view = get_view(style="simple", auto_set=True)
+        gui = GUI()
+        with create_ui(foo, dict(view=view)) as ui:
+            editor, = ui.get_editors("name")
+            set_text(editor, "NEW")
+            gui.process_events()
+
+            self.assertEqual(foo.name, "NEW")
+
+    def test_simple_auto_set_false_do_not_update(self):
+        foo = Foo(name="")
+        view = get_view(style="simple", auto_set=False)
+        gui = GUI()
+        with create_ui(foo, dict(view=view)) as ui:
+            editor, = ui.get_editors("name")
+
+            set_text(editor, "NEW")
+            gui.process_events()
+
+            self.assertEqual(foo.name, "")
+
+            key_press_return(editor)
+            gui.process_events()
+
+            self.assertEqual(foo.name, "NEW")
+
+    def test_custom_auto_set_true_update_text(self):
+        # the auto_set flag is disregard for custom editor.
+        foo = Foo()
+        view = get_view(auto_set=True, style="custom")
+        gui = GUI()
+        with create_ui(foo, dict(view=view)) as ui:
+            editor, = ui.get_editors("name")
+
+            set_text(editor, "NEW")
+            gui.process_events()
+
+            self.assertEqual(foo.name, "NEW")
+
+    def test_custom_auto_set_false_update_text(self):
+        # the auto_set flag is disregard for custom editor.
+        foo = Foo()
+        view = get_view(auto_set=False, style="custom")
+        gui = GUI()
+        with create_ui(foo, dict(view=view)) as ui:
+            editor, = ui.get_editors("name")
+
+            set_text(editor, "NEW")
+            gui.process_events()
+
+            key_press_return(editor)
+            gui.process_events()
+
+            self.assertEqual(foo.name, "NEW\n")

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -82,13 +82,12 @@ def key_press_return(editor):
     """
     if is_current_backend_qt4():
         from pyface.qt import QtGui
-        control = editor.control
 
         # ideally we should fire keyPressEvent, but the editor does not
         # bind to this event. Pressing return key will fire editingFinished
         # event on a QLineEdit
         if editor.base_style == QtGui.QLineEdit:
-            control.editingFinished.emit()
+            editor.control.editingFinished.emit()
         else:
             editor.control.append("")
     else:

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -24,6 +24,7 @@ from traitsui.tests._tools import (
     GuiTestAssistant,
     is_current_backend_qt4,
     skip_if_not_qt4,
+    store_exceptions_on_all_threads,
     no_gui_test_assistant,
 )
 
@@ -168,7 +169,8 @@ class TestTextEditor(unittest.TestCase):
         # Smoke test to test setup and tear down of an editor.
         foo = Foo()
         view = get_view(style=style, auto_set=auto_set)
-        with create_ui(foo, dict(view=view)):
+        with store_exceptions_on_all_threads(), \
+                create_ui(foo, dict(view=view)):
             pass
 
     def test_simple_editor_init_and_dispose(self):
@@ -191,7 +193,8 @@ class TestTextEditor(unittest.TestCase):
         foo = Foo()
         view = get_view(style="simple", auto_set=True)
         gui = GUI()
-        with create_ui(foo, dict(view=view)) as ui:
+        with store_exceptions_on_all_threads(), \
+                create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
             set_text(editor, "NEW")
             gui.process_events()
@@ -202,7 +205,8 @@ class TestTextEditor(unittest.TestCase):
         foo = Foo(name="")
         view = get_view(style="simple", auto_set=False)
         gui = GUI()
-        with create_ui(foo, dict(view=view)) as ui:
+        with store_exceptions_on_all_threads(), \
+                create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
             set_text(editor, "NEW")
@@ -220,7 +224,8 @@ class TestTextEditor(unittest.TestCase):
         foo = Foo()
         view = get_view(auto_set=True, style="custom")
         gui = GUI()
-        with create_ui(foo, dict(view=view)) as ui:
+        with store_exceptions_on_all_threads(), \
+                create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
             set_text(editor, "NEW")
@@ -233,7 +238,8 @@ class TestTextEditor(unittest.TestCase):
         foo = Foo()
         view = get_view(auto_set=False, style="custom")
         gui = GUI()
-        with create_ui(foo, dict(view=view)) as ui:
+        with store_exceptions_on_all_threads(), \
+                create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
             set_text(editor, "NEW")

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -78,7 +78,7 @@ def set_text(editor, text):
 
 
 def key_press_return(editor):
-    """ Imitate user confirming the text by pressing the return key.
+    """ Imitate user pressing the return key.
     """
     if is_current_backend_qt4():
         from pyface.qt import QtGui
@@ -166,8 +166,6 @@ class TestTextEditor(unittest.TestCase):
 
     def check_editor_init_and_dispose(self, style, auto_set):
         # Smoke test to test setup and tear down of an editor.
-        # This test can be pull out to become toolkit-agnostic once
-        # wx TextEditor also implements dispose.
         foo = Foo()
         view = get_view(style=style, auto_set=auto_set)
         with create_ui(foo, dict(view=view)):


### PR DESCRIPTION
Part of #431 

This PR implements the missing `dispose` method in Qt TextEditor.

In the process of testing the dispose method, I discovered a bug:
```
class Foo(HasTraits):
    value = Float()

view = View(
    Item('value', editor=TextEditor(auto_set=False), style="custom"),
)
Foo().configure_traits(view=view)
```

Launching the GUI fails with:
```
...
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/qt4/ui_panel.py", line 874, in _add_items
    editor.prepare(inner)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/editor.py", line 264, in prepare
    self.init(parent)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/qt4/text_editor.py", line 84, in init
    control.editingFinished.connect(self.update_object)
AttributeError: 'QTextEdit' object has no attribute 'editingFinished'
```

In order to test the new dispose for the custom editor, I also had to fix this bug and add more tests for the behaviour not previously tested.
I can also confirm the behaviour on `examples/demo/Standard_Editors/TextEditor_demo.py` has not changed with this PR.