### PR TITLE
TST: Make DummyObject.event process only the event it posts

### DIFF
--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -39,6 +39,9 @@ if is_current_backend_qt4():
             self.n_events = 0
 
         def event(self, event):
+            if event.type() != QtCore.QEvent.User:
+                return super().event(event)
+
             self.n_events += 1
 
             if self.n_events < self.max_n_events:


### PR DESCRIPTION
This PR updates a test (the one that fails occasionally in #951) by making sure the QObject checks the event type it is processing.

When looking into #951, this is the only one thing that jumps out at me. I am not sure what caused the issue as I wasn't able to reproduce locally. I also don't think the change in this PR will be a fix for the issue. Still it is good to make sure the object isn't treating any spurious events as the custom one used in the test.