### PR TITLE
Maint: Ensure events are processed even if dispose fails half-way

### DIFF
--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -191,9 +191,12 @@ def create_ui(object, ui_kwargs=None):
         # If dispose happens first, those events will be processed after
         # various editor states are removed, causing errors.
         process_cascade_events()
-        ui.dispose()
-        # Dispose may push more events to the event queue. Flush those too.
-        process_cascade_events()
+        try:
+            ui.dispose()
+        finally:
+            # dispose is not atomic and may push more events to the event
+            # queue. Flush those too.
+            process_cascade_events()
 
 
 # ######### Utility tools to test on both qt4 and wx


### PR DESCRIPTION
`UI.dispose` is not atomic, this PR ensures even if it fails, tests still process whatever events left over.
I don't think there are test-related issues caused by this yet, but I think it is correct to always process the events after `dispose` (even if it fails), otherwise errors from dispose could cause test interactions.