### PR TITLE
Implement dispose method for CheckListEditor (Qt)

### DIFF
--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -40,37 +40,16 @@ logger = logging.getLogger(__name__)
 capitalize = lambda s: s.capitalize()
 
 
-# -------------------------------------------------------------------------
-#  'SimpleEditor' class:
-# -------------------------------------------------------------------------
-
-
-class SimpleEditor(EditorWithList):
-    """ Simple style of editor for checklists, which displays a combo box.
+class BaseCheckListEditor(EditorWithList):
+    """ Base class that implement the common logic of simple and custom
+    CheckListEditor.
     """
-
-    # -------------------------------------------------------------------------
-    #  Trait definitions:
-    # -------------------------------------------------------------------------
 
     #: Checklist item names
     names = List(Str)
 
     #: Checklist item values
     values = List()
-
-    def init(self, parent):
-        """ Finishes initializing the editor by creating the underlying toolkit
-            widget.
-        """
-        self.create_control(parent)
-        super(SimpleEditor, self).init(parent)
-
-    def create_control(self, parent):
-        """ Creates the initial editor control.
-        """
-        self.control = QtGui.QComboBox()
-        self.control.activated[int].connect(self.update_object)
 
     def list_updated(self, values):
         """ Handles updates to the list of legal checklist values.
@@ -105,6 +84,38 @@ class SimpleEditor(EditorWithList):
 
     def rebuild_editor(self):
         """ Rebuilds the editor after its definition is modified.
+        Subclass should implement this method
+        """
+        raise NotImplementedError("rebuild_editor must be implemented.")
+
+# -------------------------------------------------------------------------
+#  'SimpleEditor' class:
+# -------------------------------------------------------------------------
+
+
+class SimpleEditor(BaseCheckListEditor):
+    """ Simple style of editor for checklists, which displays a combo box.
+    """
+
+    # -------------------------------------------------------------------------
+    #  Trait definitions:
+    # -------------------------------------------------------------------------
+
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        self.create_control(parent)
+        super(SimpleEditor, self).init(parent)
+
+    def create_control(self, parent):
+        """ Creates the initial editor control.
+        """
+        self.control = QtGui.QComboBox()
+        self.control.activated[int].connect(self.update_object)
+
+    def rebuild_editor(self):
+        """ Rebuilds the editor after its definition is modified.
         """
         control = self.control
         control.clear()
@@ -132,10 +143,17 @@ class SimpleEditor(EditorWithList):
             pass
 
 
-class CustomEditor(SimpleEditor):
+class CustomEditor(BaseCheckListEditor):
     """ Custom style of editor for checklists, which displays a set of check
         boxes.
     """
+
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        self.create_control(parent)
+        super(CustomEditor, self).init(parent)
 
     def create_control(self, parent):
         """ Creates the initial editor control.

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -45,6 +45,10 @@ class BaseCheckListEditor(EditorWithList):
     CheckListEditor.
     """
 
+    # -------------------------------------------------------------------------
+    #  Trait definitions:
+    # -------------------------------------------------------------------------
+
     #: Checklist item names
     names = List(Str)
 
@@ -96,10 +100,6 @@ class BaseCheckListEditor(EditorWithList):
 class SimpleEditor(BaseCheckListEditor):
     """ Simple style of editor for checklists, which displays a combo box.
     """
-
-    # -------------------------------------------------------------------------
-    #  Trait definitions:
-    # -------------------------------------------------------------------------
 
     def init(self, parent):
         """ Finishes initializing the editor by creating the underlying toolkit

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -108,6 +108,14 @@ class SimpleEditor(BaseCheckListEditor):
         self.create_control(parent)
         super(SimpleEditor, self).init(parent)
 
+    def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
+        if self.control is not None:
+            self.control.activated[int].disconnect(self.update_object)
+
+        super().dispose()
+
     def create_control(self, parent):
         """ Creates the initial editor control.
         """
@@ -154,6 +162,30 @@ class CustomEditor(BaseCheckListEditor):
         """
         self.create_control(parent)
         super(CustomEditor, self).init(parent)
+
+    def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
+        if self.control is not None:
+            self.clear_layout()
+
+        if self._mapper is not None:
+            self._mapper.mapped[str].disconnect(self.update_object)
+            self._mapper = None
+
+        super().dispose()
+
+    def dispose_child(self, child):
+        """ Carry out necessary clean up before a child widget is removed from
+        the control layout.
+
+        Parameters
+        ----------
+        child : QWidget
+        """
+        if self._mapper is not None:
+            child.clicked.disconnect(self._mapper.map)
+            self._mapper.removeMappings(child)
 
     def create_control(self, parent):
         """ Creates the initial editor control.

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -41,7 +41,7 @@ capitalize = lambda s: s.capitalize()
 
 
 class BaseCheckListEditor(EditorWithList):
-    """ Base class that implement the common logic of simple and custom
+    """ Base class that implements the common logic of simple and custom
     CheckListEditor.
     """
 

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -36,7 +36,22 @@ class Editor(UIEditor):
             if itm is None:
                 break
 
-            itm.widget().setParent(None)
+            widget = itm.widget()
+            self.dispose_child(widget)
+            widget.setParent(None)
+
+    def dispose_child(self, child):
+        """ Carry out necessary clean up before a child widget is removed from
+        the control layout.
+
+        Subclass should override this method if children widgets require
+        cleanup. Default implementation does nothing to the given child widget.
+
+        Parameters
+        ----------
+        child : QWidget
+        """
+        pass
 
     def _control_changed(self, control):
         """ Handles the **control** trait being set.


### PR DESCRIPTION
Part of #431

This PR does the following for the Qt implementation of `CheckListEditor`:
- `CustomEditor` no longer subclasses `SimpleEditor` in order to reuse the `list_updated` method. This relationship makes it difficult to implement `dispose` as the two editors need to perform different cleanup. The `list_updated` logic is now refactored out to a base class.  Then it is easier to see what needs to be disconnected and cleaned up in each of these concrete subclasses.
- Added `dispose_child` (naming to be confirmed?) in `traitsui.qt4.editor.Editor` which will be called when a child widget in a layout is removed.  The default implementation does nothing, and the `CheckListEditor` reimplements this method. This should be done for `EnumEditor` as well (not in this PR, but will be part of #431 as well).

See #882 too for an alternative approach.

Note: The refactored `BaseCheckListEditor` actually shares **identical** code with the implementation in wx. This should be further refactored into a toolkit-agnostic base class or mixin. This should be done in a separate PR though. 