### PR TITLE
Increase precision offset for process_cascade_events and Windows

### DIFF
--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -151,11 +151,13 @@ def process_cascade_events():
         # Qt won't raise if there are still events to be processed before
         # the time limit is reached. There are no other safe way to tell
         # if there are pending events (`hasPendingEvents` is deprecated).
-        # The minus-one is to account for precision differences between Python
+        # The offset is to account for precision differences between Python
         # and Qt, false positive triggers another redundant run that should
         # return immediately so that is fine.
+        # The precision is worse on Windows, typically around ~15 milliseconds.
+        # Give it a 1% error offset, which should be more than enough.
         while (start is None
-                or (time.time() - start) * 1000 >= _TOLERANCE_MILLISECS - 1):
+                or (time.time() - start) * 1000 >= _TOLERANCE_MILLISECS - 50):
             start = time.time()
             QtCore.QCoreApplication.processEvents(
                 QtCore.QEventLoop.AllEvents, _TOLERANCE_MILLISECS

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -16,7 +16,7 @@
 
 import re
 import sys
-import time
+import timeit
 import traceback
 from functools import partial
 from contextlib import contextmanager
@@ -147,7 +147,7 @@ def process_cascade_events():
     if is_current_backend_qt4():
         from pyface.qt import QtCore
         start = None
-
+        timer = timeit.default_timer
         # Qt won't raise if there are still events to be processed before
         # the time limit is reached. There are no other safe way to tell
         # if there are pending events (`hasPendingEvents` is deprecated).
@@ -157,8 +157,8 @@ def process_cascade_events():
         # The precision is worse on Windows, typically around ~15 milliseconds.
         # Give it a 1% error offset, which should be more than enough.
         while (start is None
-                or (time.time() - start) * 1000 >= _TOLERANCE_MILLISECS - 50):
-            start = time.time()
+                or (timer() - start) * 1000 >= _TOLERANCE_MILLISECS - 50):
+            start = timer()
             QtCore.QCoreApplication.processEvents(
                 QtCore.QEventLoop.AllEvents, _TOLERANCE_MILLISECS
             )


### PR DESCRIPTION
While Linux/OSX typically have decent timing precision (in the order of microseconds), Windows has a worse [temporal resolution](https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/high-resolution-timers).

This PR increases the precision tolerance in `process_cascade_events` to account for the larger precision error on Windows. Again false positive is okay as long as the next redundant run returns fast enough to exit the loop, so it is fine for Linux/OSX to receive the same treatment.