### PR TITLE
Minor stylistic changes to demos in Standard_Editors

### DIFF
--- a/examples/demo/Standard_Editors/BooleanEditor_demo.py
+++ b/examples/demo/Standard_Editors/BooleanEditor_demo.py
@@ -3,7 +3,7 @@ Boolean editor (checkbox or text)
 
 A Boolean (True/False) trait is displayed and edited as a checkbox, by default.
 
-It can also be displayed as text 'True' / 'False', either editable or read-only.
+It can also be displayed as text 'True'/'False', either editable or read-only.
 
 This example also shows how to listen for a change in a trait, and take
 action when its value changes.
@@ -59,6 +59,7 @@ class BooleanEditorDemo(HasTraits):
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo view (but do not yet display it):
 demo = BooleanEditorDemo()

--- a/examples/demo/Standard_Editors/ButtonEditor_demo.py
+++ b/examples/demo/Standard_Editors/ButtonEditor_demo.py
@@ -8,7 +8,8 @@ In this example, the listener just increments a click counter.
 """
 
 from traits.api import HasTraits, Button, Int
-from traitsui.api import View
+
+from traitsui.api import Item, View
 
 
 class ButtonEditorDemo(HasTraits):
@@ -16,7 +17,7 @@ class ButtonEditorDemo(HasTraits):
 
     # Define a Button trait:
     my_button_trait = Button('Click Me')
-    click_counter = Int()
+    click_counter = Int(0)
 
     # When the button is clicked, do something.
     # The listener method is named '_TraitName_fired', where
@@ -27,11 +28,12 @@ class ButtonEditorDemo(HasTraits):
     # Demo view:
     traits_view = View(
         'my_button_trait',
-        'click_counter',
+        Item('click_counter', style='readonly'),
         title='ButtonEditor',
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = ButtonEditorDemo()

--- a/examples/demo/Standard_Editors/CSVListEditor_demo.py
+++ b/examples/demo/Standard_Editors/CSVListEditor_demo.py
@@ -1,10 +1,19 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Demonstrate the CSVListEditor class.
 
 This editor allows the user to enter a *single* line of input text, containing
 comma-separated values (or another separator may be specified). Your program
 specifies an element Trait type of Int, Float, Str, Enum, or Range.
 """
+# Issue related to the demo warning: enthought/traitsui#913
+
 
 from traits.api import (
     HasTraits, List, Int, Float, Enum, Range, Str, Button, Property

--- a/examples/demo/Standard_Editors/CSVListEditor_demo.py
+++ b/examples/demo/Standard_Editors/CSVListEditor_demo.py
@@ -1,18 +1,21 @@
 """
-Demonstrate the CSVListEditor class.<br>
-<br>
+Demonstrate the CSVListEditor class.
+
 This editor allows the user to enter a *single* line of input text, containing
 comma-separated values (or another separator may be specified). Your program
 specifies an element Trait type of Int, Float, Str, Enum, or Range.
 """
 
-from traits.api import HasTraits, List, Int, Float, Enum, Range, Str, Button, \
-    Property
-from traitsui.api import View, Item, Label, Heading, VGroup, HGroup, UItem, \
-    spring, TextEditor, CSVListEditor
+from traits.api import (
+    HasTraits, List, Int, Float, Enum, Range, Str, Button, Property
+)
+from traitsui.api import (
+    View, Item, Label, Heading, VGroup, HGroup, UItem, spring, TextEditor,
+    CSVListEditor
+)
 
 
-class Demo(HasTraits):
+class CSVListEditorDemo(HasTraits):
 
     list1 = List(Int)
 
@@ -39,73 +42,96 @@ class Demo(HasTraits):
     # This will be str(self.list1).
     list1str = Property(Str, depends_on='list1')
 
-    traits_view = \
-        View(
-            HGroup(
-                # This VGroup forms the column of CSVListEditor examples.
-                VGroup(
-                    Item('list1', label="List(Int)",
-                         editor=CSVListEditor(ignore_trailing_sep=False),
-                         tooltip='options: ignore_trailing_sep=False'),
-                    Item('list1', label="List(Int)", style='readonly',
-                         editor=CSVListEditor()),
-                    Item('list2', label="List(Float)",
-                         editor=CSVListEditor(enter_set=True, auto_set=False),
-                         tooltip='options: enter_set=True, auto_set=False'),
-                    Item('list3', label="List(Str, maxlen=3)",
-                         editor=CSVListEditor()),
-                    Item('list4',
-                         label="List(Enum('red', 'green', 'blue', 2, 3))",
-                         editor=CSVListEditor(sep=None),
-                         tooltip='options: sep=None'),
-                    Item('list5', label="List(Range(low=0.0, high=10.0))",
-                         editor=CSVListEditor()),
-                    Item('list6', label="List(Range(low=-1.0, high='high'))",
-                         editor=CSVListEditor()),
-                    Item('list7', label="List(Range(low='low', high='high'))",
-                         editor=CSVListEditor()),
-                    springy=True,
+    traits_view = View(
+        HGroup(
+            # This VGroup forms the column of CSVListEditor examples.
+            VGroup(
+                Item(
+                    'list1',
+                    label="List(Int)",
+                    editor=CSVListEditor(ignore_trailing_sep=False),
+                    tooltip='options: ignore_trailing_sep=False'
                 ),
-                # This VGroup forms the right column; it will display the
-                # Python str representation of the lists.
-                VGroup(
-                    UItem('list1str', editor=TextEditor(),
-                          enabled_when='False', width=240),
-                    UItem('list1str', editor=TextEditor(),
-                          enabled_when='False', width=240),
-                    UItem('list2', editor=TextEditor(),
-                          enabled_when='False', width=240),
-                    UItem('list3', editor=TextEditor(),
-                          enabled_when='False', width=240),
-                    UItem('list4', editor=TextEditor(),
-                          enabled_when='False', width=240),
-                    UItem('list5', editor=TextEditor(),
-                          enabled_when='False', width=240),
-                    UItem('list6', editor=TextEditor(),
-                          enabled_when='False', width=240),
-                    UItem('list7', editor=TextEditor(),
-                          enabled_when='False', width=240),
+                Item(
+                    'list1',
+                    label="List(Int)",
+                    style='readonly',
+                    editor=CSVListEditor()
                 ),
+                Item(
+                    'list2',
+                    label="List(Float)",
+                    editor=CSVListEditor(enter_set=True, auto_set=False),
+                    tooltip='options: enter_set=True, auto_set=False'
+                ),
+                Item(
+                    'list3',
+                    label="List(Str, maxlen=3)",
+                    editor=CSVListEditor()
+                ),
+                Item(
+                    'list4',
+                    label="List(Enum('red', 'green', 'blue', 2, 3))",
+                    editor=CSVListEditor(sep=None),
+                    tooltip='options: sep=None'
+                ),
+                Item(
+                    'list5',
+                    label="List(Range(low=0.0, high=10.0))",
+                    editor=CSVListEditor()
+                ),
+                Item(
+                    'list6',
+                    label="List(Range(low=-1.0, high='high'))",
+                    editor=CSVListEditor()
+                ),
+                Item(
+                    'list7',
+                    label="List(Range(low='low', high='high'))",
+                    editor=CSVListEditor()
+                ),
+                springy=True,
             ),
-            '_',
-            HGroup('low', 'high', spring, UItem('pop1'), UItem('sort1')),
-            Heading("Notes"),
-            Label("Hover over a list to see which editor options are set, "
-                  "if any."),
-            Label("The editor of the first list, List(Int), uses "
-                  "ignore_trailing_sep=False, so a trailing comma is "
-                  "an error."),
-            Label("The second list is a read-only view of the first list."),
-            Label("The editor of the List(Float) example has enter_set=True "
-                  "and auto_set=False; press Enter to validate."),
-            Label("The List(Str) example will accept at most 3 elements."),
-            Label("The editor of the List(Enum(...)) example uses sep=None, "
-                  "i.e. whitespace acts as a separator."),
-            Label("The last two List(Range(...)) examples take one or both "
-                  "of their limits from the Low and High fields below."),
-            width=720,
-            title="CSVListEditor Demonstration",
-        )
+            # This VGroup forms the right column; it will display the
+            # Python str representation of the lists.
+            VGroup(
+                UItem('list1str', editor=TextEditor(),
+                      enabled_when='False', width=240),
+                UItem('list1str', editor=TextEditor(),
+                      enabled_when='False', width=240),
+                UItem('list2', editor=TextEditor(),
+                      enabled_when='False', width=240),
+                UItem('list3', editor=TextEditor(),
+                      enabled_when='False', width=240),
+                UItem('list4', editor=TextEditor(),
+                      enabled_when='False', width=240),
+                UItem('list5', editor=TextEditor(),
+                      enabled_when='False', width=240),
+                UItem('list6', editor=TextEditor(),
+                      enabled_when='False', width=240),
+                UItem('list7', editor=TextEditor(),
+                      enabled_when='False', width=240),
+            ),
+        ),
+        '_',
+        HGroup('low', 'high', spring, UItem('pop1'), UItem('sort1')),
+        Heading("Notes"),
+        Label("Hover over a list to see which editor options are set, "
+              "if any."),
+        Label("The editor of the first list, List(Int), uses "
+              "ignore_trailing_sep=False, so a trailing comma is "
+              "an error."),
+        Label("The second list is a read-only view of the first list."),
+        Label("The editor of the List(Float) example has enter_set=True "
+              "and auto_set=False; press Enter to validate."),
+        Label("The List(Str) example will accept at most 3 elements."),
+        Label("The editor of the List(Enum(...)) example uses sep=None, "
+              "i.e. whitespace acts as a separator."),
+        Label("The last three List(Range(...)) examples take neither, one or "
+              "both of their limits from the Low and High fields below."),
+        width=720,
+        title="CSVListEditor Demonstration",
+    )
 
     def _list1_default(self):
         return [1, 4, 0, 10]
@@ -123,5 +149,5 @@ class Demo(HasTraits):
 
 
 if __name__ == "__main__":
-    demo = Demo()
+    demo = CSVListEditorDemo()
     demo.configure_traits()

--- a/examples/demo/Standard_Editors/CheckListEditor_demo.py
+++ b/examples/demo/Standard_Editors/CheckListEditor_demo.py
@@ -8,31 +8,36 @@ For each of three CheckListEditor column formations, this demo shows
 each of the four styles of the CheckListEditor.
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, List
+from traits.api import HasTraits, List
 
-from traitsui.api \
-    import Item, Group, View, CheckListEditor
+from traitsui.api import Item, Group, View, CheckListEditor
+
 
 # Define the demo class:
-
-
 class CheckListEditorDemo(HasTraits):
     """ Define the main CheckListEditor demo class. """
 
     # Define a trait for each of three formations:
-    checklist_4col = List(editor=CheckListEditor(
-        values=['one', 'two', 'three', 'four'],
-        cols=4))
+    checklist_4col = List(
+        editor=CheckListEditor(
+            values=['one', 'two', 'three', 'four'],
+            cols=4
+        )
+    )
 
-    checklist_2col = List(editor=CheckListEditor(
-        values=['one', 'two', 'three', 'four'],
-        cols=2))
+    checklist_2col = List(
+        editor=CheckListEditor(
+            values=['one', 'two', 'three', 'four'],
+            cols=2
+        )
+    )
 
-    checklist_1col = List(editor=CheckListEditor(
-        values=['one', 'two', 'three', 'four'],
-        cols=1))
+    checklist_1col = List(
+        editor=CheckListEditor(
+            values=['one', 'two', 'three', 'four'],
+            cols=1
+        )
+    )
 
     # CheckListEditor display with four columns:
     cl_4_group = Group(
@@ -70,9 +75,9 @@ class CheckListEditorDemo(HasTraits):
         label='1-column'
     )
 
-    # The view includes one group per column formation.  These will be displayed
-    # on separate tabbed panels.
-    view1 = View(
+    # The view includes one group per column formation.  These will be
+    # displayed on separate tabbed panels.
+    traits_view = View(
         cl_4_group,
         cl_2_group,
         cl_1_group,
@@ -80,6 +85,7 @@ class CheckListEditorDemo(HasTraits):
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = CheckListEditorDemo()

--- a/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
+++ b/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
@@ -1,8 +1,8 @@
 """
 Checklist editor for a List of strings
 
-The checklist editor provides a simple way for the user to select multiple items
-from a list of known strings.
+The checklist editor provides a simple way for the user to select multiple
+items from a list of known strings.
 
 This example demonstrates the checklist editor's two most useful styles:
 
@@ -26,17 +26,19 @@ class CheckListEditorDemo(HasTraits):
     """ Define the main CheckListEditor simple demo class. """
 
     # Specify the strings to be displayed in the checklist:
-    checklist = List(editor=CheckListEditor(
-        values=['one', 'two', 'three', 'four',
-                'five', 'six'],
-        cols=2))
+    checklist = List(
+        editor=CheckListEditor(
+            values=['one', 'two', 'three', 'four', 'five', 'six'],
+            cols=2
+        )
+    )
 
     # CheckListEditor display with two columns:
     checklist_group = Group(
-        '10',  # insert vertical space
+        '10',  # insert vertical space (10 empty pixels)
         Label('The custom style lets you select items from a checklist:'),
         UItem('checklist', style='custom'),
-        '10', '_', '10',  # a horizontal line with 10 empty pixels above and below
+        '10', '_', '10',  # horizontal line with vertical space above and below
         Label('The readonly style shows you which items are selected, '
               'as a Python list:'),
         UItem('checklist', style='readonly'),
@@ -48,6 +50,7 @@ class CheckListEditorDemo(HasTraits):
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = CheckListEditorDemo()

--- a/examples/demo/Standard_Editors/CodeEditor_demo.py
+++ b/examples/demo/Standard_Editors/CodeEditor_demo.py
@@ -7,16 +7,12 @@ Implementation of a CodeEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the CodeEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, Code
+from traits.api import HasTraits, Code
 
-from traitsui.api \
-    import Item, Group, View
+from traitsui.api import Item, Group, View
+
 
 # The main demo class:
-
-
 class CodeEditorDemo(HasTraits):
     """ Defines the CodeEditor demo class.
     """
@@ -36,10 +32,13 @@ class CodeEditorDemo(HasTraits):
     )
 
     # Demo view:
-    view = View(
+    traits_view = View(
         code_group,
         title='CodeEditor',
-        buttons=['OK'])
+        width=600,
+        height=600,
+        buttons=['OK']
+    )
 
 
 # Create the demo:

--- a/examples/demo/Standard_Editors/ColorEditor_demo.py
+++ b/examples/demo/Standard_Editors/ColorEditor_demo.py
@@ -7,21 +7,17 @@ Implementation of a ColorEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the ColorEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits
+from traits.api import HasTraits
 
-from traitsui.api \
-    import Item, Group, View, Color
+from traitsui.api import Item, Group, View, Color
+
 
 # Demo class definition:
-
-
 class ColorEditorDemo(HasTraits):
     """ Defines the main ColorEditor demo. """
 
     # Define a Color trait to view:
-    color_trait = Color
+    color_trait = Color()
 
     # Items are used to define the demo display, one item per editor style:
     color_group = Group(
@@ -35,12 +31,13 @@ class ColorEditorDemo(HasTraits):
     )
 
     # Demo view
-    view1 = View(
+    traits_view = View(
         color_group,
         title='ColorEditor',
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = ColorEditorDemo()

--- a/examples/demo/Standard_Editors/ColorEditor_demo.py
+++ b/examples/demo/Standard_Editors/ColorEditor_demo.py
@@ -2,10 +2,20 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a ColorEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the ColorEditor
 """
+# Issues related to the demo warning: enthought/traitsui#913,
+# enthought/traitsui#946
+
 
 from traits.api import HasTraits
 

--- a/examples/demo/Standard_Editors/CompoundEditor_demo.py
+++ b/examples/demo/Standard_Editors/CompoundEditor_demo.py
@@ -7,22 +7,21 @@ Implementation of a CompoundEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the CompoundEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, Trait, Range
+from traits.api import Enum, HasTraits, Range, Union
 
-from traitsui.api \
-    import Item, Group, View
+from traitsui.api import Item, Group, View
+
 
 # Define the demo class:
-
-
 class CompoundEditorDemo(HasTraits):
     """ Defines the main CompoundEditor demo class.
     """
 
     # Define a compund trait to view:
-    compound_trait = Trait(1, Range(1, 6), 'a', 'b', 'c', 'd', 'e', 'f')
+    compound_trait = Union(
+        Range(1, 6), Enum('a', 'b', 'c', 'd', 'e', 'f'),
+        default_value=1
+    )
 
     # Display specification (one Item per editor style):
     comp_group = Group(
@@ -36,12 +35,13 @@ class CompoundEditorDemo(HasTraits):
     )
 
     # Demo view:
-    view = View(
+    traits_view = View(
         comp_group,
         title='CompoundEditor',
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = CompoundEditorDemo()

--- a/examples/demo/Standard_Editors/CompoundEditor_demo.py
+++ b/examples/demo/Standard_Editors/CompoundEditor_demo.py
@@ -2,10 +2,19 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a CompoundEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the CompoundEditor
 """
+# Issue related to the demo warning: enthought/traitsui#945
+
 
 from traits.api import Either, Enum, HasTraits, Range
 

--- a/examples/demo/Standard_Editors/CompoundEditor_demo.py
+++ b/examples/demo/Standard_Editors/CompoundEditor_demo.py
@@ -7,7 +7,7 @@ Implementation of a CompoundEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the CompoundEditor
 """
 
-from traits.api import Enum, HasTraits, Range, Union
+from traits.api import Either, Enum, HasTraits, Range
 
 from traitsui.api import Item, Group, View
 
@@ -18,9 +18,13 @@ class CompoundEditorDemo(HasTraits):
     """
 
     # Define a compund trait to view:
-    compound_trait = Union(
-        Range(1, 6), Enum('a', 'b', 'c', 'd', 'e', 'f'),
-        default_value=1
+    # Note: In Traits 6.1 a new Trait type `Union` has been added, which is
+    # recommended over `Either`:
+    # compound_trait = Union(
+    #     Range(1, 6), Enum('a', 'b', 'c', 'd', 'e', 'f'), default_value=1
+    # )
+    compound_trait = Either(
+        Range(1, 6), Enum('a', 'b', 'c', 'd', 'e', 'f'), default=1
     )
 
     # Display specification (one Item per editor style):

--- a/examples/demo/Standard_Editors/DataFrameEditor_demo.py
+++ b/examples/demo/Standard_Editors/DataFrameEditor_demo.py
@@ -5,91 +5,79 @@
 
 # Dataset from https://www.kaggle.com/mokosan/lord-of-the-rings-character-data
 
-#--[Imports]--------------------------------------------------------------
-
-from pandas import DataFrame
-from traits.api import HasTraits, Instance
-from traitsui.api import View, Item
-from traitsui.menu import NoButtons
-from traitsui.ui_editors.data_frame_editor import DataFrameEditor
 import numpy as np
+from pandas import DataFrame
 
+from traits.api import HasTraits, Instance
 
-
-
-#------ DataFrameEditorDemo Class Definition---------------------------------
+from traitsui.api import View, Item
+from traitsui.ui_editors.data_frame_editor import DataFrameEditor
 
 
 class DataFrameEditorDemo(HasTraits):
 
     df = Instance(DataFrame)
 
-    view = View(
-
-                Item('df',
-                    show_label=False,
-                    editor=DataFrameEditor(formats={
-
-                            'RuntimeInMinutes':'%.4d',
-                            'BudgetInMillions':'%d',
-                            'BoxOfficeRevenueInMillions':'%d',
-                            'AcademyAwardNominations':'%d',
-                            'AcademyAwardWins':'%d',
-                            'RottenTomatoesScore':'%.2f'
-
-                            })
-
-                    ),
-
-                    title="DataFrameEditor",
-                    resizable=True,
-                    id='traitsui.demo.Applications.data_frame_editor_demo'
-
-                )
-
+    traits_view = View(
+        Item(
+            'df',
+            show_label=False,
+            editor=DataFrameEditor(
+                formats={
+                    'RuntimeInMinutes': '%.4d',
+                    'BudgetInMillions': '%d',
+                    'BoxOfficeRevenueInMillions': '%d',
+                    'AcademyAwardNominations': '%d',
+                    'AcademyAwardWins': '%d',
+                    'RottenTomatoesScore': '%.2f'
+                }
+            )
+        ),
+        title="DataFrameEditor",
+        resizable=True,
+        id='traitsui.demo.Applications.data_frame_editor_demo'
+    )
 
 
 # Sample Data
-lotrMovieData = np.array([
-                [558, 281, 2917.0, 30, 17, 94.0],
-                [178, 93, 871.5, 13, 4, 91.0],
-                [179, 94, 926.0, 6, 2, 96.0],
-                [201, 94, 1120, 11, 11, 95.0],
-                [462.0, 675, 2932.0, 7, 1, 66.33333333],
-                [169, 200, 1021.0, 3, 1, 64.0],
-                [161, 217, 958.4, 3, 0, 75.0],
-                [144, 250, 956.0, 1, 0, 60.0]
-                ])
+lotrMovieData = np.array(
+    [
+        [558, 281, 2917.0, 30, 17, 94.0],
+        [178, 93, 871.5, 13, 4, 91.0],
+        [179, 94, 926.0, 6, 2, 96.0],
+        [201, 94, 1120, 11, 11, 95.0],
+        [462.0, 675, 2932.0, 7, 1, 66.33333333],
+        [169, 200, 1021.0, 3, 1, 64.0],
+        [161, 217, 958.4, 3, 0, 75.0],
+        [144, 250, 956.0, 1, 0, 60.0]
+    ]
+)
 
 col_names = [
-            'RuntimeInMinutes',
-            'BudgetInMillions',
-            'BoxOfficeRevenueInMillions',
-            'AcademyAwardNominations',
-            'AcademyAwardWins',
-            'RottenTomatoesScore'
+    'RuntimeInMinutes',
+    'BudgetInMillions',
+    'BoxOfficeRevenueInMillions',
+    'AcademyAwardNominations',
+    'AcademyAwardWins',
+    'RottenTomatoesScore'
             ]
 
-index_names =  [
-                'The Lord of the Rings Series',
-                'The Fellowship of the Ring',
-                'The Two Towers ',
-                'The Return of the King',
-                'The Hobbit Series',
-                'The Unexpected Journey',
-                'The Desolation of Smaug',
-                'The Battle of the Five Armies'
-                ]
+index_names = [
+    'The Lord of the Rings Series',
+    'The Fellowship of the Ring',
+    'The Two Towers ',
+    'The Return of the King',
+    'The Hobbit Series',
+    'The Unexpected Journey',
+    'The Desolation of Smaug',
+    'The Battle of the Five Armies'
+]
 
 # Create & run the demo
 df = DataFrame(data=lotrMovieData, columns=col_names, index=index_names)
 
 demo = DataFrameEditorDemo(df=df)
 
-
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':
     demo.configure_traits()
-
-
-

--- a/examples/demo/Standard_Editors/DataFrameEditor_demo.py
+++ b/examples/demo/Standard_Editors/DataFrameEditor_demo.py
@@ -4,6 +4,16 @@
 # DataFrameEditor_demo.py -- Example of using dataframe editors
 
 # Dataset from https://www.kaggle.com/mokosan/lord-of-the-rings-character-data
+"""
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+"""
+# Issue related to the demo warning: enthought/traitsui#944
+
 
 import numpy as np
 from pandas import DataFrame

--- a/examples/demo/Standard_Editors/DatetimeEditor_demo.py
+++ b/examples/demo/Standard_Editors/DatetimeEditor_demo.py
@@ -15,7 +15,7 @@ class DateEditorDemo(HasTraits):
     datetime = Datetime()
     info_string = Str('The editors for Traits Datetime objects.')
 
-    view = View(
+    traits_view = View(
         Item(
             'info_string',
             show_label=False,
@@ -41,7 +41,7 @@ class DateEditorDemo(HasTraits):
         print(self.datetime)
 
 
-#-- Set Up The Demo ------------------------------------------------------
+# -- Set Up The Demo ------------------------------------------------------
 
 demo = DateEditorDemo(
     datetime=datetime.datetime.now()

--- a/examples/demo/Standard_Editors/DatetimeEditor_demo.py
+++ b/examples/demo/Standard_Editors/DatetimeEditor_demo.py
@@ -2,8 +2,18 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 A Traits UI editor that edits a datetime panel.
 """
+# Issue related to the demo warning: enthought/traitsui#943
+
+
 import datetime
 
 from traits.api import HasTraits, Datetime, Str

--- a/examples/demo/Standard_Editors/DirectoryEditor_demo.py
+++ b/examples/demo/Standard_Editors/DirectoryEditor_demo.py
@@ -7,16 +7,12 @@ Implementation of a DirectoryEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the DirectoryEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, Directory
+from traits.api import HasTraits, Directory
 
-from traitsui.api \
-    import Item, Group, View
+from traitsui.api import Item, Group, View
+
 
 # Define the demo class:
-
-
 class DirectoryEditorDemo(HasTraits):
     """ Define the main DirectoryEditor demo class. """
 
@@ -35,12 +31,14 @@ class DirectoryEditorDemo(HasTraits):
     )
 
     # Demo view:
-    view = View(
+    traits_view = View(
         dir_group,
         title='DirectoryEditor',
+        width=400,
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = DirectoryEditorDemo()

--- a/examples/demo/Standard_Editors/DirectoryEditor_demo.py
+++ b/examples/demo/Standard_Editors/DirectoryEditor_demo.py
@@ -35,6 +35,7 @@ class DirectoryEditorDemo(HasTraits):
         dir_group,
         title='DirectoryEditor',
         width=400,
+        height=600,
         buttons=['OK'],
         resizable=True
     )

--- a/examples/demo/Standard_Editors/DirectoryEditor_demo.py
+++ b/examples/demo/Standard_Editors/DirectoryEditor_demo.py
@@ -2,10 +2,19 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a DirectoryEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the DirectoryEditor
 """
+# Issue related to the demo warning: enthought/traitsui#889
+
 
 from traits.api import HasTraits, Directory
 

--- a/examples/demo/Standard_Editors/FileEditor_demo.py
+++ b/examples/demo/Standard_Editors/FileEditor_demo.py
@@ -7,16 +7,12 @@ Implementation of a FileEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the FileEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, File
+from traits.api import HasTraits, File
 
-from traitsui.api \
-    import Item, Group, View
+from traitsui.api import Item, Group, View
+
 
 # Define the demo class:
-
-
 class FileEditorDemo(HasTraits):
     """ Defines the main FileEditor demo class. """
 
@@ -35,12 +31,13 @@ class FileEditorDemo(HasTraits):
     )
 
     # Demo view:
-    view = View(
+    traits_view = View(
         file_group,
         title='FileEditor',
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = FileEditorDemo()

--- a/examples/demo/Standard_Editors/FileEditor_demo.py
+++ b/examples/demo/Standard_Editors/FileEditor_demo.py
@@ -2,10 +2,19 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a FileEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the FileEditor
 """
+# Issue related to the demo warning: enthought/traitsui#889
+
 
 from traits.api import HasTraits, File
 

--- a/examples/demo/Standard_Editors/FileEditor_demo.py
+++ b/examples/demo/Standard_Editors/FileEditor_demo.py
@@ -34,6 +34,8 @@ class FileEditorDemo(HasTraits):
     traits_view = View(
         file_group,
         title='FileEditor',
+        width=400,
+        height=600,
         buttons=['OK'],
         resizable=True
     )

--- a/examples/demo/Standard_Editors/FontEditor_demo.py
+++ b/examples/demo/Standard_Editors/FontEditor_demo.py
@@ -1,13 +1,13 @@
 """
 Font editor
 
-A Font editor in a Traits UI allows the user to select a font from the operating
-system.
+A Font editor in a Traits UI allows the user to select a font from the
+operating system.
 
 Typically, you then pass the Font trait to another UI editor, which uses it to
 display text. You can also read the Font trait as a string, or access its
-individual attributes (note that these attributes are specific to the UI toolkit
--- QT or WX.)
+individual attributes (note that these attributes are specific to the UI
+toolkit -- QT or WX.)
 
 The default 'simple' Font editor style is usually the most useful and powerful
 style - it pops up a font selection dialog which is specific to the OS and
@@ -16,7 +16,6 @@ toolkit.
 This example also displays some other less common style choices.
 """
 
-# Imports:
 from traits.api import HasTraits
 
 from traitsui.api import Item, Group, View, Font
@@ -26,7 +25,7 @@ class FontEditorDemo(HasTraits):
     """ Defines the main FontEditor demo class. """
 
     # Define a Font trait to view:
-    my_font_trait = Font
+    my_font_trait = Font()
 
     # Display specification (one Item per editor style):
     font_group = Group(
@@ -40,12 +39,13 @@ class FontEditorDemo(HasTraits):
     )
 
     # Demo view:
-    view = View(
+    traits_view = View(
         font_group,
         title='FontEditor',
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = FontEditorDemo()

--- a/examples/demo/Standard_Editors/HTMLEditor_demo.py
+++ b/examples/demo/Standard_Editors/HTMLEditor_demo.py
@@ -52,14 +52,18 @@ class HTMLEditorDemo(HasTraits):
 
     # Demo view
     traits_view = View(
-        UItem('my_html_trait',
-              # we specify the editor explicitly in order to set format_text:
-              editor=HTMLEditor(format_text=True)),
+        UItem(
+            'my_html_trait',
+            # we specify the editor explicitly in order to set format_text:
+            editor=HTMLEditor(format_text=True)
+        ),
         title='HTMLEditor',
         buttons=['OK'],
         width=800,
         height=600,
-        resizable=True)
+        resizable=True
+    )
+
 
 # Create the demo:
 demo = HTMLEditorDemo()

--- a/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
+++ b/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
@@ -2,11 +2,21 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of an ImageEnumEditor demo plugin for the Traits UI demo
 program.
 
 This demo shows each of the four styles of the ImageEnumEditor.
 """
+# Issues related to the demo warning: enthought/traitsui#913,
+# enthought/traitsui#947
+
 
 from traits.api import Enum, HasTraits, Str
 

--- a/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
+++ b/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
@@ -2,17 +2,15 @@
 #  License: BSD Style.
 
 """
-Implementation of an ImageEnumEditor demo plugin for the Traits UI demo program.
+Implementation of an ImageEnumEditor demo plugin for the Traits UI demo
+program.
 
 This demo shows each of the four styles of the ImageEnumEditor.
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, Str, Trait
+from traits.api import Enum, HasTraits, Str
 
-from traitsui.api \
-    import Item, Group, View, ImageEnumEditor
+from traitsui.api import Item, Group, View, ImageEnumEditor
 
 # This list of image names (with the standard suffix "_origin") is used to
 # construct an image enumeration trait to demonstrate the ImageEnumEditor:
@@ -24,7 +22,7 @@ class Dummy(HasTraits):
     """
     x = Str()
 
-    view = View()
+    traits_view = View()
 
 
 class ImageEnumEditorDemo(HasTraits):
@@ -32,12 +30,16 @@ class ImageEnumEditorDemo(HasTraits):
     """
 
     # Define a trait to view:
-    image_from_list = Trait(editor=ImageEnumEditor(values=image_list,
-                                                   prefix='@icons:',
-                                                   suffix='_origin',
-                                                   cols=4,
-                                                   klass=Dummy),
-                            *image_list)
+    image_from_list = Enum(
+        *image_list,
+        editor=ImageEnumEditor(
+            values=image_list,
+            prefix='@icons:',
+            suffix='_origin',
+            cols=4,
+            klass=Dummy
+        )
+    )
 
     # Items are used to define the demo display, one Item per editor style:
     img_group = Group(
@@ -51,12 +53,13 @@ class ImageEnumEditorDemo(HasTraits):
     )
 
     # Demo view:
-    view = View(
+    traits_view = View(
         img_group,
         title='ImageEnumEditor',
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = ImageEnumEditorDemo()

--- a/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
+++ b/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
@@ -45,11 +45,11 @@ class ImageEnumEditorDemo(HasTraits):
     img_group = Group(
         Item('image_from_list', style='simple', label='Simple'),
         Item('_'),
-        Item('image_from_list', style='custom', label='Custom'),
-        Item('_'),
         Item('image_from_list', style='text', label='Text'),
         Item('_'),
-        Item('image_from_list', style='readonly', label='ReadOnly')
+        Item('image_from_list', style='readonly', label='ReadOnly'),
+        Item('_'),
+        Item('image_from_list', style='custom', label='Custom')
     )
 
     # Demo view:

--- a/examples/demo/Standard_Editors/InstanceEditor_demo.py
+++ b/examples/demo/Standard_Editors/InstanceEditor_demo.py
@@ -2,6 +2,13 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of an InstanceEditor demo plugin for the Traits UI demo program.
 
 This demo shows each of the four styles of the InstanceEditor
@@ -9,6 +16,8 @@ This demo shows each of the four styles of the InstanceEditor
 Fixme: This version of the demo only shows the old-style InstanceEditor
 capabilities.
 """
+# Issue related to the demo warning: enthought/traitsui#939
+
 
 from traits.api import HasTraits, Str, Range, Bool, Instance
 

--- a/examples/demo/Standard_Editors/InstanceEditor_demo.py
+++ b/examples/demo/Standard_Editors/InstanceEditor_demo.py
@@ -10,17 +10,14 @@ Fixme: This version of the demo only shows the old-style InstanceEditor
 capabilities.
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, Str, Range, Bool, Instance
+from traits.api import HasTraits, Str, Range, Bool, Instance
 
-from traitsui.api \
-    import Item, Group, View
+from traitsui.api import Item, Group, View
 
-#-------------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
 #  Classes:
-#-------------------------------------------------------------------------
-
+# -------------------------------------------------------------------------
 
 class SampleClass(HasTraits):
     """ This Sample class is used to demonstrate the InstanceEditor demo.
@@ -36,7 +33,7 @@ class SampleClass(HasTraits):
     # The InstanceEditor uses whatever view is defined for the class.  The
     # default view lists the fields alphabetically, so it's best to define one
     # explicitly:
-    view = View('name', 'occupation', 'age', 'registered_voter')
+    traits_view = View('name', 'occupation', 'age', 'registered_voter')
 
 
 class InstanceEditorDemo(HasTraits):
@@ -58,12 +55,13 @@ class InstanceEditorDemo(HasTraits):
     )
 
     # Demo View:
-    view = View(
+    traits_view = View(
         inst_group,
         title='InstanceEditor',
         buttons=['OK'],
         resizable=True
     )
+
 
 # Create the demo:
 demo = InstanceEditorDemo()

--- a/examples/demo/Standard_Editors/ListEditor_demo.py
+++ b/examples/demo/Standard_Editors/ListEditor_demo.py
@@ -7,16 +7,12 @@ Implemention of a ListEditor demo plugin for Traits UI demo program
 This demo shows each of the four styles of ListEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, List, Str
+from traits.api import HasTraits, List, Str
 
-from traitsui.api \
-    import Item, Group, View
+from traitsui.api import Item, Group, View
+
 
 # Define the demo class:
-
-
 class ListEditorDemo(HasTraits):
     """ Defines the main ListEditor demo class. """
 
@@ -35,12 +31,15 @@ class ListEditorDemo(HasTraits):
     )
 
     # Demo view:
-    view = View(
+    traits_view = View(
         list_group,
         title='ListEditor',
         buttons=['OK'],
+        height=600,
+        width=400,
         resizable=True
     )
+
 
 # Create the demo:
 demo = ListEditorDemo()

--- a/examples/demo/Standard_Editors/Popup_versions/BooleanEditor_demo.py
+++ b/examples/demo/Standard_Editors/Popup_versions/BooleanEditor_demo.py
@@ -4,14 +4,13 @@ Implementation of a BooleanEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the BooleanEditor
 """
 
-
-#-------------------------------------------------------------------------
-#  Demo Class
-#-------------------------------------------------------------------------
-
 from traits.api import HasTraits, Bool
 from traitsui.api import Item, Group, View
 
+
+# -------------------------------------------------------------------------
+#  Demo Class
+# -------------------------------------------------------------------------
 
 class BooleanEditorDemo(HasTraits):
     """ This class specifies the details of the BooleanEditor demo.
@@ -20,25 +19,29 @@ class BooleanEditorDemo(HasTraits):
     # To demonstrate any given Trait editor, an appropriate Trait is required.
     boolean_trait = Bool()
 
-    # Items are used to define the demo display - one Item per
-    # editor style
+    # Items are used to define the demo display - one Item per editor style
     bool_group = Group(
-        Item(
-            'boolean_trait', style='simple', label='Simple'), Item('_'), Item(
-            'boolean_trait', style='custom', label='Custom'), Item('_'), Item(
-                'boolean_trait', style='text', label='Text'), Item('_'), Item(
-                    'boolean_trait', style='readonly', label='ReadOnly'))
+        Item('boolean_trait', style='simple', label='Simple'),
+        Item('_'),
+        Item('boolean_trait', style='custom', label='Custom'),
+        Item('_'),
+        Item('boolean_trait', style='text', label='Text'),
+        Item('_'),
+        Item('boolean_trait', style='readonly', label='ReadOnly')
+    )
 
     # Demo view
-    view1 = View(bool_group,
-                 title='BooleanEditor',
-                 buttons=['OK'],
-                 width=300)
+    traits_view = View(
+        bool_group,
+        title='BooleanEditor',
+        buttons=['OK'],
+        width=300
+    )
 
 
 # Hook for 'demo.py'
-popup = BooleanEditorDemo()
+demo = BooleanEditorDemo()
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':
-    popup.configure_traits()
+    demo.configure_traits()

--- a/examples/demo/Standard_Editors/Popup_versions/ButtonEditor_demo.py
+++ b/examples/demo/Standard_Editors/Popup_versions/ButtonEditor_demo.py
@@ -6,13 +6,12 @@ This demo shows each of the two styles of the ButtonEditor.
 """
 
 from traits.api import HasTraits, Button
-from traitsui.api import Item, View, Group
-from traitsui.message import message
+from traitsui.api import Item, View, Group, message
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #  Demo Class
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 
 class ButtonEditorDemo(HasTraits):
     """ This class specifies the details of the ButtonEditor demo.
@@ -26,24 +25,28 @@ class ButtonEditorDemo(HasTraits):
 
     # ButtonEditor display
     # (Note that Text and ReadOnly versions are not applicable)
-    event_group = Group(Item('fire_event', style='simple', label='Simple'),
-                        Item('_'),
-                        Item('fire_event', style='custom', label='Custom'),
-                        Item('_'),
-                        Item(label='[text style unavailable]'),
-                        Item('_'),
-                        Item(label='[read only style unavailable]'))
+    event_group = Group(
+        Item('fire_event', style='simple', label='Simple'),
+        Item('_'),
+        Item('fire_event', style='custom', label='Custom'),
+        Item('_'),
+        Item(label='[text style unavailable]'),
+        Item('_'),
+        Item(label='[readonly style unavailable]')
+    )
 
     # Demo view
-    view1 = View(event_group,
-                 title='ButtonEditor',
-                 buttons=['OK'],
-                 width=250)
+    traits_view = View(
+        event_group,
+        title='ButtonEditor',
+        buttons=['OK'],
+        width=250
+    )
 
 
 # Create the demo:
-popup = ButtonEditorDemo()
+demo = ButtonEditorDemo()
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':
-    popup.configure_traits()
+    demo.configure_traits()

--- a/examples/demo/Standard_Editors/RGBColorEditor_demo.py
+++ b/examples/demo/Standard_Editors/RGBColorEditor_demo.py
@@ -2,10 +2,19 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a RGBColorEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the ColorEditor
 """
+# Issue related to the demo warning: enthought/traitsui#939
+
 
 from traits.api import HasTraits
 

--- a/examples/demo/Standard_Editors/RGBColorEditor_demo.py
+++ b/examples/demo/Standard_Editors/RGBColorEditor_demo.py
@@ -2,26 +2,22 @@
 #  License: BSD Style.
 
 """
-Implementation of a ColorEditor demo plugin for Traits UI demo program.
+Implementation of a RGBColorEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the ColorEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits
+from traits.api import HasTraits
 
-from traitsui.api \
-    import Item, Group, View, RGBColor
+from traitsui.api import Item, Group, View, RGBColor
+
 
 # Demo class definition:
-
-
-class ColorEditorDemo(HasTraits):
-    """ Defines the main ColorEditor demo. """
+class RGBColorEditorDemo(HasTraits):
+    """ Defines the main RGBColorEditor demo. """
 
     # Define a Color trait to view:
-    color_trait = RGBColor
+    color_trait = RGBColor()
 
     # Items are used to define the demo display, one item per editor style:
     color_group = Group(
@@ -35,15 +31,16 @@ class ColorEditorDemo(HasTraits):
     )
 
     # Demo view
-    view1 = View(
+    traits_view = View(
         color_group,
-        title='ColorEditor',
+        title='RGBColorEditor',
         buttons=['OK'],
         resizable=True
     )
 
+
 # Create the demo:
-demo = ColorEditorDemo()
+demo = RGBColorEditorDemo()
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':

--- a/examples/demo/Standard_Editors/SetEditor_demo.py
+++ b/examples/demo/Standard_Editors/SetEditor_demo.py
@@ -12,44 +12,52 @@ The four tabs of this demo show variations on the interface as follows:
    Ord II:   Creates a set whose order is specifed by the user, has "move all"
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, List
+from traits.api import HasTraits, List
 
-from traitsui.api \
-    import Item, Group, View, SetEditor
+from traitsui.api import Item, Group, View, SetEditor
+
 
 # Define the main demo class:
-
-
 class SetEditorDemo(HasTraits):
     """ Defines the SetEditor demo class.
     """
 
     # Define a trait each for four SetEditor variants:
-    unord_nma_set = List(editor=SetEditor(
-        values=['kumquats', 'pomegranates', 'kiwi'],
-        can_move_all=False,
-        left_column_title='Available Fruit',
-        right_column_title='Exotic Fruit Bowl'))
+    unord_nma_set = List(
+        editor=SetEditor(
+            values=['kumquats', 'pomegranates', 'kiwi'],
+            left_column_title='Available Fruit',
+            right_column_title='Exotic Fruit Bowl',
+            can_move_all=False
+        )
+    )
 
-    unord_ma_set = List(editor=SetEditor(
-        values=['kumquats', 'pomegranates', 'kiwi'],
-        left_column_title='Available Fruit',
-        right_column_title='Exotic Fruit Bowl'))
+    unord_ma_set = List(
+        editor=SetEditor(
+            values=['kumquats', 'pomegranates', 'kiwi'],
+            left_column_title='Available Fruit',
+            right_column_title='Exotic Fruit Bowl'
+        )
+    )
 
-    ord_nma_set = List(editor=SetEditor(
-        values=['apples', 'berries', 'cantaloupe'],
-        ordered=True,
-        can_move_all=False,
-        left_column_title='Available Fruit',
-        right_column_title='Fruit Bowl'))
+    ord_nma_set = List(
+        editor=SetEditor(
+            values=['apples', 'berries', 'cantaloupe'],
+            left_column_title='Available Fruit',
+            right_column_title='Fruit Bowl',
+            ordered=True,
+            can_move_all=False
+        )
+    )
 
-    ord_ma_set = List(editor=SetEditor(
-        values=['apples', 'berries', 'cantaloupe'],
-        ordered=True,
-        left_column_title='Available Fruit',
-        right_column_title='Fruit Bowl'))
+    ord_ma_set = List(
+        editor=SetEditor(
+            values=['apples', 'berries', 'cantaloupe'],
+            left_column_title='Available Fruit',
+            right_column_title='Fruit Bowl',
+            ordered=True
+        )
+    )
 
     # SetEditor display, unordered, no move-all buttons:
     no_nma_group = Group(
@@ -81,7 +89,7 @@ class SetEditorDemo(HasTraits):
 
     # The view includes one group per data type. These will be displayed
     # on separate tabbed panels:
-    view = View(
+    traits_view = View(
         no_nma_group,
         no_ma_group,
         o_nma_group,
@@ -89,6 +97,7 @@ class SetEditorDemo(HasTraits):
         title='SetEditor',
         buttons=['OK']
     )
+
 
 # Create the demo:
 demo = SetEditorDemo()

--- a/examples/demo/Standard_Editors/SetEditor_demo.py
+++ b/examples/demo/Standard_Editors/SetEditor_demo.py
@@ -2,6 +2,13 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a SetEditor demo plugin for the Traits UI demo program.
 
 The four tabs of this demo show variations on the interface as follows:
@@ -11,6 +18,8 @@ The four tabs of this demo show variations on the interface as follows:
    Ord I:    Creates a set whose order is specified by the user, no "move all"
    Ord II:   Creates a set whose order is specifed by the user, has "move all"
 """
+# Issue related to the demo warning: enthought/traitsui#913
+
 
 from traits.api import HasTraits, List
 

--- a/examples/demo/Standard_Editors/TableEditor_demo.py
+++ b/examples/demo/Standard_Editors/TableEditor_demo.py
@@ -14,6 +14,8 @@ Implementation of a TableEditor demo plugin for Traits UI demo program
 This demo shows the full behavior of a straightforward TableEditor.  Only
 one style of TableEditor is implemented, so that is the one shown.
 """
+# Issue related to the demo warning: enthought/traitsui#948
+
 
 from traits.api import HasTraits, HasStrictTraits, Str, Int, Regex, List
 

--- a/examples/demo/Standard_Editors/TitleEditor_demo.py
+++ b/examples/demo/Standard_Editors/TitleEditor_demo.py
@@ -20,12 +20,9 @@ This demonstration shows three variations of using a TitleEditor:
    into the value field to cause the title to changed.
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, Enum, Str, Float, Property, cached_property
+from traits.api import HasTraits, Enum, Str, Float, Property, cached_property
 
-from traitsui.api \
-    import View, VGroup, HGroup, Item, TitleEditor
+from traitsui.api import View, VGroup, HGroup, Item, TitleEditor
 
 
 class TitleEditorDemo(HasTraits):
@@ -48,7 +45,7 @@ class TitleEditorDemo(HasTraits):
     value = Float()
 
     # Define the test view:
-    view = View(
+    traits_view = View(
         VGroup(
             VGroup(
                 HGroup(
@@ -87,16 +84,23 @@ class TitleEditorDemo(HasTraits):
         width=0.4
     )
 
-    #-- Property Implementations ---------------------------------------------
+    # -- Property Implementations ---------------------------------------------
 
     @cached_property
     def _get_title_3(self):
-        try:
-            return ('The square root of %s is %s' %
-                    (self.value, self.value ** 0.5))
-        except:
-            return ('The square root of %s is %si' %
-                    (self.value, (-self.value) ** 0.5))
+        if self.value >= 0:
+            return (
+                'The square root of {} is {}'.format(
+                    self.value, self.value ** 0.5
+                )
+            )
+        else:
+            return (
+                'The square root of {} is {}i'.format(
+                    self.value, (-self.value) ** 0.5
+                )
+            )
+
 
 # Create the demo:
 demo = TitleEditorDemo()

--- a/examples/demo/Standard_Editors/TreeEditor_demo.py
+++ b/examples/demo/Standard_Editors/TreeEditor_demo.py
@@ -14,8 +14,8 @@ In this case, the tree has the following hierarchy:
 
         - Employee
 
-The TreeEditor generates a hierarchical tree control, consisting of nodes. It is
-useful for cases where objects contain lists of other objects.
+The TreeEditor generates a hierarchical tree control, consisting of nodes. It
+is useful for cases where objects contain lists of other objects.
 
 The tree control is displayed in one pane of the editor, and a user interface
 for the selected object is displayed in the other pane. The layout orientation
@@ -29,15 +29,14 @@ subclasses of TreeNode).
 You must specify the classes whose instances the node type applies to. Use the
 **node_for** attribute of TreeNode to specify a list of classes; often, this
 list contains only one class. You can have more than one node type that applies
-to a particular class; in this case, each object of that class is represented by
-multiple nodes, one for each applicable node type.
+to a particular class; in this case, each object of that class is represented
+by multiple nodes, one for each applicable node type.
 
 See the Traits User Manual for more details.
 """
 
-# FIXME: provide accessible copy or equivalent of factories_advanced_extra.rst
-
 from traits.api import HasTraits, Str, Regex, List, Instance
+
 from traitsui.api import Item, View, TreeEditor, TreeNode
 
 
@@ -66,6 +65,7 @@ class Company(HasTraits):
     departments = List(Department)
     employees = List(Employee)
 
+
 # Create an empty view for objects that have no data to display:
 no_view = View()
 
@@ -73,39 +73,44 @@ no_view = View()
 tree_editor = TreeEditor(
     nodes=[
         # The first node specified is the top level one
-        TreeNode(node_for=[Company],
-                 auto_open=True,
-                 # child nodes are
-                 children='',
-                 label='name',  # label with Company name
-                 view=View(['name'])
-                 ),
-        TreeNode(node_for=[Company],
-                 auto_open=True,
-                 children='departments',
-                 label='=Departments',  # constant label
-                 view=no_view,
-                 add=[Department],
-                 ),
-        TreeNode(node_for=[Company],
-                 auto_open=True,
-                 children='employees',
-                 label='=Employees',   # constant label
-                 view=no_view,
-                 add=[Employee]
-                 ),
-        TreeNode(node_for=[Department],
-                 auto_open=True,
-                 children='employees',
-                 label='name',   # label with Department name
-                 view=View(['name']),
-                 add=[Employee]
-                 ),
-        TreeNode(node_for=[Employee],
-                 auto_open=True,
-                 label='name',   # label with Employee name
-                 view=View(['name', 'title', 'phone'])
-                 )
+        TreeNode(
+            node_for=[Company],
+            auto_open=True,
+            # child nodes are
+            children='',
+            label='name',  # label with Company name
+            view=View(['name'])
+        ),
+        TreeNode(
+            node_for=[Company],
+            auto_open=True,
+            children='departments',
+            label='=Departments',  # constant label
+            view=no_view,
+            add=[Department],
+         ),
+        TreeNode(
+            node_for=[Company],
+            auto_open=True,
+            children='employees',
+            label='=Employees',   # constant label
+            view=no_view,
+            add=[Employee]
+        ),
+        TreeNode(
+            node_for=[Department],
+            auto_open=True,
+            children='employees',
+            label='name',   # label with Department name
+            view=View(['name']),
+            add=[Employee]
+        ),
+        TreeNode(
+            node_for=[Employee],
+            auto_open=True,
+            label='name',   # label with Employee name
+            view=View(['name', 'title', 'phone'])
+        )
     ]
 )
 
@@ -116,11 +121,8 @@ class Partner(HasTraits):
     name = Str('<unknown>')
     company = Instance(Company)
 
-    view = View(
-        Item(name='company',
-             editor=tree_editor,
-             show_label=False
-             ),
+    traits_view = View(
+        Item(name='company', editor=tree_editor, show_label=False),
         title='Company Structure',
         buttons=['OK'],
         resizable=True,
@@ -129,22 +131,13 @@ class Partner(HasTraits):
         height=500
     )
 
+
 # Create an example data structure:
-jason = Employee(name='Jason',
-                 title='Senior Engineer',
-                 phone='536-1057')
-mike = Employee(name='Mike',
-                title='Senior Engineer',
-                phone='536-1057')
-dave = Employee(name='Dave',
-                title='Senior Software Developer',
-                phone='536-1057')
-martin = Employee(name='Martin',
-                  title='Senior Engineer',
-                  phone='536-1057')
-duncan = Employee(name='Duncan',
-                  title='Consultant',
-                  phone='526-1057')
+jason = Employee(name='Jason', title='Senior Engineer', phone='536-1057')
+mike = Employee(name='Mike', title='Senior Engineer', phone='536-1057')
+dave = Employee(name='Dave', title='Senior Developer', phone='536-1057')
+martin = Employee(name='Martin', title='Senior Engineer', phone='536-1057')
+duncan = Employee(name='Duncan', title='Consultant', phone='526-1057')
 
 # Create the demo:
 demo = Partner(

--- a/examples/demo/Standard_Editors/TupleEditor_demo.py
+++ b/examples/demo/Standard_Editors/TupleEditor_demo.py
@@ -7,16 +7,12 @@ Implementation of a TupleEditor demo plugin for Traits UI demo program.
 This demo shows each of the four styles of the TupleEditor
 """
 
-# Imports:
-from traits.api \
-    import HasTraits, Tuple, Range, Str
+from traits.api import HasTraits, Tuple, Range, Str
 
-from traitsui.api \
-    import Item, Group, View, Color
+from traitsui.api import Item, Group, View, Color
+
 
 # The main demo class:
-
-
 class TupleEditorDemo(HasTraits):
     """ Defines the TupleEditor demo class.
     """
@@ -36,7 +32,7 @@ class TupleEditorDemo(HasTraits):
     )
 
     # Demo view
-    view = View(
+    traits_view = View(
         tuple_group,
         title='TupleEditor',
         buttons=['OK'],

--- a/examples/demo/Standard_Editors/TupleEditor_demo.py
+++ b/examples/demo/Standard_Editors/TupleEditor_demo.py
@@ -2,10 +2,19 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a TupleEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the TupleEditor
 """
+# Issue related to the demo warning: enthought/traitsui#939
+
 
 from traits.api import HasTraits, Tuple, Range, Str
 


### PR DESCRIPTION
Addresses #866 

These are mostly flake8, formatting and other minor stylistic fixes for demos in `Standard_Editors`. 

Some of the demos are broken. ~Warnings will be added soon, after relevant issues are opened.~ Warning are added to demos that are broken in some way. Issue references also added as comments.

More important changes are pointed out with in-code review comments.