### PR TITLE
Test running one test with Linux to confirm absence of test interaction

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -213,7 +213,7 @@ def test(runtime, toolkit, environment):
         environ["EXCLUDE_TESTS"] = "(wx|qt)"
 
     commands = [
-        "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui"
+        "edm run -e {environment} -- coverage run -p -m unittest traitsui.tests.editors.test_image_enum_editor.TestSimpleImageEnumEditor.test_simple_editor_combobox"
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui


### PR DESCRIPTION
This test `traitsui.tests.editors.test_image_enum_editor.TestSimpleImageEnumEditor.test_simple_editor_combobox` seems to be failing on Travis CI Linux + PySide2, but I noticed this on another branch. This PR is a draft open to confirm and log the behaviour in the CI environment. Will be closed when CI finishes.