### PR TITLE
Implement dispose for DropEditor (Qt)

### DIFF
--- a/traitsui/qt4/drop_editor.py
+++ b/traitsui/qt4/drop_editor.py
@@ -22,6 +22,7 @@ from pyface.qt import QtGui, QtCore
 # traitsui.editors.drop_editor file.
 from traitsui.editors.drop_editor import ToolkitEditorFactory
 
+from .editor import Editor as _BaseEditor
 from .text_editor import SimpleEditor as Editor
 from .constants import DropColor
 from .clipboard import PyMimeData, clipboard
@@ -55,6 +56,15 @@ class SimpleEditor(Editor):
         self.control.installEventFilter(drop_event_filter)
 
         self.control._qt4_editor = self
+
+    def dispose(self):
+        """ Disposes of the content of an editor.
+        """
+        if self.factory.readonly:
+            # enthought/traitsui#884
+            _BaseEditor.dispose(self)
+        else:
+            super(SimpleEditor, self).dispose()
 
     def string_value(self, value):
         """ Returns the text representation of a specified object trait value.

--- a/traitsui/tests/editors/test_drop_editor.py
+++ b/traitsui/tests/editors/test_drop_editor.py
@@ -29,10 +29,20 @@ class Model(HasTraits):
 class TestDropEditor(unittest.TestCase):
     """ Test DropEditor. """
 
-    def test_init_dispose(self):
+    def test_init_dispose_editable(self):
 
         obj = Model()
-        view = View(Item("value", editor=DropEditor()))
+        view = View(Item("value", editor=DropEditor(readonly=False)))
+        with store_exceptions_on_all_threads():
+                with create_ui(obj, dict(view=view)):
+                    pass
+                # Mutating value after UI is closed should be okay.
+                obj.value = "New"
+
+    def test_init_dispose_readonly(self):
+
+        obj = Model()
+        view = View(Item("value", editor=DropEditor(readonly=True)))
         with store_exceptions_on_all_threads():
                 with create_ui(obj, dict(view=view)):
                     pass

--- a/traitsui/tests/editors/test_drop_editor.py
+++ b/traitsui/tests/editors/test_drop_editor.py
@@ -34,17 +34,17 @@ class TestDropEditor(unittest.TestCase):
         obj = Model()
         view = View(Item("value", editor=DropEditor(readonly=False)))
         with store_exceptions_on_all_threads():
-                with create_ui(obj, dict(view=view)):
-                    pass
-                # Mutating value after UI is closed should be okay.
-                obj.value = "New"
+            with create_ui(obj, dict(view=view)):
+                pass
+            # Mutating value after UI is closed should be okay.
+            obj.value = "New"
 
     def test_init_dispose_readonly(self):
 
         obj = Model()
         view = View(Item("value", editor=DropEditor(readonly=True)))
         with store_exceptions_on_all_threads():
-                with create_ui(obj, dict(view=view)):
-                    pass
-                # Mutating value after UI is closed should be okay.
-                obj.value = "New"
+            with create_ui(obj, dict(view=view)):
+                pass
+            # Mutating value after UI is closed should be okay.
+            obj.value = "New"

--- a/traitsui/tests/editors/test_drop_editor.py
+++ b/traitsui/tests/editors/test_drop_editor.py
@@ -1,0 +1,40 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+
+import unittest
+
+from traits.api import HasTraits, Str
+from traitsui.api import DropEditor, Item, View
+from traitsui.tests._tools import (
+    create_ui,
+    skip_if_not_qt4,
+    store_exceptions_on_all_threads,
+)
+
+
+class Model(HasTraits):
+
+    value = Str()
+
+
+# Run this test against wx when enthought/traitsui#752 is fixed.
+@skip_if_not_qt4
+class TestDropEditor(unittest.TestCase):
+    """ Test DropEditor. """
+
+    def test_init_dispose(self):
+
+        obj = Model()
+        view = View(Item("value", editor=DropEditor()))
+        with store_exceptions_on_all_threads():
+                with create_ui(obj, dict(view=view)):
+                    pass
+                # Mutating value after UI is closed should be okay.
+                obj.value = "New"


### PR DESCRIPTION
Part of #431 

The PR adds open-and-close tests for DropEditor which are already passing without the new dispose method.

A `dispose` method is still added to ensure correctness: DropEditor uses the simple `TextEditor`'s `init` only if `readonly` is false. The new `dispose` to ensure it does not call the TextEditor dispose when the TextEditor `init` is not actually used. See #884.

(Orthogonal note 1: I tried but I still could not figure out how DropEditor is meant to be used.)
(Orthogonal note 2: The `_DropEventFilter` in this module is used by the Qt InstanceEditor.)