### PR TITLE
Maint: Add raise_to_debug when failed to import a toolkit specific editor

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -213,6 +213,7 @@ def test(runtime, toolkit, environment):
     parameters = get_parameters(runtime, toolkit, environment)
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
+    environ['TRAITS_DEBUG'] = "1"
 
     if toolkit == "wx":
         environ["EXCLUDE_TESTS"] = "qt"

--- a/traitsui/editor_factory.py
+++ b/traitsui/editor_factory.py
@@ -226,6 +226,8 @@ class EditorFactory(HasPrivateTraits):
         try:
             SimpleEditor = self._get_toolkit_editor("SimpleEditor")
         except Exception as e:
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
             msg = "Can't import SimpleEditor for {}: {}"
             logger.debug(msg.format(self.__class__, e))
             SimpleEditor = toolkit_object("editor_factory:SimpleEditor")


### PR DESCRIPTION
Motivated by #864 and #920, it is hard to debug when a different editor is used in place of the intended one.
This PR adds `raise_to_debug` to allow exceptions otherwise swallowed to be propagated in development environment.
We might want to add this for all types of editors.