### PR TITLE
Add links from TabularEditor and TreeEditor to adapter docs

### DIFF
--- a/docs/source/traitsui_user_manual/adapters.rst
+++ b/docs/source/traitsui_user_manual/adapters.rst
@@ -12,11 +12,12 @@ are the ListStrEditor, the TabularEditor and the TreeEditor.  In this section
 we will look more closely at each of these and discuss how they can be
 customized as needed.
 
-
-.. _tree-nodes:
+.. _advanced-tree-node:
 
 The TreeEditor and TreeNodes
 ============================
+
+.. _tree-nodes:
 
 .. module:: traitsui.tree_node
    :noindex:

--- a/docs/source/traitsui_user_manual/adapters.rst
+++ b/docs/source/traitsui_user_manual/adapters.rst
@@ -12,10 +12,11 @@ are the ListStrEditor, the TabularEditor and the TreeEditor.  In this section
 we will look more closely at each of these and discuss how they can be
 customized as needed.
 
-The TreeEditor and TreeNodes
-============================
 
 .. _tree-nodes:
+
+The TreeEditor and TreeNodes
+============================
 
 .. module:: traitsui.tree_node
    :noindex:
@@ -301,6 +302,8 @@ There are a number of examples of use of the
 - :github-demo:`HDF5 Tree <Advanced/HDF5_tree_demo.py>`
 - :github-demo:`Tree Editor with Renderer <Extras/Tree_editor_with_TreeNodeRenderer.py>`
 
+
+.. _advanced-tabular-adapter:
 
 The TabularAdapter Class
 ========================

--- a/docs/source/traitsui_user_manual/factories_advanced_extra.rst
+++ b/docs/source/traitsui_user_manual/factories_advanced_extra.rst
@@ -943,7 +943,7 @@ Defining Nodes
 
 For details on the attributes of the TreeNode class, refer to the *Traits API
 Reference*. More information about the TreeNode class is also available in
-:ref:`tree-nodes`.
+:ref:`advanced-tree-node`.
 
 You must specify the classes whose instances the node type applies to. Use the
 **node_for** attribute of TreeNode to specify a list of classes; often, this

--- a/docs/source/traitsui_user_manual/factories_advanced_extra.rst
+++ b/docs/source/traitsui_user_manual/factories_advanced_extra.rst
@@ -609,7 +609,9 @@ TabularAdapter
 The tabular editor works in conjunction with an adapter class, derived from
 TabularAdapter. The tabular adapter interfaces between the tabular editor and
 the data being displayed. The tabular adapter is the reason for the flexibility
-and power of the tabular editor to display a wide variety of data.
+and power of the tabular editor to display a wide variety of data. For more
+detailed information about the TabularAdapter class please see
+:ref:`advanced-tabular-adapter`.
 
 The most important attribute of TabularAdapter is **columns**, which is list of
 columns to be displayed. Each entry in the **columns** list can be either a
@@ -940,7 +942,8 @@ Defining Nodes
 ::::::::::::::
 
 For details on the attributes of the TreeNode class, refer to the *Traits API
-Reference*.
+Reference*. More information about the TreeNode class is also available in
+:ref:`tree-nodes`.
 
 You must specify the classes whose instances the node type applies to. Use the
 **node_for** attribute of TreeNode to specify a list of classes; often, this


### PR DESCRIPTION
Closes #830 

Adds links from TabularEditor and TreeEditor documentation to more detailed TabularAdapter and TreeNode documentation.
