### PR TITLE
Implement dispose for DateEditor (Qt)

### DIFF
--- a/traitsui/qt4/date_editor.py
+++ b/traitsui/qt4/date_editor.py
@@ -77,6 +77,12 @@ class SimpleEditor(Editor):
 
         self.control.dateChanged.connect(self.update_object)
 
+    def dispose(self):
+        """ Disposes of the contents of an editor."""
+        if self.control is not None:
+            self.control.dateChanged.disconnect(self.update_object)
+        super().dispose()
+
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
             editor.
@@ -113,6 +119,12 @@ class CustomEditor(Editor):
             self.control.setMaximumDate(QtCore.QDate.currentDate())
 
         self.control.clicked.connect(self.update_object)
+
+    def dispose(self):
+        """ Disposes of the contents of an editor."""
+        if self.control is not None:
+            self.control.clicked.disconnect(self.update_object)
+        super().dispose()
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the

--- a/traitsui/qt4/styled_date_editor.py
+++ b/traitsui/qt4/styled_date_editor.py
@@ -9,7 +9,6 @@ from .date_editor import SimpleEditor
 from .date_editor import CustomEditor as DateCustomEditor
 
 
-
 class CustomEditor(DateCustomEditor):
 
     dates = Dict()
@@ -17,10 +16,7 @@ class CustomEditor(DateCustomEditor):
     styles = Dict()
 
     def init(self, parent):
-        self.control = QtGui.QCalendarWidget()
-
-        if not self.factory.allow_future:
-            self.control.setMaximumDate(QtCore.QDate.currentDate())
+        super().init(parent)
 
         if not self.factory.allow_past:
             self.control.setMinimumDate(QtCore.QDate.currentDate())
@@ -28,10 +24,6 @@ class CustomEditor(DateCustomEditor):
         if self.factory.dates_trait and self.factory.styles_trait:
             self.sync_value(self.factory.dates_trait, "dates", "from")
             self.sync_value(self.factory.styles_trait, "styles", "from")
-
-        self.control.clicked.connect(self.update_object)
-
-        return
 
     def _dates_changed(self, old, new):
         # Someone changed out the entire dict.  The easiest, most robust

--- a/traitsui/tests/editors/test_date_editor.py
+++ b/traitsui/tests/editors/test_date_editor.py
@@ -6,7 +6,11 @@ from traits.api import Date, HasTraits, List
 from traitsui.api import DateEditor, View, Item
 from traitsui.editors.date_editor import CellFormat
 
-from traitsui.tests._tools import skip_if_not_qt4
+from traitsui.tests._tools import (
+    create_ui,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
 
 
 class Foo(HasTraits):
@@ -158,3 +162,32 @@ class TestDateEditorCustomQt(unittest.TestCase):
             expected,
             "Expected color: {!r}. Got color: {!r}".format(expected, actual),
         )
+
+
+# Run this test case against wx too once enthought/traitsui#752 is fixed.
+@skip_if_not_qt4
+class TestDateEditorInitDispose(unittest.TestCase):
+    """ Test the init and dispose of date editor."""
+
+    def check_init_and_dispose(self, view):
+        with store_exceptions_on_all_threads(), \
+                create_ui(Foo(), dict(view=view)):
+            pass
+
+    def test_simple_date_editor(self):
+        view = View(
+            Item(
+                name="single_date",
+                style="simple",
+            )
+        )
+        self.check_init_and_dispose(view)
+
+    def test_custom_date_editor(self):
+        view = View(
+            Item(
+                name="single_date",
+                style="custom",
+            )
+        )
+        self.check_init_and_dispose(view)

--- a/traitsui/tests/editors/test_styled_date_editor.py
+++ b/traitsui/tests/editors/test_styled_date_editor.py
@@ -19,7 +19,7 @@ class DateModel(HasTraits):
     styles_mapping = Dict(Str, Instance(CellFormat))
 
 
-def example_model():
+def get_example_model():
     return DateModel(
         special_days={
             "public-holidays": [datetime.date(2020, 1, 1)],
@@ -39,7 +39,7 @@ class TestStyledDateEditor(unittest.TestCase):
 
     def test_init_and_dispose(self):
         # Smoke test to test init and dispose.
-        instance = example_model()
+        instance = get_example_model()
         view = View(
             Item(
                 "selected_date",

--- a/traitsui/tests/editors/test_styled_date_editor.py
+++ b/traitsui/tests/editors/test_styled_date_editor.py
@@ -46,7 +46,8 @@ class TestStyledDateEditor(unittest.TestCase):
                 editor=StyledDateEditor(
                     dates_trait="special_days",
                     styles_trait="styles_mapping",
-                )
+                ),
+                style="custom",
             )
         )
         with store_exceptions_on_all_threads(), \

--- a/traitsui/tests/editors/test_styled_date_editor.py
+++ b/traitsui/tests/editors/test_styled_date_editor.py
@@ -1,0 +1,54 @@
+
+import datetime
+import unittest
+
+from traits.api import Dict, HasTraits, Instance, List, Str
+from traitsui.api import Item, StyledDateEditor, View
+from traitsui.editors.date_editor import CellFormat
+from traitsui.tests._tools import (
+    create_ui,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
+
+
+class DateModel(HasTraits):
+
+    selected_date = Instance(datetime.date)
+    special_days = Dict(Str, List(Instance(datetime.date)))
+    styles_mapping = Dict(Str, Instance(CellFormat))
+
+
+def example_model():
+    return DateModel(
+        special_days={
+            "public-holidays": [datetime.date(2020, 1, 1)],
+            "weekends": [datetime.date(2020, 1, 12)],
+        },
+        styles_mapping={
+            "public-holidays": CellFormat(bgcolor=(255, 0, 0)),
+            "weekends": CellFormat(bold=True),
+        },
+    )
+
+
+
+# StyledDateEditor is currently only implemented for Qt
+@skip_if_not_qt4
+class TestStyledDateEditor(unittest.TestCase):
+
+    def test_init_and_dispose(self):
+        # Smoke test to test init and dispose.
+        instance = example_model()
+        view = View(
+            Item(
+                "selected_date",
+                editor=StyledDateEditor(
+                    dates_trait="special_days",
+                    styles_trait="styles_mapping",
+                )
+            )
+        )
+        with store_exceptions_on_all_threads(), \
+                create_ui(instance, dict(view=view)):
+            pass


### PR DESCRIPTION
Part of #431 

This PR implements the `dispose` method for Qt DateEditor.

The custom DateEditor is also subclassed by `DateRangeEditor` and `StyledDateEditor`. I checked `DateRangeEditor` does not need changes because it basically just calls `super().init(parent)` and so it makes sense to carry on using the inherited `dispose`.

`StyledDateEditor.init` has much in common with the base but it did not call the base class `init`. The option is (1) keep the `init` as is but add a `dispose` and then call `traitsui.editor.Editor.dispose` there, or (2) reuse the base class `init` so that it makes sense to inherit the base class `dispose` too. I opt-ed for the second option.

Tests for `DateRangeEditor` already cover init and dispose. New tests are added for `StyledDateEditor` to confirm the init-dispose works. I did some manual testing there too. 