### PR TITLE
Maintenance of Standard_Editors/File_Dialog demos

### DIFF
--- a/examples/demo/Standard_Editors/File_Dialog/File_Open.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open.py
@@ -79,7 +79,7 @@ class FileDialogDemo(HasTraits):
 
     # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
+    traits_view = View(
         HGroup(
             Item('open', show_label=False),
             '_',

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 This demonstrates one of the simplest cases of using the TraitsUI file dialog
 to select a file for opening (i.e. reading or editing).
 
@@ -52,6 +59,7 @@ TraitsUI file dialog are:
  - It's easy to use. That's what this particular example is all about. So take
    a look at the source code for this example to see how easy it is...
 """
+# Issue related to the demo warning: enthought/traitsui#953
 
 from traits.api import HasTraits, File, Button
 

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open.py
@@ -1,12 +1,12 @@
 """
-This demonstrates one of the simplest cases of using the Traits file dialog to
-select a file for opening (i.e. reading or editing).
+This demonstrates one of the simplest cases of using the TraitsUI file dialog
+to select a file for opening (i.e. reading or editing).
 
-The first question of course is why use the Traits file dialog at all, when the
-standard OS file dialog is also available?
+The first question of course is why use the TraitsUI file dialog at all, when
+the standard OS file dialog is also available?
 
 And the answer is that you can use either, but the advantages of using the
-Traits file dialog are:
+TraitsUI file dialog are:
 
  - It supports history. That is, each time the user selects a file for opening,
    the file is added to a persistent history list, similar to many applications
@@ -22,8 +22,8 @@ Traits file dialog are:
    file.
 
  - There is a very nice synergy between the file system view and the history
-   list. Quite often users shuttle between several <i>favorite</i> locations
-   in the file system when opening files. The Traits file dialog automatically
+   list. Quite often users shuttle between several <i>favorite</i> locations in
+   the file system when opening files. The TraitsUI file dialog automatically
    discovers these favorite locations just by the user opening files. When a
    user opens the file dialog, they can select a previously opened file from
    the history list, which then automatically causes the file system view to
@@ -33,10 +33,10 @@ Traits file dialog are:
    set</i> of favorite directories just through simple use, without the user
    having to explicitly designate them as such.
 
- - It's customizable. The Traits file dialog accepts extension objects which
+ - It's customizable. The TraitsUI file dialog accepts extension objects which
    can be used to display additional file information or even modify the
    selection behavior of the dialog. Several extensions are provided with
-   Traits (and are demonstrated in some of the other examples), and you are
+   TraitsUI (and are demonstrated in some of the other examples), and you are
    free to write your own by implementing a very simple interface.
 
  - The history and user settings are customizable per application. Just by
@@ -53,20 +53,14 @@ Traits file dialog are:
    a look at the source code for this example to see how easy it is...
 """
 
-#-- Imports --------------------------------------------------------------
+from traits.api import HasTraits, File, Button
 
-from traits.api \
-    import HasTraits, File, Button
+from traitsui.api import View, HGroup, Item
 
-from traitsui.api \
-    import View, HGroup, Item
-
-from traitsui.file_dialog  \
-    import open_file
-
-#-- FileDialogDemo Class -------------------------------------------------
+from traitsui.file_dialog import open_file
 
 
+# -- FileDialogDemo Class -------------------------------------------------
 class FileDialogDemo(HasTraits):
 
     # The name of the selected file:
@@ -75,7 +69,7 @@ class FileDialogDemo(HasTraits):
     # The button used to display the file dialog:
     open = Button('Open...')
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
     view = View(
         HGroup(
@@ -86,7 +80,7 @@ class FileDialogDemo(HasTraits):
         width=0.5
     )
 
-    #-- Traits Event Handlers ------------------------------------------------
+    # -- Traits Event Handlers ------------------------------------------------
 
     def _open_changed(self):
         """ Handles the user clicking the 'Open...' button.
@@ -94,6 +88,7 @@ class FileDialogDemo(HasTraits):
         file_name = open_file()
         if file_name != '':
             self.file_name = file_name
+
 
 # Create the demo:
 demo = FileDialogDemo()

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
@@ -15,9 +15,6 @@ from traitsui.api import View, VGroup, HGroup, Item
 
 from traitsui.file_dialog import open_file, MFileDialogModel
 
-from traitsui.helper import commatize
-
-from io import open
 
 # -- LineCountInfo Class --------------------------------------------------
 class LineCountInfo(MFileDialogModel):
@@ -46,16 +43,16 @@ class LineCountInfo(MFileDialogModel):
             if getsize(self.file_name) > 10000000:
                 return 'File too big...'
 
-            fh = open(self.file_name, 'rU', encoding='utf8')
-            data = fh.read()
-            fh.close()
-        except:
+            with open(self.file_name, 'r', encoding='utf8') as fh:
+                data = fh.read()
+        except OSError:
             return ''
 
         if (data.find('\x00') >= 0) or (data.find('\xFF') >= 0):
             return 'File contains binary data...'
 
-        return ('%s lines' % commatize(len(data.splitlines())))
+        return ('{:n} lines'.format(len(data.splitlines())))
+
 
 # -- FileDialogDemo Class -------------------------------------------------
 

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 This demonstrates using the TraitsUI file dialog with a custom written file
 dialog extension, in this case an extension called <b>LineCountInfo</b>, which
 displays the number of text lines in the currently selected file.
@@ -6,6 +13,7 @@ displays the number of text lines in the currently selected file.
 For more information about why you would want to use the TraitsUI file dialog
 over the standard OS file dialog, select the <b>File Open</b> demo.
 """
+# Issue related to the demo warning: enthought/traitsui#953
 
 from os.path import getsize
 

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
@@ -1,33 +1,25 @@
 """
-This demonstrates using the Traits file dialog with a custom written file
+This demonstrates using the TraitsUI file dialog with a custom written file
 dialog extension, in this case an extension called <b>LineCountInfo</b>, which
 displays the number of text lines in the currently selected file.
 
-For more information about why you would want to use the Traits file dialog
+For more information about why you would want to use the TraitsUI file dialog
 over the standard OS file dialog, select the <b>File Open</b> demo.
 """
 
-#-- Imports --------------------------------------------------------------
+from os.path import getsize
 
-from os.path \
-    import getsize
+from traits.api import HasTraits, File, Button, Property, cached_property
 
-from traits.api \
-    import HasTraits, File, Button, Property, cached_property
+from traitsui.api import View, VGroup, HGroup, Item
 
-from traitsui.api \
-    import View, VGroup, HGroup, Item
+from traitsui.file_dialog import open_file, MFileDialogModel
 
-from traitsui.file_dialog  \
-    import open_file, MFileDialogModel
+from traitsui.helper import commatize
 
-from traitsui.helper \
-    import commatize
 from io import open
 
-#-- LineCountInfo Class --------------------------------------------------
-
-
+# -- LineCountInfo Class --------------------------------------------------
 class LineCountInfo(MFileDialogModel):
     """ Defines a file dialog extension that displays the number of text lines
         in the currently selected file.
@@ -36,7 +28,7 @@ class LineCountInfo(MFileDialogModel):
     # The number of text lines in the currently selected file:
     lines = Property(depends_on='file_name')
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
     view = View(
         VGroup(
@@ -46,7 +38,7 @@ class LineCountInfo(MFileDialogModel):
         )
     )
 
-    #-- Property Implementations ---------------------------------------------
+    # -- Property Implementations ---------------------------------------------
 
     @cached_property
     def _get_lines(self):
@@ -65,11 +57,10 @@ class LineCountInfo(MFileDialogModel):
 
         return ('%s lines' % commatize(len(data.splitlines())))
 
-#-- FileDialogDemo Class -------------------------------------------------
+# -- FileDialogDemo Class -------------------------------------------------
 
 # Demo specific file dialig id:
-demo_id = ('traitsui.demo.standard_editors.file_dialog.'
-           'line_count_info')
+demo_id = 'traitsui.demo.standard_editors.file_dialog.line_count_info'
 
 
 class FileDialogDemo(HasTraits):
@@ -80,7 +71,7 @@ class FileDialogDemo(HasTraits):
     # The button used to display the file dialog:
     open = Button('Open...')
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
     view = View(
         HGroup(
@@ -91,7 +82,7 @@ class FileDialogDemo(HasTraits):
         width=0.5
     )
 
-    #-- Traits Event Handlers ------------------------------------------------
+    # -- Traits Event Handlers ------------------------------------------------
 
     def _open_changed(self):
         """ Handles the user clicking the 'Open...' button.
@@ -99,6 +90,7 @@ class FileDialogDemo(HasTraits):
         file_name = open_file(extensions=LineCountInfo(), id=demo_id)
         if file_name != '':
             self.file_name = file_name
+
 
 # Create the demo:
 demo = FileDialogDemo()

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
@@ -35,7 +35,7 @@ class LineCountInfo(MFileDialogModel):
 
     # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
+    traits_view = View(
         VGroup(
             Item('lines', style='readonly'),
             label='Line Count Info',
@@ -78,7 +78,7 @@ class FileDialogDemo(HasTraits):
 
     # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
+    traits_view = View(
         HGroup(
             Item('open', show_label=False),
             '_',

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
@@ -45,7 +45,7 @@ class FileDialogDemo(HasTraits):
 
     # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
+    traits_view = View(
         HGroup(
             Item('open', show_label=False),
             '_',

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
@@ -1,5 +1,5 @@
 """
-This demonstrates using the Traits file dialog with a file dialog extension,
+This demonstrates using the TraitsUI file dialog with a file dialog extension,
 in this case, the <b>FileInfo</b> extension, which displays information about
 the currently selected file, such as:
 
@@ -8,24 +8,20 @@ the currently selected file, such as:
  - Date and time last modified.
  - Date and time last created.
 
-For more information about why you would want to use the Traits file dialog
+For more information about why you would want to use the TraitsUI file dialog
 over the standard OS file dialog, select the <b>File Open</b> demo. For a
 demonstration of writing a custom file dialog extension, select the
 <b>File Open with Custom Extension</b> demo.
 """
 
-#-- Imports --------------------------------------------------------------
+from traits.api import HasTraits, File, Button
 
-from traits.api \
-    import HasTraits, File, Button
+from traitsui.api import View, HGroup, Item
 
-from traitsui.api \
-    import View, HGroup, Item
+from traitsui.file_dialog import open_file, FileInfo
 
-from traitsui.file_dialog  \
-    import open_file, FileInfo
 
-#-- FileDialogDemo Class -------------------------------------------------
+# -- FileDialogDemo Class -------------------------------------------------
 
 # Demo specific file dialig id:
 demo_id = 'traitsui.demo.standard_editors.file_dialog.file_info'
@@ -39,7 +35,7 @@ class FileDialogDemo(HasTraits):
     # The button used to display the file dialog:
     open = Button('Open...')
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
     view = View(
         HGroup(
@@ -50,7 +46,7 @@ class FileDialogDemo(HasTraits):
         width=0.5
     )
 
-    #-- Traits Event Handlers ------------------------------------------------
+    # -- Traits Event Handlers ------------------------------------------------
 
     def _open_changed(self):
         """ Handles the user clicking the 'Open...' button.
@@ -58,6 +54,7 @@ class FileDialogDemo(HasTraits):
         file_name = open_file(extensions=FileInfo(), id=demo_id)
         if file_name != '':
             self.file_name = file_name
+
 
 # Create the demo:
 demo = FileDialogDemo()

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 This demonstrates using the TraitsUI file dialog with a file dialog extension,
 in this case, the <b>FileInfo</b> extension, which displays information about
 the currently selected file, such as:
@@ -13,6 +20,7 @@ over the standard OS file dialog, select the <b>File Open</b> demo. For a
 demonstration of writing a custom file dialog extension, select the
 <b>File Open with Custom Extension</b> demo.
 """
+# Issue related to the demo warning: enthought/traitsui#953
 
 from traits.api import HasTraits, File, Button
 

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_ImageInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_ImageInfo_Extension.py
@@ -53,7 +53,7 @@ class FileDialogDemo(HasTraits):
 
     # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
+    traits_view = View(
         HGroup(
             Item('open', show_label=False),
             '_',

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_ImageInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_ImageInfo_Extension.py
@@ -1,11 +1,11 @@
 """
-This demonstrates using the Traits file dialog with a file dialog extension,
+This demonstrates using the TraitsUI file dialog with a file dialog extension,
 in this case, the <b>ImageInfo</b> extension, which displays (if possible) the
 contents, width and height information for the currently selected image file
 so that the user can quickly verify they are opening the correct file before
 leaving the file dialog.
 
-For more information about why you would want to use the Traits file dialog
+For more information about why you would want to use the TraitsUI file dialog
 over the standard OS file dialog, select the <b>File Open</b> demo. For a
 demonstration of writing a custom file dialog extension, select the
 <b>File Open with Custom Extension</b> demo.
@@ -15,18 +15,13 @@ image file formats (i.e. *.png, *.gif, *.jpg, *.jpeg) files to be viewed and
 selected.
 """
 
-#-- Imports --------------------------------------------------------------
+from traits.api import HasTraits, File, Button
 
-from traits.api \
-    import HasTraits, File, Button
+from traitsui.api import View, HGroup, Item
 
-from traitsui.api \
-    import View, HGroup, Item
+from traitsui.file_dialog import open_file, ImageInfo
 
-from traitsui.file_dialog  \
-    import open_file, ImageInfo
-
-#-- FileDialogDemo Class -------------------------------------------------
+# -- FileDialogDemo Class -------------------------------------------------
 
 # Demo specific file dialig id:
 demo_id = 'traitsui.demo.standard_editors.file_dialog.image_info'
@@ -48,7 +43,7 @@ class FileDialogDemo(HasTraits):
     # The button used to display the file dialog:
     open = Button('Open...')
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
     view = View(
         HGroup(
@@ -59,7 +54,7 @@ class FileDialogDemo(HasTraits):
         width=0.5
     )
 
-    #-- Traits Event Handlers ------------------------------------------------
+    # -- Traits Event Handlers ------------------------------------------------
 
     def _open_changed(self):
         """ Handles the user clicking the 'Open...' button.
@@ -69,6 +64,7 @@ class FileDialogDemo(HasTraits):
                               id=demo_id)
         if file_name != '':
             self.file_name = file_name
+
 
 # Create the demo:
 demo = FileDialogDemo()

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_ImageInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_ImageInfo_Extension.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 This demonstrates using the TraitsUI file dialog with a file dialog extension,
 in this case, the <b>ImageInfo</b> extension, which displays (if possible) the
 contents, width and height information for the currently selected image file
@@ -14,6 +21,7 @@ This example also shows setting a file name filter which only allows common
 image file formats (i.e. *.png, *.gif, *.jpg, *.jpeg) files to be viewed and
 selected.
 """
+# Issue related to the demo warning: enthought/traitsui#953
 
 from traits.api import HasTraits, File, Button
 

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Multiple_Extensions.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Multiple_Extensions.py
@@ -1,9 +1,9 @@
 """
-This demonstrates using the Traits file dialog with multiple file dialog
+This demonstrates using the TraitsUI file dialog with multiple file dialog
 extensions, in this case, the <b>FileInfo</b>, <b>TextInfo</b> and
 <b>ImageInfo</b> extensions.
 
-For more information about why you would want to use the Traits file dialog
+For more information about why you would want to use the TraitsUI file dialog
 over the standard OS file dialog, select the <b>File Open</b> demo. For a
 demonstration of writing a custom file dialog extension, select the
 <b>File Open with Custom Extension</b> demo.
@@ -16,18 +16,14 @@ demo to verify that the customizations are not affected by any of the other
 demos because this demo specifies a custom id when invoking the file dialog.
 """
 
-#-- Imports --------------------------------------------------------------
+from traits.api import HasTraits, File, Button
 
-from traits.api \
-    import HasTraits, File, Button
+from traitsui.api import View, HGroup, Item
 
-from traitsui.api \
-    import View, HGroup, Item
+from traitsui.file_dialog import open_file, FileInfo, TextInfo, ImageInfo
 
-from traitsui.file_dialog  \
-    import open_file, FileInfo, TextInfo, ImageInfo
 
-#-- FileDialogDemo Class -------------------------------------------------
+# -- FileDialogDemo Class -------------------------------------------------
 
 # Demo specific file dialig id:
 demo_id = 'traitsui.demo.standard_editors.file_dialog.multiple_info'
@@ -44,7 +40,7 @@ class FileDialogDemo(HasTraits):
     # The button used to display the file dialog:
     open = Button('Open...')
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
     view = View(
         HGroup(
@@ -55,7 +51,7 @@ class FileDialogDemo(HasTraits):
         width=0.5
     )
 
-    #-- Traits Event Handlers ------------------------------------------------
+    # -- Traits Event Handlers ------------------------------------------------
 
     def _open_changed(self):
         """ Handles the user clicking the 'Open...' button.
@@ -63,6 +59,7 @@ class FileDialogDemo(HasTraits):
         file_name = open_file(extensions=extensions, id=demo_id)
         if file_name != '':
             self.file_name = file_name
+
 
 # Create the demo:
 demo = FileDialogDemo()

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Multiple_Extensions.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Multiple_Extensions.py
@@ -50,7 +50,7 @@ class FileDialogDemo(HasTraits):
 
     # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
+    traits_view = View(
         HGroup(
             Item('open', show_label=False),
             '_',

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Multiple_Extensions.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Multiple_Extensions.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 This demonstrates using the TraitsUI file dialog with multiple file dialog
 extensions, in this case, the <b>FileInfo</b>, <b>TextInfo</b> and
 <b>ImageInfo</b> extensions.
@@ -15,6 +22,7 @@ your new arrangement has been correctly restored. Try a different file dialog
 demo to verify that the customizations are not affected by any of the other
 demos because this demo specifies a custom id when invoking the file dialog.
 """
+# Issue related to the demo warning: enthought/traitsui#953
 
 from traits.api import HasTraits, File, Button
 

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_TextInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_TextInfo_Extension.py
@@ -1,11 +1,11 @@
 """
-This demonstrates using the Traits file dialog with a file dialog extension,
+This demonstrates using the TraitsUI file dialog with a file dialog extension,
 in this case, the <b>TextInfo</b> extension, which displays (if possible) the
 contents of the currently selected file in a read-only text editor so the user
 can quickly verify they are opening the correct file before leaving the file
 dialog.
 
-For more information about why you would want to use the Traits file dialog
+For more information about why you would want to use the TraitsUI file dialog
 over the standard OS file dialog, select the <b>File Open</b> demo. For a
 demonstration of writing a custom file dialog extension, select the
 <b>File Open with Custom Extension</b> demo.
@@ -14,20 +14,16 @@ This example also shows setting a file name filter which only allows Python
 source (i.e. *.py) files to be viewed and selected.
 """
 
-#-- Imports --------------------------------------------------------------
+from traits.api import HasTraits, File, Button
 
-from traits.api \
-    import HasTraits, File, Button
+from traitsui.api import View, HGroup, Item
 
-from traitsui.api \
-    import View, HGroup, Item
+from traitsui.file_dialog import open_file, TextInfo
 
-from traitsui.file_dialog  \
-    import open_file, TextInfo
 
-#-- FileDialogDemo Class -------------------------------------------------
+# -- FileDialogDemo Class -------------------------------------------------
 
-# Demo specific file dialig id:
+# Demo specific file dialog id:
 demo_id = 'traitsui.demo.standard_editors.file_dialog.text_info'
 
 
@@ -39,7 +35,7 @@ class FileDialogDemo(HasTraits):
     # The button used to display the file dialog:
     open = Button('Open...')
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
     view = View(
         HGroup(
@@ -50,7 +46,7 @@ class FileDialogDemo(HasTraits):
         width=0.5
     )
 
-    #-- Traits Event Handlers ------------------------------------------------
+    # -- Traits Event Handlers ------------------------------------------------
 
     def _open_changed(self):
         """ Handles the user clicking the 'Open...' button.
@@ -60,6 +56,7 @@ class FileDialogDemo(HasTraits):
                               id=demo_id)
         if file_name != '':
             self.file_name = file_name
+
 
 # Create the demo:
 demo = FileDialogDemo()

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_TextInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_TextInfo_Extension.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 This demonstrates using the TraitsUI file dialog with a file dialog extension,
 in this case, the <b>TextInfo</b> extension, which displays (if possible) the
 contents of the currently selected file in a read-only text editor so the user
@@ -13,6 +20,7 @@ demonstration of writing a custom file dialog extension, select the
 This example also shows setting a file name filter which only allows Python
 source (i.e. *.py) files to be viewed and selected.
 """
+# Issue related to the demo warning: enthought/traitsui#953
 
 from traits.api import HasTraits, File, Button
 

--- a/examples/demo/Standard_Editors/File_Dialog/File_Open_with_TextInfo_Extension.py
+++ b/examples/demo/Standard_Editors/File_Dialog/File_Open_with_TextInfo_Extension.py
@@ -45,7 +45,7 @@ class FileDialogDemo(HasTraits):
 
     # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
+    traits_view = View(
         HGroup(
             Item('open', show_label=False),
             '_',


### PR DESCRIPTION
Addresses #866

This PR mainly does stylistic and flake8 fixes to demos in `Standard_Editors/File_Dialog`. It also adds warning about all these demos being broken (see issue #953)

A few more significant changes:
- replace "Traits" references to "TraitsUI"
- replace `io.open` with Python built-in `open` and use it as a context manager
- remove the use of `commatize` function in demo code because it raises errors. Use integer string formatting instead