### PR TITLE
[WIP] Unset editor attribute later using the GUI event queue

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -20,6 +20,8 @@
 from contextlib import contextmanager
 from functools import partial
 
+from pyface.api import GUI
+
 from traits.api import (
     Any,
     Bool,
@@ -291,7 +293,7 @@ class Editor(HasPrivateTraits):
 
         # Break linkages to references we no longer need:
         for name in self.trait_names(clean_up=True):
-            setattr(self, name, None)
+            GUI.invoke_later(setattr, self, name, None)
 
     # -- Undo/redo methods --------------------------------------------------
 

--- a/traitsui/tests/editors/test_image_enum_editor.py
+++ b/traitsui/tests/editors/test_image_enum_editor.py
@@ -282,10 +282,6 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
 
         return gui, control
 
-    @unittest.skipIf(
-        is_linux and is_current_backend_qt4(),
-        "Issue enthought/traitsui#854, possible test interactions on Linux"
-    )
     def test_simple_editor_more_cols(self):
         # Smoke test for setting up an editor with more than one column
         enum_edit = EnumModel()
@@ -338,11 +334,6 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
             # Check that dialog window is closed
             self.assertEqual(list(control.GetChildren()), [])
 
-    @skip_if_not_qt4
-    @unittest.skipIf(
-        is_linux,
-        "Issue enthought/traitsui#854, possible test interactions on Linux"
-    )
     def test_simple_editor_combobox(self):
         enum_edit = EnumModel()
 

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -200,10 +200,6 @@ def right_click_item(control, index):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@unittest.skipIf(
-    is_windows and is_current_backend_qt4(),
-    "Issue enthought/traitsui#854; possible test interactions on Windows"
-)
 @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
 @skip_if_null
 class TestListStrEditor(unittest.TestCase):

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -13,6 +13,8 @@
 
 import unittest
 
+from pyface.api import GUI
+
 from traits.api import Any, Bool, Event, Float, HasTraits, Int, List, Undefined
 from traits.trait_base import xgetattr
 
@@ -237,6 +239,7 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         self.assertEqual(editor.object.user_value, "even newer test")
 
         editor.dispose()
+        GUI.process_events()
 
         self.assertIsNone(editor.object)
         self.assertIsNone(editor.factory)


### PR DESCRIPTION
The many errors we have seen in the past relate to getting an attribute error because a GUI event is processed after several editor's attributes are set to None in in `dispose`.

This PR attempts to fix this by asking the GUI event loop to unset the attributes in `dispose`, i.e. delay unsetting the attributes. 
