### PR TITLE
Alternative approach to implement dispose for Qt CheckListEditor

### DIFF
--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -226,7 +226,6 @@ class CustomEditor(BaseCheckListEditor):
         incr[-1] = -sum(incr[:-1]) + 1
 
         # Add the set of all possible choices:
-        check_boxes = []
         layout = self.control.layout()
         index = 0
         for i in range(rows):
@@ -240,17 +239,16 @@ class CustomEditor(BaseCheckListEditor):
                     else:
                         cb.setCheckState(QtCore.Qt.Unchecked)
 
+                    cb.clicked.connect(self._mapper.map)
+                    self._rebuild_signals.append(
+                        (cb.clicked, self._mapper.map)
+                    )
                     self._mapper.setMapping(cb, labels[index])
 
                     layout.addWidget(cb, i, j)
-                    check_boxes.append(cb)
 
                     index += incr[j]
                     n -= 1
-
-        for check_box in check_boxes:
-            check_box.clicked.connect(self._mapper.map)
-            self._rebuild_signals.append((check_box.clicked, self._mapper.map))
 
     def update_object(self, label):
         """ Handles the user clicking one of the custom check boxes.

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -152,6 +152,13 @@ class CustomEditor(SimpleEditor):
     #: editor.
     _connections_to_rebuild = List(Tuple(Any, Callable))
 
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        self.create_control(parent)
+        EditorWithList.init(self, parent)
+
     def create_control(self, parent):
         """ Creates the initial editor control.
         """

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -40,37 +40,16 @@ logger = logging.getLogger(__name__)
 capitalize = lambda s: s.capitalize()
 
 
-# -------------------------------------------------------------------------
-#  'SimpleEditor' class:
-# -------------------------------------------------------------------------
-
-
-class SimpleEditor(EditorWithList):
-    """ Simple style of editor for checklists, which displays a combo box.
+class BaseCheckListEditor(EditorWithList):
+    """ Base class that implement the common logic of simple and custom
+    CheckListEditor.
     """
-
-    # -------------------------------------------------------------------------
-    #  Trait definitions:
-    # -------------------------------------------------------------------------
 
     #: Checklist item names
     names = List(Str)
 
     #: Checklist item values
     values = List()
-
-    def init(self, parent):
-        """ Finishes initializing the editor by creating the underlying toolkit
-            widget.
-        """
-        self.create_control(parent)
-        super(SimpleEditor, self).init(parent)
-
-    def create_control(self, parent):
-        """ Creates the initial editor control.
-        """
-        self.control = QtGui.QComboBox()
-        self.control.activated[int].connect(self.update_object)
 
     def list_updated(self, values):
         """ Handles updates to the list of legal checklist values.
@@ -105,6 +84,38 @@ class SimpleEditor(EditorWithList):
 
     def rebuild_editor(self):
         """ Rebuilds the editor after its definition is modified.
+        Subclass should implement this method
+        """
+        raise NotImplementedError("rebuild_editor must be implemented.")
+
+# -------------------------------------------------------------------------
+#  'SimpleEditor' class:
+# -------------------------------------------------------------------------
+
+
+class SimpleEditor(BaseCheckListEditor):
+    """ Simple style of editor for checklists, which displays a combo box.
+    """
+
+    # -------------------------------------------------------------------------
+    #  Trait definitions:
+    # -------------------------------------------------------------------------
+
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        self.create_control(parent)
+        super(SimpleEditor, self).init(parent)
+
+    def create_control(self, parent):
+        """ Creates the initial editor control.
+        """
+        self.control = QtGui.QComboBox()
+        self.control.activated[int].connect(self.update_object)
+
+    def rebuild_editor(self):
+        """ Rebuilds the editor after its definition is modified.
         """
         control = self.control
         control.clear()
@@ -132,10 +143,17 @@ class SimpleEditor(EditorWithList):
             pass
 
 
-class CustomEditor(SimpleEditor):
+class CustomEditor(BaseCheckListEditor):
     """ Custom style of editor for checklists, which displays a set of check
         boxes.
     """
+
+    def init(self, parent):
+        """ Finishes initializing the editor by creating the underlying toolkit
+            widget.
+        """
+        self.create_control(parent)
+        super(CustomEditor, self).init(parent)
 
     def create_control(self, parent):
         """ Creates the initial editor control.

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -45,6 +45,10 @@ class BaseCheckListEditor(EditorWithList):
     CheckListEditor.
     """
 
+    # -------------------------------------------------------------------------
+    #  Trait definitions:
+    # -------------------------------------------------------------------------
+
     #: Checklist item names
     names = List(Str)
 
@@ -96,10 +100,6 @@ class BaseCheckListEditor(EditorWithList):
 class SimpleEditor(BaseCheckListEditor):
     """ Simple style of editor for checklists, which displays a combo box.
     """
-
-    # -------------------------------------------------------------------------
-    #  Trait definitions:
-    # -------------------------------------------------------------------------
 
     def init(self, parent):
         """ Finishes initializing the editor by creating the underlying toolkit

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -173,12 +173,12 @@ class CustomEditor(BaseCheckListEditor):
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
-        while self._connections_to_dispose:
-            signal, handler = self._connections_to_dispose.pop()
-            signal.disconnect(handler)
-
         while self._connections_to_rebuild:
             signal, handler = self._connections_to_rebuild.pop()
+            signal.disconnect(handler)
+
+        while self._connections_to_dispose:
+            signal, handler = self._connections_to_dispose.pop()
             signal.disconnect(handler)
 
         if self.control is not None:

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -145,9 +145,6 @@ class CustomEditor(SimpleEditor):
         boxes.
     """
 
-    #: List of tuple(signal, slot) to be disconnected in dispose
-    _connections_to_dispose = List(Tuple(Any, Callable))
-
     #: List of tuple(signal, slot) to be disconnected while rebuilding the
     #: editor.
     _connections_to_rebuild = List(Tuple(Any, Callable))
@@ -168,9 +165,6 @@ class CustomEditor(SimpleEditor):
 
         self._mapper = QtCore.QSignalMapper()
         self._mapper.mapped[str].connect(self.update_object)
-        self._connections_to_dispose.append(
-            (self._mapper.mapped[str], self.update_object)
-        )
 
     def dispose(self):
         """ Disposes of the contents of an editor.
@@ -179,11 +173,9 @@ class CustomEditor(SimpleEditor):
             signal, handler = self._connections_to_rebuild.pop()
             signal.disconnect(handler)
 
-        while self._connections_to_dispose:
-            signal, handler = self._connections_to_dispose.pop()
-            signal.disconnect(handler)
-
+        # signal from create_control
         if self._mapper is not None:
+            self._mapper.mapped[str].disconnect(self.update_object)
             self._mapper = None
 
         # enthought/traitsui#884

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -108,6 +108,14 @@ class SimpleEditor(BaseCheckListEditor):
         self.create_control(parent)
         super(SimpleEditor, self).init(parent)
 
+    def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
+        if self.control is not None:
+            self.control.activated[int].disconnect(self.update_object)
+
+        super().dispose()
+
     def create_control(self, parent):
         """ Creates the initial editor control.
         """
@@ -154,6 +162,30 @@ class CustomEditor(BaseCheckListEditor):
         """
         self.create_control(parent)
         super(CustomEditor, self).init(parent)
+
+    def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
+        if self.control is not None:
+            self.clear_layout()
+
+        if self._mapper is not None:
+            self._mapper.mapped[str].disconnect(self.update_object)
+            self._mapper = None
+
+        super().dispose()
+
+    def dispose_child(self, child):
+        """ Carry out necessary clean up before a child widget is removed from
+        the control layout.
+
+        Parameters
+        ----------
+        child : QWidget
+        """
+        if self._mapper is not None:
+            child.clicked.disconnect(self._mapper.map)
+            self._mapper.removeMappings(child)
 
     def create_control(self, parent):
         """ Creates the initial editor control.

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -41,7 +41,7 @@ capitalize = lambda s: s.capitalize()
 
 
 class BaseCheckListEditor(EditorWithList):
-    """ Base class that implement the common logic of simple and custom
+    """ Base class that implements the common logic of simple and custom
     CheckListEditor.
     """
 

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -181,9 +181,6 @@ class CustomEditor(BaseCheckListEditor):
             signal, handler = self._connections_to_dispose.pop()
             signal.disconnect(handler)
 
-        if self.control is not None:
-            self.clear_layout()
-
         if self._mapper is not None:
             self._mapper = None
 

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -36,7 +36,22 @@ class Editor(UIEditor):
             if itm is None:
                 break
 
-            itm.widget().setParent(None)
+            widget = itm.widget()
+            self.dispose_child(widget)
+            widget.setParent(None)
+
+    def dispose_child(self, child):
+        """ Carry out necessary clean up before a child widget is removed from
+        the control layout.
+
+        Subclass should override this method if children widgets require
+        cleanup. Default implementation does nothing to the given child widget.
+
+        Parameters
+        ----------
+        child : QWidget
+        """
+        pass
 
     def _control_changed(self, control):
         """ Handles the **control** trait being set.

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -36,22 +36,7 @@ class Editor(UIEditor):
             if itm is None:
                 break
 
-            widget = itm.widget()
-            self.dispose_child(widget)
-            widget.setParent(None)
-
-    def dispose_child(self, child):
-        """ Carry out necessary clean up before a child widget is removed from
-        the control layout.
-
-        Subclass should override this method if children widgets require
-        cleanup. Default implementation does nothing to the given child widget.
-
-        Parameters
-        ----------
-        child : QWidget
-        """
-        pass
+            itm.widget().setParent(None)
 
     def _control_changed(self, control):
         """ Handles the **control** trait being set.


### PR DESCRIPTION
This PR presents an alternative approach to https://github.com/enthought/traitsui/pull/881
~One of these two can merge, but not both :)~.  I have unilaterally closed #881 in favour of this.

~Like in #881, this is also done here:~
- ~`CustomEditor` no longer subclasses `SimpleEditor` in order to reuse the `list_updated` method. This relationship makes it difficult to implement `dispose` as the two editors need to perform different cleanup. The `list_updated` logic is now refactored out to a base class.  Then it is easier to see what needs to be disconnected and cleaned up in each of these concrete subclasses.~ (Edited: This is removed)

Instead of adding `dispose_child` to the editor base class's `clear_layout`, the approach in this PR keeps lists of connected signals.

In particular, `append` is called immediately after `connect`. This is particularly important because `rebuild_editors` is called from a change handler, and it is possible for it to fail halfway.