### PR TITLE
TST: Update tests to use the same dispose and event queue process logic

### DIFF
--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -4,7 +4,11 @@ from traits.api import HasTraits, Int, Str, Instance
 from traitsui.api import View, Item, Group
 from traitsui.menu import ToolBar, Action
 
-from traitsui.tests._tools import skip_if_not_qt4
+from traitsui.tests._tools import (
+    create_ui,
+    skip_if_not_qt4,
+    process_cascade_events,
+)
 
 
 class FooPanel(HasTraits):
@@ -50,6 +54,8 @@ class TestUIPanel(unittest.TestCase):
 
         # set up the dock window for qt
         main_window = QtGui.QMainWindow()
+        self.addCleanup(process_cascade_events)
+        self.addCleanup(main_window.close)
         dock = QtGui.QDockWidget("testing", main_window)
         dock.setWidget(QtGui.QMainWindow())
         return main_window, dock
@@ -61,16 +67,16 @@ class TestUIPanel(unittest.TestCase):
 
         # add panel
         panel = FooPanel()
-        ui = panel.edit_traits(parent=dock.widget(), kind="panel")
-        dock.widget().setCentralWidget(ui.control)
+        with create_ui(panel, dict(parent=dock.widget(), kind="panel")) as ui:
+            dock.widget().setCentralWidget(ui.control)
 
-        # There should be a toolbar for the panel
-        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+            # There should be a toolbar for the panel
+            self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
 
-        # There should be buttons too
-        # Not searching from dock because the dock panel has buttons for
-        # popping up and closing the panel
-        self.assertIsNotNone(ui.control.findChild(QtGui.QPushButton))
+            # There should be buttons too
+            # Not searching from dock because the dock panel has buttons for
+            # popping up and closing the panel
+            self.assertIsNotNone(ui.control.findChild(QtGui.QPushButton))
 
     def test_subpanel_has_toolbar_no_buttons_qt4(self):
         from pyface.qt import QtGui
@@ -79,16 +85,17 @@ class TestUIPanel(unittest.TestCase):
 
         # add panel
         panel = FooPanel()
-        ui = panel.edit_traits(parent=dock.widget(), kind="subpanel")
-        dock.widget().setCentralWidget(ui.control)
+        parent = dock.widget()
+        with create_ui(panel, dict(parent=parent, kind="subpanel")) as ui:
+            dock.widget().setCentralWidget(ui.control)
 
-        # There should be a toolbar for the subpanel
-        self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
+            # There should be a toolbar for the subpanel
+            self.assertIsNotNone(dock.findChild(QtGui.QToolBar))
 
-        # Buttons should not be shown for subpanel
-        # Not searching from dock because the dock panel has buttons for
-        # popping up and closing the panel
-        self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
+            # Buttons should not be shown for subpanel
+            # Not searching from dock because the dock panel has buttons for
+            # popping up and closing the panel
+            self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
 
     def test_subpanel_no_toolbar_nor_button_in_widget(self):
         from pyface.qt import QtGui
@@ -96,10 +103,9 @@ class TestUIPanel(unittest.TestCase):
         # FooDialog uses a QWidget to contain the panels
         # No attempt should be made for adding the toolbars
         foo_window = FooDialog()
-        ui = foo_window.edit_traits()
+        with create_ui(foo_window) as ui:
+            # No toolbar for the dialog
+            self.assertIsNone(ui.control.findChild(QtGui.QToolBar))
 
-        # No toolbar for the dialog
-        self.assertIsNone(ui.control.findChild(QtGui.QToolBar))
-
-        # No button
-        self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
+            # No button
+            self.assertIsNone(ui.control.findChild(QtGui.QPushButton))

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -8,6 +8,7 @@ from traitsui.tests._tools import (
     create_ui,
     is_current_backend_qt4,
     is_current_backend_wx,
+    process_cascade_events,
     skip_if_null,
     skip_if_not_qt4,
     store_exceptions_on_all_threads,
@@ -56,14 +57,12 @@ def get_button_text(button):
 
 class TestButtonEditor(unittest.TestCase):
     def check_button_text_update(self, view):
-        gui = GUI()
         button_text_edit = ButtonTextEdit()
 
-        with store_exceptions_on_all_threads():
-            ui = button_text_edit.edit_traits(view=view)
-            self.addCleanup(ui.dispose)
+        with store_exceptions_on_all_threads(), \
+                create_ui(button_text_edit, dict(view=view)) as ui:
 
-            gui.process_events()
+            process_cascade_events()
             editor, = ui.get_editors("play_button")
             button = editor.control
 
@@ -75,12 +74,9 @@ class TestButtonEditor(unittest.TestCase):
     @skip_if_null
     def test_styles(self):
         # simple smoke test of buttons
-        gui = GUI()
         button_text_edit = ButtonTextEdit()
-        with store_exceptions_on_all_threads():
-            ui = button_text_edit.edit_traits()
-            self.addCleanup(ui.dispose)
-            gui.process_events()
+        with store_exceptions_on_all_threads(), create_ui(button_text_edit):
+            pass
 
     @skip_if_null
     def test_simple_button_editor(self):

--- a/traitsui/tests/editors/test_csv_editor.py
+++ b/traitsui/tests/editors/test_csv_editor.py
@@ -59,9 +59,9 @@ class TestCSVEditor(unittest.TestCase):
         list_of_floats = ListOfFloats(data=[1, 2, 3])
         csv_view = ListOfFloatsWithCSVEditor(model=list_of_floats)
         try:
-            with store_exceptions_on_all_threads(), create_ui(csv_view) as ui:
-                press_ok_button(ui)
-
+            with store_exceptions_on_all_threads():
+                with create_ui(csv_view) as ui:
+                    pass
                 # raise an exception if still hooked
                 list_of_floats.data.append(2)
 
@@ -99,8 +99,6 @@ class TestCSVEditor(unittest.TestCase):
 
             expected = csv_list_editor._format_list_str([1.0, 3.14])
             self.assertEqual(value_str, expected)
-
-            press_ok_button(ui)
 
 
 if __name__ == "__main__":

--- a/traitsui/tests/editors/test_date_editor.py
+++ b/traitsui/tests/editors/test_date_editor.py
@@ -109,12 +109,9 @@ class TestDateEditorCustomQt(unittest.TestCase):
     @contextlib.contextmanager
     def launch_editor(self, view_factory):
         foo = Foo()
-        ui = foo.edit_traits(view=view_factory())
-        try:
+        with create_ui(foo, dict(view=view_factory())) as ui:
             editor, = ui._editors
             yield foo, editor
-        finally:
-            ui.dispose()
 
     def check_select_status(self, editor, date, selected):
         from pyface.qt import QtCore, QtGui

--- a/traitsui/tests/editors/test_date_range_editor.py
+++ b/traitsui/tests/editors/test_date_range_editor.py
@@ -12,7 +12,10 @@ from traits.api import (
 )
 from traitsui.api import DateRangeEditor, View, Item
 
-from traitsui.tests._tools import skip_if_not_qt4
+from traitsui.tests._tools import (
+    create_ui,
+    skip_if_not_qt4,
+)
 
 
 class Foo(HasTraits):
@@ -205,12 +208,9 @@ class TestDateRangeEditorQt(unittest.TestCase):
     @contextlib.contextmanager
     def launch_editor(self, view_factory):
         foo = Foo()
-        ui = foo.edit_traits(view=view_factory())
-        try:
+        with create_ui(foo, dict(view=view_factory())) as ui:
             editor, = ui._editors
             yield foo, editor
-        finally:
-            ui.dispose()
 
     def check_select_status(self, editor, date, selected):
         from pyface.qt import QtCore, QtGui

--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -5,7 +5,9 @@ import unittest
 from traits.api import HasTraits, Datetime
 from traitsui.api import DatetimeEditor, Item, View
 from traitsui.tests._tools import (
+    create_ui,
     GuiTestAssistant,
+    process_cascade_events,
     skip_if_not_qt4,
     store_exceptions_on_all_threads,
     no_gui_test_assistant,
@@ -76,7 +78,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
             instance.date_time = datetime.datetime(1980, 1, 1)
 
             # does not seem needed to flush the event loop, but just in case.
-            self.gui.process_events()
+            process_cascade_events()
 
             displayed_value = to_datetime(editor.control.dateTime())
 
@@ -103,7 +105,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
             editor.minimum_datetime = new_minimum_datetime
 
             # does not seem needed to flush the event loop, but just in case.
-            self.gui.process_events()
+            process_cascade_events()
 
             displayed_value = to_datetime(editor.control.dateTime())
 
@@ -131,7 +133,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
             editor.minimum_datetime = new_minimum_datetime
 
             # does not seem needed to flush the event loop, but just in case.
-            self.gui.process_events()
+            process_cascade_events()
 
             displayed_value = to_datetime(editor.control.dateTime())
 
@@ -152,7 +154,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
             q_maximum_datetime = editor.control.maximumDateTime()
 
             # does not seem needed to flush the event loop, but just in case.
-            self.gui.process_events()
+            process_cascade_events()
 
             actual_maximum_datetime = to_datetime(q_maximum_datetime)
 
@@ -171,7 +173,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
             instance.date_time = datetime.datetime(2020, 1, 1)
 
             # does not seem needed to flush the event loop, but just in case.
-            self.gui.process_events()
+            process_cascade_events()
 
             displayed_value = to_datetime(editor.control.dateTime())
 
@@ -198,7 +200,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
             editor.maximum_datetime = new_maximum_datetime
 
             # does not seem needed to flush the event loop, but just in case.
-            self.gui.process_events()
+            process_cascade_events()
 
             displayed_value = to_datetime(editor.control.dateTime())
 
@@ -220,7 +222,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
             instance.date_time = new_value
 
             # does not seem needed to flush the event loop, but just in case.
-            self.gui.process_events()
+            process_cascade_events()
 
             displayed_value = to_datetime(editor.control.dateTime())
 
@@ -250,9 +252,6 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
 
     @contextlib.contextmanager
     def launch_editor(self, object, view):
-        ui = object.edit_traits(view=view)
-        try:
+        with create_ui(object, dict(view=view)) as ui:
             editor, = ui._editors
             yield editor
-        finally:
-            ui.dispose()

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -35,9 +35,6 @@ class TestInstanceEditor(unittest.TestCase):
             # close the ui dialog
             press_ok_button(editor._dialog_ui)
 
-            # close the main ui
-            press_ok_button(ui)
-
     @skip_if_not_qt4
     def test_simple_editor_parent_closed(self):
         obj = NonmodalInstanceEditor()
@@ -46,6 +43,3 @@ class TestInstanceEditor(unittest.TestCase):
 
             # make the dialog appear
             editor._button.click()
-
-            # close the main ui
-            press_ok_button(ui)

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -19,10 +19,10 @@ Test case for bug (wx, Mac OS X)
 A ListStrEditor was not checking for valid item indexes under Wx.  This was
 most noticeable when the selected_index was set in the editor factory.
 """
+import contextlib
 import platform
 import unittest
 
-from pyface.gui import GUI
 from traits.has_traits import HasTraits
 from traits.trait_types import List, Int, Str
 from traitsui.item import Item
@@ -34,6 +34,7 @@ from traitsui.tests._tools import (
     is_current_backend_wx,
     is_current_backend_qt4,
     press_ok_button,
+    process_cascade_events,
     skip_if_not_qt4,
     skip_if_not_wx,
     skip_if_null,
@@ -208,19 +209,16 @@ def right_click_item(control, index):
 @skip_if_null
 class TestListStrEditor(unittest.TestCase):
 
+    @contextlib.contextmanager
     def setup_gui(self, model, view):
-        gui = GUI()
-        ui = model.edit_traits(view=view)
-        self.addCleanup(ui.dispose)
-
-        gui.process_events()
-        editor = ui.get_editors("value")[0]
-
-        return gui, editor
+        with create_ui(model, dict(view=view)) as ui:
+            process_cascade_events()
+            editor = ui.get_editors("value")[0]
+            yield editor
 
     def test_list_str_editor_single_selection(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListStrModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), get_view()) as editor:
 
             if is_current_backend_qt4():  # No initial selection
                 self.assertEqual(editor.selected_index, -1)
@@ -230,19 +228,19 @@ class TestListStrEditor(unittest.TestCase):
                 self.assertEqual(editor.selected, "one")
 
             set_selected_single(editor, 1)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(editor.selected_index, 1)
             self.assertEqual(editor.selected, "two")
 
             set_selected_single(editor, 2)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(editor.selected_index, 2)
             self.assertEqual(editor.selected, "three")
 
             clear_selection(editor)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(editor.selected_index, -1)
             self.assertEqual(editor.selected, None)
@@ -250,33 +248,33 @@ class TestListStrEditor(unittest.TestCase):
     def test_list_str_editor_multi_selection(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListStrModel(), view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), view) as editor:
 
             self.assertEqual(editor.multi_selected_indices, [])
             self.assertEqual(editor.multi_selected, [])
 
             set_selected_multiple(editor, [0, 1])
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(editor.multi_selected_indices, [0, 1])
             self.assertEqual(editor.multi_selected, ["one", "two"])
 
             set_selected_multiple(editor, [2])
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(editor.multi_selected_indices, [2])
             self.assertEqual(editor.multi_selected, ["three"])
 
             clear_selection(editor)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(editor.multi_selected_indices, [])
             self.assertEqual(editor.multi_selected, [])
 
     def test_list_str_editor_single_selection_changed(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListStrModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), get_view()) as editor:
 
             if is_current_backend_qt4():  # No initial selection
                 self.assertEqual(get_selected_indices(editor), [])
@@ -284,27 +282,27 @@ class TestListStrEditor(unittest.TestCase):
                 self.assertEqual(get_selected_indices(editor), [0])
 
             editor.selected_index = 1
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_indices(editor), [1])
             self.assertEqual(editor.selected, "two")
 
             editor.selected = "three"
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_indices(editor), [2])
             self.assertEqual(editor.selected_index, 2)
 
             # Selected set to invalid value doesn't change anything
             editor.selected = "four"
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_indices(editor), [2])
             self.assertEqual(editor.selected_index, 2)
 
             # Selected index changed to
             editor.selected_index = -1
-            gui.process_events()
+            process_cascade_events()
 
             if is_current_backend_qt4():
                 # -1 clears selection
@@ -318,25 +316,25 @@ class TestListStrEditor(unittest.TestCase):
     def test_list_str_editor_multi_selection_changed(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListStrModel(), view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), view) as editor:
 
             self.assertEqual(get_selected_indices(editor), [])
 
             editor.multi_selected_indices = [0, 1]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_indices(editor), [0, 1])
             self.assertEqual(editor.multi_selected, ["one", "two"])
 
             editor.multi_selected = ["three", "one"]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(sorted(get_selected_indices(editor)), [0, 2])
             self.assertEqual(sorted(editor.multi_selected_indices), [0, 2])
 
             editor.multi_selected = ["three", "four"]
-            gui.process_events()
+            process_cascade_events()
 
             if is_current_backend_qt4():
                 # Invalid values assigned to multi_selected are ignored
@@ -349,7 +347,7 @@ class TestListStrEditor(unittest.TestCase):
 
             # Setting selected indices to an empty list clears selection
             editor.multi_selected_indices = []
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_indices(editor), [])
             self.assertEqual(editor.multi_selected, [])
@@ -357,25 +355,25 @@ class TestListStrEditor(unittest.TestCase):
     def test_list_str_editor_multi_selection_items_changed(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListStrModel(), view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), view) as editor:
 
             self.assertEqual(get_selected_indices(editor), [])
 
             editor.multi_selected_indices.extend([0, 1])
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_indices(editor), [0, 1])
             self.assertEqual(editor.multi_selected, ["one", "two"])
 
             editor.multi_selected_indices[1] = 2
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_indices(editor), [0, 2])
             self.assertEqual(editor.multi_selected, ["one", "three"])
 
             editor.multi_selected[0] = "two"
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(sorted(get_selected_indices(editor)), [1, 2])
             self.assertEqual(sorted(editor.multi_selected_indices), [1, 2])
@@ -383,55 +381,54 @@ class TestListStrEditor(unittest.TestCase):
             # If a change in multi_selected involves an invalid value, nothing
             # is changed
             editor.multi_selected[0] = "four"
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(sorted(get_selected_indices(editor)), [1, 2])
             self.assertEqual(sorted(editor.multi_selected_indices), [1, 2])
 
     def test_list_str_editor_item_count(self):
-        gui = GUI()
         model = ListStrModel()
 
         # Without auto_add
         with store_exceptions_on_all_threads(), \
                 create_ui(model, dict(view=get_view())) as ui:
-            gui.process_events()
+            process_cascade_events()
             editor = ui.get_editors("value")[0]
             self.assertEqual(editor.item_count, 3)
 
         # With auto_add
         with store_exceptions_on_all_threads(), \
                 create_ui(model, dict(view=get_view(auto_add=True))) as ui:
-            gui.process_events()
+            process_cascade_events()
             editor = ui.get_editors("value")[0]
             self.assertEqual(editor.item_count, 3)
 
     def test_list_str_editor_refresh_editor(self):
         # Smoke test for refresh_editor/refresh_
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListStrModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), get_view()) as editor:
             if is_current_backend_qt4():
                 editor.refresh_editor()
             elif is_current_backend_wx():
                 editor._refresh()
-            gui.process_events()
+            process_cascade_events()
 
     @skip_if_not_qt4
     def test_list_str_editor_update_editor_single_qt(self):
         # QT editor uses selected items as the source of truth when updating
         model = ListStrModel()
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(model, get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, get_view()) as editor:
 
             set_selected_single(editor, 0)
-            gui.process_events()
+            process_cascade_events()
             # Sanity check
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "one")
 
             model.value = ["two", "one"]
-            gui.process_events()
+            process_cascade_events()
 
             # Selected remains "one" and indices are updated accordingly
             self.assertEqual(get_selected_indices(editor), [1])
@@ -440,7 +437,7 @@ class TestListStrEditor(unittest.TestCase):
 
             # Removing "one" creates a case of no longer valid selection
             model.value = ["two", "three"]
-            gui.process_events()
+            process_cascade_events()
 
             # Internal view model selection is reset, but editor selection
             # values are not (see issue enthought/traitsui#872)
@@ -453,17 +450,17 @@ class TestListStrEditor(unittest.TestCase):
         # WX editor uses selected indices as the source of truth when updating
         model = ListStrModel()
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(model, get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, get_view()) as editor:
 
             set_selected_single(editor, 0)
-            gui.process_events()
+            process_cascade_events()
             # Sanity check
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "one")
 
             model.value = ["two", "one"]
-            gui.process_events()
+            process_cascade_events()
 
             # Selected_index remains 0 and selected is updated accordingly
             self.assertEqual(get_selected_indices(editor), [0])
@@ -472,7 +469,7 @@ class TestListStrEditor(unittest.TestCase):
 
             # Empty list creates a case of no longer valid selection
             model.value = []
-            gui.process_events()
+            process_cascade_events()
 
             # Internal view model selection is reset, but editor selection
             # values are not (see issue enthought/traitsui#872)
@@ -486,17 +483,17 @@ class TestListStrEditor(unittest.TestCase):
         model = ListStrModel()
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(model, view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, view) as editor:
 
             set_selected_multiple(editor, [0])
-            gui.process_events()
+            process_cascade_events()
             # Sanity check
             self.assertEqual(editor.multi_selected_indices, [0])
             self.assertEqual(editor.multi_selected, ["one"])
 
             model.value = ["two", "one"]
-            gui.process_events()
+            process_cascade_events()
 
             # Selected remains "one" and indices are updated accordingly
             self.assertEqual(get_selected_indices(editor), [1])
@@ -505,7 +502,7 @@ class TestListStrEditor(unittest.TestCase):
 
             # Removing "one" creates a case of no longer valid selection.
             model.value = ["two", "three"]
-            gui.process_events()
+            process_cascade_events()
 
             # Internal view model selection is reset, but editor selection
             # values are not (see issue enthought/traitsui#872)
@@ -519,17 +516,17 @@ class TestListStrEditor(unittest.TestCase):
         model = ListStrModel()
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(model, view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, view) as editor:
 
             set_selected_multiple(editor, [0])
-            gui.process_events()
+            process_cascade_events()
             # Sanity check
             self.assertEqual(editor.multi_selected_indices, [0])
             self.assertEqual(editor.multi_selected, ["one"])
 
             model.value = ["two", "one"]
-            gui.process_events()
+            process_cascade_events()
 
             # Selected_index remains 0 and selected is updated accordingly
             self.assertEqual(get_selected_indices(editor), [0])
@@ -538,7 +535,7 @@ class TestListStrEditor(unittest.TestCase):
 
             # Empty list creates a case of no longer valid selection
             model.value = []
-            gui.process_events()
+            process_cascade_events()
 
             # Internal view model selection is reset, but editor selection
             # values are not (see issue enthought/traitsui#872)
@@ -553,17 +550,17 @@ class TestListStrEditor(unittest.TestCase):
         def change_value(model, value):
             model.value = value
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(model, get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, get_view()) as editor:
 
             set_selected_single(editor, 0)
-            gui.process_events()
+            process_cascade_events()
             # Sanity check
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "one")
 
             editor.callx(change_value, model, ["two", "one"])
-            gui.process_events()
+            process_cascade_events()
 
             # Nothing is updated
             self.assertEqual(get_selected_indices(editor), [0])
@@ -572,17 +569,17 @@ class TestListStrEditor(unittest.TestCase):
 
     @skip_if_not_qt4  # wx editor doesn't have a `setx` method
     def test_list_str_editor_setx(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListStrModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), get_view()) as editor:
 
             set_selected_single(editor, 0)
-            gui.process_events()
+            process_cascade_events()
             # Sanity check
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "one")
 
             editor.setx(selected="two")
-            gui.process_events()
+            process_cascade_events()
 
             # Specified attribute is modified
             self.assertEqual(editor.selected, "two")
@@ -596,13 +593,16 @@ class TestListStrEditor(unittest.TestCase):
 
     def test_list_str_editor_horizontal_lines(self):
         # Smoke test for painting horizontal lines
-        with store_exceptions_on_all_threads():
-            self.setup_gui(ListStrModel(), get_view(horizontal_lines=True))
+        view = get_view(horizontal_lines=True)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), view):
+            pass
 
     def test_list_str_editor_title(self):
         # Smoke test for adding a title
-        with store_exceptions_on_all_threads():
-            self.setup_gui(ListStrModel(), get_view(title="testing"))
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListStrModel(), get_view(title="testing")):
+            pass
 
     @skip_if_not_wx  # see `right_click_item` and issue enthought/traitsui#868
     def test_list_str_editor_right_click(self):
@@ -617,14 +617,14 @@ class TestListStrEditor(unittest.TestCase):
             right_clicked_index="object.right_clicked_index",
         )
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(model, view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, view) as editor:
 
             self.assertEqual(model.right_clicked, "")
             self.assertEqual(model.right_clicked_index, 0)
 
             right_click_item(editor.control, 1)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(model.right_clicked, "two")
             self.assertEqual(model.right_clicked_index, 1)
@@ -650,9 +650,6 @@ class TestListStrEditorSelection(unittest.TestCase):
             obj.selected_index = 0
             selected_2 = get_selected_indices(editor)
 
-            # press the OK button and close the dialog
-            press_ok_button(ui)
-
         # the number traits should be between 3 and 8
         self.assertEqual(selected_1, [1])
         self.assertEqual(selected_2, [0])
@@ -674,9 +671,6 @@ class TestListStrEditorSelection(unittest.TestCase):
 
             obj.selected_indices = [0]
             selected_2 = get_selected_indices(editor)
-
-            # press the OK button and close the dialog
-            press_ok_button(ui)
 
         # the number traits should be between 3 and 8
         self.assertEqual(selected_1, [1])
@@ -700,8 +694,7 @@ class TestListStrEditorSelection(unittest.TestCase):
 
             # open the UI and run until the dialog is closed
             with create_ui(obj, dict(view=single_select_item_view)) as ui:
-                with helper.delete_widget(ui.control):
-                    press_ok_button(ui)
+                pass
 
             # now run again and change the selection
             with create_ui(obj, dict(view=single_select_item_view)) as ui, \

--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -82,8 +82,6 @@ class TestRangeEditorSpinner(unittest.TestCase):
                     spintxt = spin.FindWindowByName("text", spin)
                     spintxt.SetValue("4")
 
-                # press the OK button and close the dialog
-                press_ok_button(ui)
         except AttributeError:
             # if all went well, we should not be here
             self.fail("AttributeError raised")
@@ -120,9 +118,6 @@ class TestRangeEditorSpinner(unittest.TestCase):
                 spintxt = spin.FindWindowByName("text")
                 spintxt.SetValue("4")
 
-            # press the OK button and close the dialog
-            press_ok_button(ui)
-
             # if all went well, the number traits has been updated and its
             # value is 4
             self.assertEqual(num.number, 4)
@@ -145,9 +140,6 @@ class TestRangeEditorSpinner(unittest.TestCase):
             lineedit = ui.control.findChild(qt.QtGui.QLineEdit)
             lineedit.setFocus()
             lineedit.setText("4")
-
-            # press the OK button and close the dialog
-            press_ok_button(ui)
 
         # if all went well, the number traits has been updated and its value is
         # 4

--- a/traitsui/tests/editors/test_range_editor_text.py
+++ b/traitsui/tests/editors/test_range_editor_text.py
@@ -76,9 +76,6 @@ class TestRangeEditorText(unittest.TestCase):
             textctrl = ui.control.FindWindowByName("text")
             textctrl.SetValue("1")
 
-            # press the OK button and close the dialog
-            press_ok_button(ui)
-
         # the number traits should be between 3 and 8
         self.assertTrue(3 <= num.number <= 8)
 
@@ -97,9 +94,6 @@ class TestRangeEditorText(unittest.TestCase):
             lineedit.setFocus()
             lineedit.setText("4")
             lineedit.editingFinished.emit()
-
-            # press the OK button and close the dialog
-            press_ok_button(ui)
 
         # the number trait should be 4 extactly
         self.assertEqual(num.number, 4.0)

--- a/traitsui/tests/editors/test_set_editor.py
+++ b/traitsui/tests/editors/test_set_editor.py
@@ -1,14 +1,15 @@
+import contextlib
 import unittest
-
-from pyface.gui import GUI
 
 from traits.api import HasTraits, List
 from traitsui.api import SetEditor, UItem, View
 from traitsui.tests._tools import (
+    create_ui,
     click_button,
     is_control_enabled,
     is_current_backend_qt4,
     is_current_backend_wx,
+    process_cascade_events,
     skip_if_null,
     store_exceptions_on_all_threads,
 )
@@ -146,10 +147,10 @@ def double_click_on_item(editor, item_idx, in_used=False):
 @skip_if_null
 class TestSetEditorMapping(unittest.TestCase):
 
+    @contextlib.contextmanager
     def setup_ui(self, model, view):
-        ui = model.edit_traits(view=view)
-        self.addCleanup(ui.dispose)
-        return ui.get_editors("value")[0]
+        with create_ui(model, dict(view=view)) as ui:
+            yield ui.get_editors("value")[0]
 
     def test_simple_editor_mapping_values(self):
         class IntListModel(HasTraits):
@@ -167,8 +168,8 @@ class TestSetEditorMapping(unittest.TestCase):
             )
         )
 
-        with store_exceptions_on_all_threads():
-            editor = self.setup_ui(IntListModel(), formatted_view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_ui(IntListModel(), formatted_view) as editor:
 
             self.assertEqual(editor.names, ["FALSE", "TRUE"])
             self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
@@ -201,8 +202,8 @@ class TestSetEditorMapping(unittest.TestCase):
         )
         model = IntListModel()
 
-        with store_exceptions_on_all_threads():
-            editor = self.setup_ui(model, formatted_view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_ui(model, formatted_view) as editor:
 
             self.assertEqual(editor.names, ["FALSE", "TRUE"])
             self.assertEqual(editor.mapping, {"FALSE": 0, "TRUE": 1})
@@ -222,35 +223,29 @@ class TestSetEditorMapping(unittest.TestCase):
 @skip_if_null
 class TestSimpleSetEditor(unittest.TestCase):
 
+    @contextlib.contextmanager
     def setup_gui(self, model, view):
-        gui = GUI()
-        ui = model.edit_traits(view=view)
-        self.addCleanup(ui.dispose)
-
-        gui.process_events()
-        editor = ui.get_editors("value")[0]
-
-        return gui, editor
+        with create_ui(model, dict(view=view)) as ui:
+            yield ui.get_editors("value")[0]
 
     def test_simple_set_editor_use_button(self):
-        with store_exceptions_on_all_threads():
-            # Initiate with non-alphabetical list
-            gui, editor = self.setup_gui(
-                ListModel(value=["two", "one"]), get_view()
-            )
+        # Initiate with non-alphabetical list
+        model = ListModel(value=["two", "one"])
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             # Used list is sorted alphabetically
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 1, in_used=False)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertTrue(is_control_enabled(editor._use))
             self.assertFalse(is_control_enabled(editor._unuse))
 
             click_button(editor._use)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), ["four"])
             # Button inserts at the top
@@ -260,20 +255,20 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(editor._get_selected_strings(editor._used), [])
 
     def test_simple_set_editor_unuse_button(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 0, in_used=True)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertFalse(is_control_enabled(editor._use))
             self.assertTrue(is_control_enabled(editor._unuse))
 
             click_button(editor._unuse)
-            gui.process_events()
+            process_cascade_events()
 
             # Button inserts at the top
             self.assertEqual(
@@ -282,14 +277,14 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), ["two"])
 
     def test_simple_set_editor_use_dclick(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             double_click_on_item(editor, 1, in_used=False)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), ["four"])
             # Inserts at the top
@@ -299,14 +294,14 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(editor._get_selected_strings(editor._used), [])
 
     def test_simple_set_editor_unuse_dclick(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             double_click_on_item(editor, 0, in_used=True)
-            gui.process_events()
+            process_cascade_events()
 
             # Inserts at the top
             self.assertEqual(
@@ -315,20 +310,20 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), ["two"])
 
     def test_simple_set_editor_use_all(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 1, in_used=False)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertTrue(is_control_enabled(editor._use_all))
             self.assertFalse(is_control_enabled(editor._unuse_all))
 
             click_button(editor._use_all)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), [])
             # Button inserts at the end
@@ -337,20 +332,20 @@ class TestSimpleSetEditor(unittest.TestCase):
             )
 
     def test_simple_set_editor_unuse_all(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 0, in_used=True)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertFalse(is_control_enabled(editor._use_all))
             self.assertTrue(is_control_enabled(editor._unuse_all))
 
             click_button(editor._unuse_all)
-            gui.process_events()
+            process_cascade_events()
 
             # Button inserts at the end
             self.assertEqual(
@@ -359,62 +354,58 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), [])
 
     def test_simple_set_editor_move_up(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(
-                ListModel(), get_view(ordered=True)
-            )
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view(ordered=True)) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 1, in_used=True)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertTrue(is_control_enabled(editor._up))
             self.assertFalse(is_control_enabled(editor._down))
 
             click_button(editor._up)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["two", "one"])
 
     def test_simple_set_editor_move_down(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(
-                ListModel(), get_view(ordered=True)
-            )
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view(ordered=True)) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 0, in_used=True)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertFalse(is_control_enabled(editor._up))
             self.assertTrue(is_control_enabled(editor._down))
 
             click_button(editor._down)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["two", "one"])
 
     def test_simple_set_editor_use_all_button(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 1, in_used=False)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertTrue(is_control_enabled(editor._use_all))
             self.assertFalse(is_control_enabled(editor._unuse_all))
 
             click_button(editor._use_all)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), [])
             # Button inserts at the end
@@ -423,20 +414,20 @@ class TestSimpleSetEditor(unittest.TestCase):
             )
 
     def test_simple_set_editor_unuse_all_button(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_on_item(editor, 0, in_used=True)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertFalse(is_control_enabled(editor._use_all))
             self.assertTrue(is_control_enabled(editor._unuse_all))
 
             click_button(editor._unuse_all)
-            gui.process_events()
+            process_cascade_events()
 
             # Button inserts at the end
             self.assertEqual(
@@ -445,14 +436,14 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), [])
 
     def test_simple_set_editor_default_selection_unused(self):
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             click_button(editor._use)
-            gui.process_events()
+            process_cascade_events()
 
             # Button inserts at the top
             self.assertEqual(
@@ -466,15 +457,15 @@ class TestSimpleSetEditor(unittest.TestCase):
         # When all items are used, top used item is selected by default
         list_edit = ListModel(value=["one", "two", "three", "four"])
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(list_edit, get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(list_edit, get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), [])
             self.assertEqual(
                 get_list_items(editor._used), ["four", "one", "three", "two"])
 
             click_button(editor._unuse)
-            gui.process_events()
+            process_cascade_events()
 
             # Button inserts at the top
             self.assertEqual(get_list_items(editor._unused), ["four"])
@@ -487,14 +478,14 @@ class TestSimpleSetEditor(unittest.TestCase):
         view = View(UItem("value", editor=editor_factory, style="simple",))
         list_edit = ListModel()
 
-        with store_exceptions_on_all_threads():
-            gui, editor = self.setup_gui(list_edit, view)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(list_edit, view) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             self.assertEqual(get_list_items(editor._used), ["one", "two"])
 
             editor_factory.values = ["two", "three", "four"]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             # FIXME issue enthought/traitsui#840
@@ -507,24 +498,23 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(list_edit.value, ["two"])
 
     def test_simple_set_editor_use_ordered_selected(self):
-        with store_exceptions_on_all_threads():
-            # Initiate with non-alphabetical list
-            gui, editor = self.setup_gui(
-                ListModel(value=["two", "one"]), get_view(ordered=True)
-            )
+        # Initiate with non-alphabetical list
+        model = ListModel(value=["two", "one"])
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(model, get_view(ordered=True)) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             # Used list maintains the order
             self.assertEqual(get_list_items(editor._used), ["two", "one"])
 
             click_on_item(editor, 1, in_used=False)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertTrue(is_control_enabled(editor._use))
             self.assertFalse(is_control_enabled(editor._unuse))
 
             click_button(editor._use)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_list_items(editor._unused), ["four"])
             # Button inserts at the top
@@ -536,17 +526,16 @@ class TestSimpleSetEditor(unittest.TestCase):
             )
 
     def test_simple_set_editor_unordeder_button_existence(self):
-        with store_exceptions_on_all_threads():
-            _, editor = self.setup_gui(ListModel(), get_view())
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertIsNone(editor._up)
             self.assertIsNone(editor._down)
 
     def test_simple_set_editor_cant_move_all_button_existence(self):
-        with store_exceptions_on_all_threads():
-            _, editor = self.setup_gui(
-                ListModel(), get_view(can_move_all=False)
-            )
+        view = get_view(can_move_all=False)
+        with store_exceptions_on_all_threads(), \
+                self.setup_gui(ListModel(), view) as editor:
 
             self.assertIsNone(editor._use_all)
             self.assertIsNone(editor._unuse_all)

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -1,6 +1,5 @@
 import unittest
 
-from pyface.gui import GUI
 from traits.api import HasTraits, Instance, Int, List, Str, Tuple
 
 from traitsui.api import EvalTableFilter, Item, ObjectColumn, TableEditor, View
@@ -8,6 +7,7 @@ from traitsui.tests._tools import (
     create_ui,
     is_current_backend_qt4,
     is_current_backend_wx,
+    process_cascade_events,
     press_ok_button,
     skip_if_not_qt4,
     skip_if_null,
@@ -263,38 +263,32 @@ class TestTableEditor(unittest.TestCase):
 
     @skip_if_null
     def test_table_editor(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
 
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=simple_view)) as ui:
-            gui.process_events()
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
     @skip_if_null
     def test_filtered_table_editor(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
 
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=filtered_view)) as ui:
-            gui.process_events()
+            process_cascade_events()
 
             filter = ui.get_editors("values")[0].filter
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertIsNotNone(filter)
 
     @skip_if_null
     def test_table_editor_select_row(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -303,20 +297,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=select_row_view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected
             elif is_current_backend_wx():
                 selected = editor.selected_row
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertIs(selected, object_list.values[5])
 
     @skip_if_null
     def test_table_editor_select_rows(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -325,20 +317,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=select_rows_view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected
             elif is_current_backend_wx():
                 selected = editor.selected_rows
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, object_list.values[5:7])
 
     @skip_if_null
     def test_table_editor_select_row_index(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -347,20 +337,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=select_row_index_view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected_indices
             elif is_current_backend_wx():
                 selected = editor.selected_row_index
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, 5)
 
     @skip_if_null
     def test_table_editor_select_row_indices(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -370,20 +358,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected_indices
             elif is_current_backend_wx():
                 selected = editor.selected_row_indices
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, [5, 7, 8])
 
     @skip_if_null
     def test_table_editor_select_column(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -392,20 +378,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=select_column_view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected
             elif is_current_backend_wx():
                 selected = editor.selected_column
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, "value")
 
     @skip_if_null
     def test_table_editor_select_columns(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -414,20 +398,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=select_columns_view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected
             elif is_current_backend_wx():
                 selected = editor.selected_columns
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, ["value", "other_value"])
 
     @skip_if_null
     def test_table_editor_select_column_index(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -437,20 +419,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected_indices
             elif is_current_backend_wx():
                 selected = editor.selected_column_index
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, 1)
 
     @skip_if_null
     def test_table_editor_select_column_indices(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -460,20 +440,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected_indices
             elif is_current_backend_wx():
                 selected = editor.selected_column_indices
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, [0, 1])
 
     @skip_if_null
     def test_table_editor_select_cell(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -482,20 +460,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=select_cell_view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected
             elif is_current_backend_wx():
                 selected = editor.selected_cell
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, (object_list.values[5], "value"))
 
     @skip_if_null
     def test_table_editor_select_cells(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -508,14 +484,13 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=select_cells_view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected
             elif is_current_backend_wx():
                 selected = editor.selected_cells
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, [
             (object_list.values[5], "value"),
@@ -525,7 +500,6 @@ class TestTableEditor(unittest.TestCase):
 
     @skip_if_null
     def test_table_editor_select_cell_index(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -535,20 +509,18 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected_indices
             elif is_current_backend_wx():
                 selected = editor.selected_cell_index
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, (5, 1))
 
     @skip_if_null
     def test_table_editor_select_cell_indices(self):
-        gui = GUI()
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
@@ -558,14 +530,13 @@ class TestTableEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            gui.process_events()
+            process_cascade_events()
             if is_current_backend_qt4():
                 selected = editor.selected_indices
             elif is_current_backend_wx():
                 selected = editor.selected_cell_indices
 
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()
 
         self.assertEqual(selected, [(5, 0), (6, 1), (8, 0)])
 
@@ -586,13 +557,10 @@ class TestTableEditor(unittest.TestCase):
             ),
             buttons=["OK"],
         )
-        gui = GUI()
         object_list = ObjectList(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
 
         with store_exceptions_on_all_threads(), \
                 create_ui(object_list, dict(view=progress_view)) as ui:
-            gui.process_events()
-            press_ok_button(ui)
-            gui.process_events()
+            process_cascade_events()

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -19,8 +19,10 @@ from traits.testing.api import UnittestTools
 from traitsui.api import Item, TabularEditor, View
 from traitsui.tabular_adapter import TabularAdapter
 from traitsui.tests._tools import (
+    create_ui,
     is_current_backend_wx,
     is_current_backend_qt4,
+    process_cascade_events,
     skip_if_null,
     store_exceptions_on_all_threads,
 )
@@ -181,24 +183,23 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
 
     @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_single_selection(self):
-        gui = GUI()
 
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (report, editor):
-            gui.process_events()
+            process_cascade_events()
             people = report.people
 
             self.assertEqual(report.selected_row, -1)
             self.assertIsNone(report.selected)
 
             set_selected_single(editor, 1)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(report.selected_row, 1)
             self.assertEqual(report.selected, people[1])
 
             set_selected_single(editor, 2)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(report.selected_row, 2)
             self.assertEqual(report.selected, people[2])
@@ -207,92 +208,89 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
 
     @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_multi_selection(self):
-        gui = GUI()
         view = get_view(multi_select=True)
 
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(view) as (report, editor):
-            gui.process_events()
+            process_cascade_events()
             people = report.people
 
             self.assertEqual(report.selected_rows, [])
             self.assertEqual(report.multi_selected, [])
 
             set_selected_multiple(editor, [0, 1])
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(report.selected_rows, [0, 1])
             self.assertEqual(report.multi_selected, people[:2])
 
             set_selected_multiple(editor, [2])
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(report.selected_rows, [2])
             self.assertEqual(report.multi_selected, [people[2]])
 
             clear_selection(editor)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(report.selected_rows, [])
             self.assertEqual(report.multi_selected, [])
 
     @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_single_selection_changed(self):
-        gui = GUI()
 
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (report, editor):
-            gui.process_events()
+            process_cascade_events()
             people = report.people
 
             self.assertEqual(get_selected_rows(editor), [])
 
             report.selected_row = 1
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [1])
             self.assertEqual(report.selected, people[1])
 
             report.selected = people[2]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [2])
             self.assertEqual(report.selected_row, 2)
 
             # Selected set to invalid value doesn't change anything
             report.selected = Person(name="invalid", age=-1)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [2])
             self.assertEqual(report.selected_row, 2)
 
             # -1 clears selection
             report.selected_row = -1
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [])
             self.assertEqual(report.selected, None)
 
     @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_multi_selection_changed(self):
-        gui = GUI()
         view = get_view(multi_select=True)
 
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(view) as (report, editor):
-            gui.process_events()
+            process_cascade_events()
             people = report.people
 
             self.assertEqual(get_selected_rows(editor), [])
 
             report.selected_rows = [0, 1]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [0, 1])
             self.assertEqual(report.multi_selected, people[:2])
 
             report.multi_selected = [people[2], people[0]]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(sorted(get_selected_rows(editor)), [0, 2])
             self.assertEqual(sorted(report.selected_rows), [0, 2])
@@ -300,51 +298,50 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             # If there's a single invalid value, nothing is updated
             invalid_person = Person(name="invalid", age=-1)
             report.multi_selected = [people[2], invalid_person]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(sorted(get_selected_rows(editor)), [0, 2])
             self.assertEqual(sorted(report.selected_rows), [0, 2])
 
             # Empty list clears selection
             report.selected_rows = []
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [])
             self.assertEqual(report.multi_selected, [])
 
     @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_multi_selection_items_changed(self):
-        gui = GUI()
         view = get_view(multi_select=True)
 
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(view) as (report, editor):
-            gui.process_events()
+            process_cascade_events()
             people = report.people
 
             self.assertEqual(get_selected_rows(editor), [])
 
             report.selected_rows.extend([0, 1])
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [0, 1])
             self.assertEqual(report.multi_selected, people[:2])
 
             report.selected_rows[1] = 2
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(get_selected_rows(editor), [0, 2])
             self.assertEqual(report.multi_selected, people[0:3:2])
 
             report.multi_selected[0] = people[1]
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(sorted(get_selected_rows(editor)), [1, 2])
             self.assertEqual(sorted(report.selected_rows), [1, 2])
 
             # If there's a single invalid value, nothing is updated
             report.multi_selected[0] = Person(name="invalid", age=-1)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(sorted(get_selected_rows(editor)), [1, 2])
             self.assertEqual(sorted(report.selected_rows), [1, 2])
@@ -423,9 +420,6 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
                 Person(name="Karen", age=40),
             ]
         )
-        ui = report.edit_traits(view=view)
-        try:
+        with create_ui(report, dict(view=view)) as ui:
             editor, = ui.get_editors("people")
             yield report, editor
-        finally:
-            ui.dispose()

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -396,7 +396,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             # when the columns is updated such that recalculation does not
             # fail.
             editor.adapter.columns = [("Name", "name")]
-            GUI.process_events()
+            process_cascade_events()
 
     def test_view_column_resized_attribute_error_workaround(self):
         # This tests the workaround which checks if `factory` is None before

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -12,8 +12,6 @@
 import contextlib
 import unittest
 
-from pyface.api import GUI
-
 from traits.api import (
     HasTraits,
     Str,
@@ -23,6 +21,7 @@ from traitsui.tests._tools import (
     create_ui,
     GuiTestAssistant,
     is_current_backend_qt4,
+    process_cascade_events,
     skip_if_not_qt4,
     store_exceptions_on_all_threads,
     no_gui_test_assistant,
@@ -182,30 +181,28 @@ class TestTextEditor(unittest.TestCase):
     def test_simple_auto_set_update_text(self):
         foo = Foo()
         view = get_view(style="simple", auto_set=True)
-        gui = GUI()
         with store_exceptions_on_all_threads(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
             set_text(editor, "NEW")
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(foo.name, "NEW")
 
     def test_simple_auto_set_false_do_not_update(self):
         foo = Foo(name="")
         view = get_view(style="simple", auto_set=False)
-        gui = GUI()
         with store_exceptions_on_all_threads(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
             set_text(editor, "NEW")
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(foo.name, "")
 
             key_press_return(editor)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(foo.name, "NEW")
 
@@ -213,13 +210,12 @@ class TestTextEditor(unittest.TestCase):
         # the auto_set flag is disregard for custom editor.
         foo = Foo()
         view = get_view(auto_set=True, style="custom")
-        gui = GUI()
         with store_exceptions_on_all_threads(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
             set_text(editor, "NEW")
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(foo.name, "NEW")
 
@@ -227,15 +223,14 @@ class TestTextEditor(unittest.TestCase):
         # the auto_set flag is disregard for custom editor.
         foo = Foo()
         view = get_view(auto_set=False, style="custom")
-        gui = GUI()
         with store_exceptions_on_all_threads(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
             set_text(editor, "NEW")
-            gui.process_events()
+            process_cascade_events()
 
             key_press_return(editor)
-            gui.process_events()
+            process_cascade_events()
 
             self.assertEqual(foo.name, "NEW\n")

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -34,16 +34,6 @@ class Foo(HasTraits):
     name = Str()
 
 
-@contextlib.contextmanager
-def launch_ui(gui_test_case, object, view):
-    ui = object.edit_traits(view=view)
-    try:
-        yield ui
-    finally:
-        with gui_test_case.delete_widget(ui.control):
-            ui.dispose()
-
-
 def get_view(style, auto_set):
     """ Return the default view for the Foo object.
 
@@ -107,7 +97,7 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
             placeholder="Enter name",
         )
         view = View(Item(name="name", editor=editor))
-        with launch_ui(self, object=foo, view=view) as ui:
+        with create_ui(foo, dict(view=view)) as ui:
             name_editor, = ui.get_editors("name")
             self.assertEqual(
                 name_editor.control.placeholderText(),
@@ -122,7 +112,7 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
             read_only=True,
         )
         view = View(Item(name="name", editor=editor))
-        with launch_ui(self, object=foo, view=view) as ui:
+        with create_ui(foo, dict(view=view)) as ui:
             name_editor, = ui.get_editors("name")
             self.assertEqual(
                 name_editor.control.placeholderText(),
@@ -131,7 +121,7 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
 
     def test_text_editor_default_view(self):
         foo = Foo()
-        with launch_ui(self, object=foo, view=None) as ui:
+        with create_ui(foo) as ui:
             name_editor, = ui.get_editors("name")
             self.assertEqual(
                 name_editor.control.placeholderText(),
@@ -146,7 +136,7 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
             style="custom",
             editor=TextEditor(placeholder="Enter name"),
         ))
-        with launch_ui(self, object=foo, view=view) as ui:
+        with create_ui(foo, dict(view=view)) as ui:
             name_editor, = ui.get_editors("name")
             try:
                 placeholder = name_editor.control.placeholderText()

--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -142,12 +142,9 @@ class TestTreeView(unittest.TestCase):
             notifiers_list = bogus.trait(trait)._notifiers(False)
             self.assertEqual(expected_listeners, len(notifiers_list))
 
-            # Manually close the UI
-            press_ok_button(ui)
-
-            # The listener should be removed after the UI has been closed
-            notifiers_list = bogus.trait(trait)._notifiers(False)
-            self.assertEqual(0, len(notifiers_list))
+        # The listener should be removed after the UI has been closed
+        notifiers_list = bogus.trait(trait)._notifiers(False)
+        self.assertEqual(0, len(notifiers_list))
 
     def _test_tree_node_object_releases_listeners(
         self, hide_root, nodes=None, trait="bogus_list", expected_listeners=1
@@ -175,12 +172,9 @@ class TestTreeView(unittest.TestCase):
                 # change the children
                 bogus.bogus_list.append(BogusTreeNodeObject())
 
-            # Manually close the UI
-            press_ok_button(ui)
-
-            # The listener should be removed after the UI has been closed
-            notifiers_list = bogus.trait(trait)._notifiers(False)
-            self.assertEqual(0, len(notifiers_list))
+        # The listener should be removed after the UI has been closed
+        notifiers_list = bogus.trait(trait)._notifiers(False)
+        self.assertEqual(0, len(notifiers_list))
 
     @skip_if_not_qt4
     def test_tree_editor_listeners_with_shown_root(self):
@@ -272,5 +266,5 @@ class TestTreeView(unittest.TestCase):
     def test_smoke_word_wrap(self):
         bogus = Bogus(bogus_list=[Bogus()])
         tree_editor_view = BogusTreeView(bogus=bogus, word_wrap=True)
-        ui = tree_editor_view.edit_traits()
-        ui.dispose()
+        with create_ui(tree_editor_view):
+            pass

--- a/traitsui/tests/editors/test_tuple_editor.py
+++ b/traitsui/tests/editors/test_tuple_editor.py
@@ -59,9 +59,6 @@ class TestTupleEditor(unittest.TestCase):
             # is 4
             self.assertEqual(val.tup, (4, 6))
 
-            # press the OK button and close the dialog
-            press_ok_button(ui)
-
 
 if __name__ == "__main__":
     # Executing the file opens the dialog for manual testing

--- a/traitsui/tests/test_color_column.py
+++ b/traitsui/tests/test_color_column.py
@@ -42,11 +42,8 @@ class TestColorColumn(TestCase):
     def test_color_column(self):
         # Behaviour: column ui should display without error
 
-        with store_exceptions_on_all_threads():
-            d1 = MyEntry(name="a", value=2, color=(1.0, 0.3, 0.1))
-            d2 = MyEntry(name="b", value=3, color=(0.1, 0.0, 0.9))
-            data = MyData(data_list=[d1, d2])
-
-            ui = data.edit_traits()
-
-            ui.dispose()
+        d1 = MyEntry(name="a", value=2, color=(1.0, 0.3, 0.1))
+        d2 = MyEntry(name="b", value=3, color=(0.1, 0.0, 0.9))
+        data = MyData(data_list=[d1, d2])
+        with store_exceptions_on_all_threads(), create_ui(data):
+            pass

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -218,8 +218,6 @@ class TestLabels(unittest.TestCase):
 
             dialog.bool_item = True
 
-            ui.dispose()
-
 
 @skip_if_null
 class TestAnyToolkit(unittest.TestCase):

--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -314,9 +314,8 @@ class TestDataFrameEditor(unittest.TestCase):
     @skip_if_null
     def test_data_frame_editor(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits()
-            ui.dispose()
+        with store_exceptions_on_all_threads(), create_ui(viewer):
+            pass
 
     @skip_if_null
     def test_data_frame_editor_alternate_adapter(self):
@@ -331,44 +330,42 @@ class TestDataFrameEditor(unittest.TestCase):
             )
         )
         viewer = sample_data()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits(view=alternate_adapter_view)
-            ui.dispose()
+        with store_exceptions_on_all_threads(), \
+                create_ui(viewer, dict(view=alternate_adapter_view)):
+            pass
 
     @skip_if_null
     def test_data_frame_editor_numerical_index(self):
         viewer = sample_data_numerical_index()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits()
-            ui.dispose()
+        with store_exceptions_on_all_threads(), create_ui(viewer):
+            pass
 
     @skip_if_null
     def test_data_frame_editor_text_data(self):
         viewer = sample_text_data()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits()
-            ui.dispose()
+        with store_exceptions_on_all_threads(), create_ui(viewer):
+            pass
 
     @skip_if_null
     def test_data_frame_editor_format_mapping(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits(view=format_mapping_view)
-            ui.dispose()
+        with store_exceptions_on_all_threads(), \
+                create_ui(viewer, dict(view=format_mapping_view)):
+            pass
 
     @skip_if_null
     def test_data_frame_editor_font_mapping(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits(view=font_mapping_view)
-            ui.dispose()
+        with store_exceptions_on_all_threads(), \
+                create_ui(viewer, dict(view=font_mapping_view)):
+            pass
 
     @skip_if_null
     def test_data_frame_editor_columns(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits(view=columns_view)
-            ui.dispose()
+        with store_exceptions_on_all_threads(), \
+                create_ui(viewer, dict(view=columns_view)):
+            pass
 
     @skip_if_null
     def test_data_frame_editor_with_update_refresh(self):
@@ -412,9 +409,9 @@ class TestDataFrameEditor(unittest.TestCase):
             Item("data", editor=DataFrameEditor(multi_select=True), width=400)
         )
         viewer = sample_data()
-        with store_exceptions_on_all_threads():
-            ui = viewer.edit_traits(view=view)
-            ui.dispose()
+        with store_exceptions_on_all_threads(), \
+                create_ui(viewer, dict(view=view)):
+            pass
 
     @skip_if_null
     def test_adapter_set_text(self):


### PR DESCRIPTION
This is an ongoing efforts to clean up UI and GUI event queue in order to resolve test interactions.

This PR does the following:
(1) Search for `edit_traits` in tests and convert them to use `create_ui` so that the tests receive the same dispose logic. One exception is `test_editor`, which is the logic `create_ui` depends on. Using `create_ui` will be a bit circular.
(2) Use `process_cascade_events` to ensure cascade events are processed in Qt. In many places where there are no cascade events, `GUI.process_events()` would be enough, but really the tests often mean to process everything before doing the next things, not just the current snapshots of events.
(3) Drive-by: Avoid holding references to `Editor.control` in tests

Closes #851