### PR TITLE
Reverse on_trait_change hook in Qt ButtonEditor's dispose

### DIFF
--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -168,6 +168,8 @@ class CustomEditor(SimpleEditor):
         self.set_tooltip()
 
     def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
         if self.control is not None:
             self.control.clicked.disconnect(self.update_object)
 

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -75,6 +75,19 @@ class SimpleEditor(Editor):
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
+
+        if self.factory.values_trait:
+            self.object.on_trait_change(
+                self._update_menu,
+                self.factory.values_trait,
+                remove=True,
+            )
+            self.object.on_trait_change(
+                self._update_menu,
+                self.factory.values_trait + "_items",
+                remove=True,
+            )
+
         if self.control is not None:
             self.control.clicked.disconnect(self.update_object)
         super(SimpleEditor, self).dispose()
@@ -153,3 +166,10 @@ class CustomEditor(SimpleEditor):
         self.sync_value(self.factory.label_value, "label", "from")
         self.control.clicked.connect(self.update_object)
         self.set_tooltip()
+
+    def dispose(self):
+        if self.control is not None:
+            self.control.clicked.disconnect(self.update_object)
+
+        # enthought/traitsui#884
+        Editor.dispose(self)

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -173,5 +173,6 @@ class CustomEditor(SimpleEditor):
         if self.control is not None:
             self.control.clicked.disconnect(self.update_object)
 
+        # FIXME: Maybe better to let this class subclass Editor directly
         # enthought/traitsui#884
         Editor.dispose(self)

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -116,7 +116,7 @@ class TestButtonEditorValuesTrait(unittest.TestCase):
             with create_ui(instance, dict(view=view)):
                 pass
 
-            # Mutating trait afterward the GUI is closed is okay
+            # It is okay to mutate trait after the GUI is disposed.
             instance.values = ["Item3"]
 
     def test_simple_editor_values_trait_init_and_dispose(self):

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -109,7 +109,6 @@ class TestButtonEditorValuesTrait(unittest.TestCase):
 
     def check_editor_values_trait_init_and_dispose(self, style):
         # Smoke test to check init and dispose when values_trait is used.
-        gui = GUI()
         instance = ButtonTextEdit(values=["Item1", "Item2"])
         view = self.get_view(style=style)
         with store_exceptions_on_all_threads():


### PR DESCRIPTION
Part of #431

This PR adds missing dispose logic for Qt's ButtonEditor.
