### PR TITLE
Fix unexpected format_func in RangeEditor bug

### DIFF
--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -720,8 +720,7 @@ class RangeTextEditor(TextEditor):
 
 
 def SimpleEnumEditor(
-    parent, factory, ui, object, name, description, format_func=None,
-    format_str='', invalid_trait_name=''
+    parent, factory, ui, object, name, description, **kwargs
 ):
     return CustomEnumEditor(
         parent, factory, ui, object, name, description, "simple"
@@ -729,8 +728,7 @@ def SimpleEnumEditor(
 
 
 def CustomEnumEditor(
-    parent, factory, ui, object, name, description, style="custom",
-    format_func=None, format_str='', invalid_trait_name=''
+    parent, factory, ui, object, name, description, style="custom", **kwargs
 ):
     """ Factory adapter that returns a enumeration editor of the specified
     style.

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -719,14 +719,18 @@ class RangeTextEditor(TextEditor):
 # -------------------------------------------------------------------------
 
 
-def SimpleEnumEditor(parent, factory, ui, object, name, description):
+def SimpleEnumEditor(
+    parent, factory, ui, object, name, description, format_func=None,
+    format_str='', invalid_trait_name=''
+):
     return CustomEnumEditor(
         parent, factory, ui, object, name, description, "simple"
     )
 
 
 def CustomEnumEditor(
-    parent, factory, ui, object, name, description, style="custom"
+    parent, factory, ui, object, name, description, style="custom",
+    format_func=None, format_str='', invalid_trait_name=''
 ):
     """ Factory adapter that returns a enumeration editor of the specified
     style.

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -1,0 +1,50 @@
+import unittest
+
+from traits.api import HasTraits, Int
+from traitsui.api import RangeEditor, UItem, View
+from traitsui.tests._tools import (
+    create_ui,
+    skip_if_null,
+    store_exceptions_on_all_threads,
+)
+
+
+class RangeModel(HasTraits):
+
+    value = Int()
+
+
+@skip_if_null
+class TestRangeEditor(unittest.TestCase):
+
+    def check_range_enum_editor_format_func(self, style):
+        # RangeEditor with enum mode doesn't support format_func
+        obj = RangeModel()
+        view = View(
+            UItem(
+                "value",
+                editor=RangeEditor(
+                    low=1, high=3,
+                    format_func=lambda v: "{:02d}".format(v),
+                    mode="enum"
+                ),
+                style=style,
+            )
+        )
+
+        with store_exceptions_on_all_threads(),\
+                create_ui(obj, dict(view=view)) as ui:
+            editor = ui.get_editors("value")[0]
+
+            # No formatting - simple strings
+            self.assertEqual(editor.names[:3], ["1", "2", "3"])
+            self.assertEqual(editor.mapping, {"1": 1, "2": 2, "3": 3})
+            self.assertEqual(
+                editor.inverse_mapping, {1: "1", 2: "2", 3: "3"}
+            )
+
+    def test_simple_editor_format_func(self):
+        self.check_range_enum_editor_format_func("simple")
+
+    def test_custom_editor_format_func(self):
+        self.check_range_enum_editor_format_func("custom")

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -914,14 +914,18 @@ class RangeTextEditor(TextEditor):
             self.control.SetValue(int(self.value))
 
 
-def SimpleEnumEditor(parent, factory, ui, object, name, description):
+def SimpleEnumEditor(
+    parent, factory, ui, object, name, description, format_func=None,
+    format_str='', invalid_trait_name=''
+):
     return CustomEnumEditor(
         parent, factory, ui, object, name, description, "simple"
     )
 
 
 def CustomEnumEditor(
-    parent, factory, ui, object, name, description, style="custom"
+    parent, factory, ui, object, name, description, style="custom",
+    format_func=None, format_str='', invalid_trait_name=''
 ):
     """ Factory adapter that returns a enumeration editor of the specified
         style.

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -915,8 +915,7 @@ class RangeTextEditor(TextEditor):
 
 
 def SimpleEnumEditor(
-    parent, factory, ui, object, name, description, format_func=None,
-    format_str='', invalid_trait_name=''
+    parent, factory, ui, object, name, description, **kwargs
 ):
     return CustomEnumEditor(
         parent, factory, ui, object, name, description, "simple"
@@ -924,8 +923,7 @@ def SimpleEnumEditor(
 
 
 def CustomEnumEditor(
-    parent, factory, ui, object, name, description, style="custom",
-    format_func=None, format_str='', invalid_trait_name=''
+    parent, factory, ui, object, name, description, style="custom", **kwargs
 ):
     """ Factory adapter that returns a enumeration editor of the specified
         style.


### PR DESCRIPTION
Closes #898

`SimpleEnumEditor` and `CustomEnumEditor` in `range_editor.py` (both qt and wx) are not subclasses of `Editor` themselves. Instead they are functions that return an `EnumEditor` via `traitsui.editors.enum_editor.ToolkitEditorFactory`.

The PR modifies the signatures of these functions to match what `EditorFactory` expects (adding `format_func`, `format_str` and `invalid_trait_name`). These additional arguments aren't passed to the actual editor to match the behaviour as it was before the bug.