### PR TITLE
Add dispose method in DatetimeEditor (Qt)

### DIFF
--- a/traitsui/qt4/datetime_editor.py
+++ b/traitsui/qt4/datetime_editor.py
@@ -46,6 +46,13 @@ class SimpleEditor(Editor):
         self.update_minimum_datetime()
         self.update_maximum_datetime()
 
+    def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
+        if self.control is not None:
+            self.control.dateTimeChanged.disconnect(self.update_object)
+        super().dispose()
+
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
             editor.


### PR DESCRIPTION
Part of #431

This PR adds a dispose method to disconnect signals in DatetimeEditor. DatetimeEditor is only implemented by Qt and its init-dispose is already covered by tests.

Note that there are two `on_trait_change` handlers attached for the editor's traits and they are never removed. It is not necessary to remove those change handlers in `dispose` because the change handler checks `if self.control is None` to avoid accessing GUI components that have been disposed. I will add these tests separately as they pass independently of this PR.