### PR TITLE
Fix install script for CI cron job

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -109,6 +109,11 @@ dependencies = {
     "docutils"
 }
 
+# NOTE : pyface is always installed from source
+source_dependencies = {
+    "traits": "git+http://github.com/enthought/traits.git#egg=traits",
+}
+
 # Additional toolkit-independent dependencies for demo testing
 test_dependencies = {
     "apptools",


### PR DESCRIPTION
The master cron job is failing (with error) on CI because of a missing variable in the install script, and `python etstool.py install --source` fails.
This variable was added in #914 but a merge (conflict?) with master resulted in it being erroneously removed.
This PR adds the variable back so that `python etstool.py install --source` does not fail.