### PR TITLE
Reinstate pyface master for CI

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -176,7 +176,7 @@ def install(runtime, toolkit, environment, editable):
     commands = [
         "edm environments create {environment} --force --version={runtime}",
         "edm install -y -e {environment} " + packages,
-        "edm run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
+        "edm run -e {environment} -- pip install --force-reinstall -r ci-src-requirements.txt --no-dependencies",
         "edm run -e {environment} -- python setup.py clean --all",
         install_traitsui,
     ]


### PR DESCRIPTION
Closes #920

> #853 added test dependencies which install the release version of pyface from PyPI. While that would have been our goal in the future, we do need pyface master for CI. When CI script gets to pip install -r ci-src-requirements.txt --no-dependencies for installing pyface master, pyface is already there and master is not installed. Then when the test tries to import traitsui.wx.table_editor, it runs into an error

This PR fixes this by making sure pyface master is always installed 