### PR TITLE
Alternative fix to TabularAdapter crashes when column number reduces

### DIFF
--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -247,7 +247,7 @@ class TabularEditor(Editor):
         # Rebuild the editor columns and headers whenever the adapter's
         # 'columns' changes:
         self.on_trait_change(
-            self.update_editor, "adapter.columns", dispatch="ui"
+            self._adapter_columns_updated, "adapter.columns", dispatch="ui"
         )
 
     def dispose(self):
@@ -266,7 +266,7 @@ class TabularEditor(Editor):
             self.refresh_editor, "adapter.+update", remove=True
         )
         self.on_trait_change(
-            self.update_editor, "adapter.columns", remove=True
+            self._adapter_columns_updated, "adapter.columns", remove=True
         )
 
         self.adapter.cleanup()
@@ -391,6 +391,19 @@ class TabularEditor(Editor):
         """
         if not self.factory.multi_select:
             self.selected_column = self.column_clicked.column
+
+    def _adapter_columns_updated(self):
+        """ Update the view when the adapter columns trait changes.
+        Note that this change handler is added after the UI is instantiated,
+        and removed when the UI is disposed.
+        """
+        # Invalidate internal state of the view related to the columns
+        n_columns = len(self.adapter.columns)
+        if (self.control is not None
+                and self.control._user_widths is not None
+                and len(self.control._user_widths) != n_columns):
+            self.control._user_widths = None
+        self.update_editor()
 
     def _update_changed(self):
         self.update_editor()

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -40,9 +40,9 @@ from traits.api import (
     Property,
     TraitListEvent,
 )
+
 from traitsui.tabular_adapter import TabularAdapter
 from traitsui.helper import compute_column_widths
-from traitsui.qt4 import toolkit
 from .editor import Editor
 from .tabular_model import TabularModel
 
@@ -270,8 +270,6 @@ class TabularEditor(Editor):
         )
 
         self.adapter.cleanup()
-
-        toolkit.destroy_control(self.control)
 
         super(TabularEditor, self).dispose()
 
@@ -928,7 +926,8 @@ class _TableView(QtGui.QTableView):
             if self._user_widths is None:
                 self._user_widths = [None] * len(self._editor.adapter.columns)
             self._user_widths[index] = new
-            if not self._editor.factory.auto_resize:
+            if (self._editor.factory is not None
+                    and not self._editor.factory.auto_resize):
                 self.resizeColumnsToContents()
 
     @contextmanager

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -926,7 +926,8 @@ class _TableView(QtGui.QTableView):
             if self._user_widths is None:
                 self._user_widths = [None] * len(self._editor.adapter.columns)
             self._user_widths[index] = new
-            if not self._editor.factory.auto_resize:
+            if (self._editor.factory is not None
+                    and not self._editor.factory.auto_resize):
                 self.resizeColumnsToContents()
 
     @contextmanager

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -40,9 +40,9 @@ from traits.api import (
     Property,
     TraitListEvent,
 )
-
 from traitsui.tabular_adapter import TabularAdapter
 from traitsui.helper import compute_column_widths
+from traitsui.qt4 import toolkit
 from .editor import Editor
 from .tabular_model import TabularModel
 
@@ -270,6 +270,8 @@ class TabularEditor(Editor):
         )
 
         self.adapter.cleanup()
+
+        toolkit.destroy_control(self.control)
 
         super(TabularEditor, self).dispose()
 
@@ -926,8 +928,7 @@ class _TableView(QtGui.QTableView):
             if self._user_widths is None:
                 self._user_widths = [None] * len(self._editor.adapter.columns)
             self._user_widths[index] = new
-            if (self._editor.factory is not None
-                    and not self._editor.factory.auto_resize):
+            if not self._editor.factory.auto_resize:
                 self.resizeColumnsToContents()
 
     @contextmanager

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -389,14 +389,24 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
         # Regression test for enthought/traitsui#894
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (report, editor):
+            # This ensures the the cached user widths in the view has a length
+            # of 2 One of them is non-None
             editor.adapter.columns = [
                 ("Name", "name"), ("Age", "age"),
             ]
+            # Set the columns to an empty list should not fail because the
+            # cached user widths has been invalidated.
+            # The cached user widths should have been updated if columns is
+            # changed. Otherwise recalculation of column widths.
             editor.adapter.columns = []
 
-    def test_adapter_columns_changes_reduce_columns(self):
-        # Test workaround for enthought/traits#431
-        # The factory is set to None but signals are not disconnected.
+    def test_view_column_resized_attribute_error_workaround(self):
+        # This tests the workaround which checks if `factory` is None before
+        # using it while resizing the columns
+        # Maybe related to enthought/traitsui#854 and enthought/traits#431
+        # Changing the columns causes a header-resize signal to be emitted.
+        # If the signal is processed after the UI is disposed, that will
+        # cause AttributeError because the factory would have been set to None.
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (_, editor):
             editor.adapter.columns = [("Name", "name")]

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -385,6 +385,15 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             with self.assertTraitChanges(editor, "update", count=1):
                 report.update = True
 
+    def test_adapter_columns_changes(self):
+        # Regression test for enthought/traitsui#894
+        with store_exceptions_on_all_threads(), \
+                self.report_and_editor(get_view()) as (report, editor):
+            editor.adapter.columns = [
+                ("Name", "name"), ("Age", "age"),
+            ]
+            editor.adapter.columns = []
+
     @contextlib.contextmanager
     def report_and_editor(self, view):
         """

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -394,6 +394,13 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             ]
             editor.adapter.columns = []
 
+    def test_adapter_columns_changes_reduce_columns(self):
+        # Test workaround for enthought/traits#752
+        # The factory is set to None but signals are not disconnected.
+        with store_exceptions_on_all_threads(), \
+                self.report_and_editor(get_view()) as (_, editor):
+            editor.adapter.columns = [("Name", "name")]
+
     @contextlib.contextmanager
     def report_and_editor(self, view):
         """

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -395,8 +395,8 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             editor.adapter.columns = []
 
     def test_adapter_columns_changes_reduce_columns(self):
-        # If destroy_control is not called in dispose, slots may be called
-        # after the factory is set to None and then this test would fail.
+        # Test workaround for enthought/traits#752
+        # The factory is set to None but signals are not disconnected.
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (_, editor):
             editor.adapter.columns = [("Name", "name")]

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -402,11 +402,9 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
 
     def test_view_column_resized_attribute_error_workaround(self):
         # This tests the workaround which checks if `factory` is None before
-        # using it while resizing the columns
+        # using it while resizing the columns.
+        # The resize event is processed after UI.dispose is called.
         # Maybe related to enthought/traitsui#854 and enthought/traits#431
-        # Changing the columns causes a header-resize signal to be emitted.
-        # If the signal is processed after the UI is disposed, that will
-        # cause AttributeError because the factory would have been set to None.
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (_, editor):
             editor.adapter.columns = [("Name", "name")]

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -389,16 +389,17 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
         # Regression test for enthought/traitsui#894
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (report, editor):
-            # This ensures the the cached user widths in the view has a length
-            # of 2 One of them is non-None
+
+            # Reproduce the scenario when the column count is reduced.
             editor.adapter.columns = [
                 ("Name", "name"), ("Age", "age"),
             ]
-            # Set the columns to an empty list should not fail because the
-            # cached user widths has been invalidated.
-            # The cached user widths should have been updated if columns is
-            # changed. Otherwise recalculation of column widths.
-            editor.adapter.columns = []
+            # Recalculating column widths take into account the user defined
+            # widths, cached in the view. The cache should be invalidated
+            # when the columns is updated such that recalculation does not
+            # fail.
+            editor.adapter.columns = [("Name", "name")]
+            GUI.process_events()
 
     def test_view_column_resized_attribute_error_workaround(self):
         # This tests the workaround which checks if `factory` is None before

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -395,7 +395,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             editor.adapter.columns = []
 
     def test_adapter_columns_changes_reduce_columns(self):
-        # Test workaround for enthought/traits#752
+        # Test workaround for enthought/traits#431
         # The factory is set to None but signals are not disconnected.
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (_, editor):

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -395,8 +395,8 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             editor.adapter.columns = []
 
     def test_adapter_columns_changes_reduce_columns(self):
-        # Test workaround for enthought/traits#752
-        # The factory is set to None but signals are not disconnected.
+        # If destroy_control is not called in dispose, slots may be called
+        # after the factory is set to None and then this test would fail.
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (_, editor):
             editor.adapter.columns = [("Name", "name")]


### PR DESCRIPTION
Many thanks to @FedeMiorelli tracking down the cause to issue #894.  The issue is indeed resolved by resetting the user widths.

This PR proposes resetting the user-defined widths in a slightly different place.

This PR actually does two things:
(1) Invalidating the view's `_user_widths` cache when the adapter columns is changed.
(2) Workaround an error that occurs when the UI is disposed. I believe the error is caused by header resize signal still being connected after the factory is removed from the editor. (See #431). The second test fails with this error if the `if self._editor.factory is not None` check is removed:
```
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 402, in test_adapter_columns_changes_reduce_columns
    editor.adapter.columns = [("Name", "name")]
  File "/Users/kchoi/.edm/envs/traitsui-test-3.6-pyqt/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/tests/_tools.py", line 66, in store_exceptions_on_all_threads
    raise exceptions[0]
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/qt4/tabular_editor.py", line 929, in columnResized
    if (not self._editor.factory.auto_resize):
AttributeError: 'NoneType' object has no attribute 'auto_resize'
``` 
