### PR TITLE
Wrap DatetimeEditor tests with store_exceptions_on_all_threads

### DIFF
--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -43,7 +43,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
     def test_datetime_editor_simple(self):
         view = get_date_time_simple_view(DatetimeEditor())
         instance = InstanceWithDatetime(date_time=datetime.datetime.now())
-        with self.launch_editor(instance, view):
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view):
             pass
 
     def test_datetime_editor_simple_with_minimum_datetime(self):

--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -7,8 +7,10 @@ from traitsui.api import DatetimeEditor, Item, View
 from traitsui.tests._tools import (
     GuiTestAssistant,
     skip_if_not_qt4,
+    store_exceptions_on_all_threads,
     no_gui_test_assistant,
 )
+
 
 class InstanceWithDatetime(HasTraits):
     """ Demo class to show Datetime editors. """
@@ -52,7 +54,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
             q_minimum_datetime = editor.control.minimumDateTime()
             actual_minimum_datetime = to_datetime(q_minimum_datetime)
 
@@ -67,7 +70,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
             instance.date_time = datetime.datetime(1980, 1, 1)
 
             # does not seem needed to flush the event loop, but just in case.
@@ -86,7 +90,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
 
             # This value is in-range
             instance.date_time = datetime.datetime(2001, 1, 1)
@@ -113,7 +118,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
 
             # This value is in-range
             instance.date_time = datetime.datetime(2001, 1, 1)
@@ -140,7 +146,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
             q_maximum_datetime = editor.control.maximumDateTime()
 
             # does not seem needed to flush the event loop, but just in case.
@@ -157,7 +164,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
             # out-of-bound
             instance.date_time = datetime.datetime(2020, 1, 1)
 
@@ -177,7 +185,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
 
             # This value is in-range
             instance.date_time = datetime.datetime(1999, 1, 1)
@@ -202,7 +211,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         view = get_date_time_simple_view(editor_factory)
         init_datetime = datetime.datetime(1900, 1, 1)
         instance = InstanceWithDatetime(date_time=init_datetime)
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
             # This value is too early and is not supported by Qt
             # But the editor should not crash
             new_value = datetime.datetime(1, 1, 1)
@@ -224,7 +234,8 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         view = get_date_time_simple_view(editor_factory)
         init_datetime = datetime.datetime(1900, 1, 1)
         instance = InstanceWithDatetime(date_time=init_datetime)
-        with self.launch_editor(instance, view) as editor:
+        with store_exceptions_on_all_threads(), \
+                self.launch_editor(instance, view) as editor:
             # the user set the datetime on the Qt widget to a value
             # too large for Python
             from pyface.qt.QtCore import QDateTime, QDate


### PR DESCRIPTION
The `store_exceptions_on_all_threads` does a few things, one of those is to capture exceptions 
 from trait change and then re-raise. 
This is needed if an error occurs in the change handlers for `minimum_datetime` and `maximum_datetime` on the DatetimeEditor.

For example if the `if self.control is None` was removed from the change handler, we get errors logged on the console but the tests still pass. Wrapping the test with the context manager make them fail in that scenario.

Motivated by #431 which also concerns the hooking and unhooking of trait change handlers. 

Solves part of #876 