### PR TITLE
Maintenance of TabularEditor demos in demos/Advanced

### DIFF
--- a/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
+++ b/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Auto-update from a list to a TabularEditor
 
 Demonstrates using a TabularEditor with the 'auto_update' feature enabled,
@@ -18,6 +25,8 @@ long lists are used, since enabling this feature adds and removed Traits
 listeners to each item in the list.
 
 """
+# Issues related to the demo warning: enthought/traitsui#913,
+# enthought/traitsui#960
 
 from traits.api import HasTraits, Str, Float, List, Instance, Button
 from traitsui.api import (

--- a/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
+++ b/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
@@ -1,9 +1,9 @@
 """
 Auto-update from a list to a TabularEditor
 
-Demonstrates using a TabularEditor with the 'auto_update' feature enabled, which
-allows the tabular editor to automatically update itself when the content of
-any object in the list associated with the editor is modified.
+Demonstrates using a TabularEditor with the 'auto_update' feature enabled,
+which allows the tabular editor to automatically update itself when the content
+of any object in the list associated with the editor is modified.
 
 To interact with the demo:
   - Select an employee from the list.
@@ -12,38 +12,36 @@ To interact with the demo:
   - Observe that the table automatically updates to reflect the employees new
     salary.
 
-In order for auto-update to work correctly, the editor trait should be a list of
-objects derived from HasTraits. Also, performance can be affected when very long
-lists are used, since enabling this feature adds and removed Traits listeners to
-each item in the list.
+In order for auto-update to work correctly, the editor trait should be a list
+of objects derived from HasTraits. Also, performance can be affected when very
+long lists are used, since enabling this feature adds and removed Traits
+listeners to each item in the list.
 
 """
 
 from traits.api import HasTraits, Str, Float, List, Instance, Button
-from traitsui.api import View, HGroup, Item, TabularEditor, spring
-from traitsui.tabular_adapter import TabularAdapter
+from traitsui.api import (
+    View, HGroup, Item, TabularAdapter, TabularEditor, spring
+)
 
-#-- EmployeeAdapter Class ------------------------------------------------
 
-
+# -- EmployeeAdapter Class ------------------------------------------------
 class EmployeeAdapter(TabularAdapter):
 
     columns = [('Name', 'name'), ('Salary', 'salary')]
 
     def get_default_value(self, object, trait):
-        return Employee(salary=30000)
-
-#-- Employee Class -------------------------------------------------------
+        return Employee(name="John", salary=30000)
 
 
+# -- Employee Class -------------------------------------------------------
 class Employee(HasTraits):
 
     name = Str()
     salary = Float()
 
-#-- Company Class --------------------------------------------------------
 
-
+# -- Company Class --------------------------------------------------------
 class Company(HasTraits):
 
     employees = List(Employee)
@@ -51,19 +49,25 @@ class Company(HasTraits):
     increase = Float()
     give_raise = Button('Give raise')
 
-    view = View(
-        Item('employees',
-             show_label=False,
-             editor=TabularEditor(adapter=EmployeeAdapter(),
-                                  selected='employee',
-                                  auto_update=True)
-             ),
+    traits_view = View(
+        Item(
+            'employees',
+            show_label=False,
+            editor=TabularEditor(
+                adapter=EmployeeAdapter(),
+                selected='employee',
+                auto_resize=True,
+                auto_update=True
+            )
+        ),
         HGroup(
             spring,
             Item('increase'),
-            Item('give_raise',
-                 show_label=False,
-                 enabled_when='employee is not None')
+            Item(
+                'give_raise',
+                show_label=False,
+                enabled_when='employee is not None'
+            )
         ),
         title='Auto Update Tabular Editor demo',
         height=0.25,
@@ -75,15 +79,19 @@ class Company(HasTraits):
         self.employee.salary += self.increase
         self.employee = None
 
-#-- Set up the demo ------------------------------------------------------
 
-demo = Company(increase=1000, employees=[
-    Employee(name='Fred', salary=45000),
-    Employee(name='Sally', salary=52000),
-    Employee(name='Jim', salary=39000),
-    Employee(name='Helen', salary=41000),
-    Employee(name='George', salary=49000),
-    Employee(name='Betty', salary=46000)])
+# -- Set up the demo ------------------------------------------------------
+demo = Company(
+    increase=1000,
+    employees=[
+        Employee(name='Fred', salary=45000),
+        Employee(name='Sally', salary=52000),
+        Employee(name='Jim', salary=39000),
+        Employee(name='Helen', salary=41000),
+        Employee(name='George', salary=49000),
+        Employee(name='Betty', salary=46000)
+    ]
+)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':

--- a/examples/demo/Advanced/Multi_select_string_list.py
+++ b/examples/demo/Advanced/Multi_select_string_list.py
@@ -9,8 +9,7 @@ are shown in the right table. Each table has only one column.
 """
 
 from traits.api import HasPrivateTraits, List, Str, Property
-from traitsui.api import View, HGroup, UItem, TabularEditor
-from traitsui.tabular_adapter import TabularAdapter
+from traitsui.api import View, HGroup, UItem, TabularAdapter, TabularEditor
 
 
 class MultiSelectAdapter(TabularAdapter):
@@ -45,31 +44,40 @@ class MultiSelect(HasPrivateTraits):
     choices = List(Str)
     selected = List(Str)
 
-    view = View(
+    traits_view = View(
         HGroup(
-            UItem('choices',
-                  editor=TabularEditor(
-                      show_titles=True,
-                      selected='selected',
-                      editable=False,
-                      multi_select=True,
-                      adapter=MultiSelectAdapter())
-                  ),
-            UItem('selected',
-                  editor=TabularEditor(
-                      show_titles=True,
-                      editable=False,
-                      adapter=MultiSelectAdapter())
-                  )
+            UItem(
+                'choices',
+                editor=TabularEditor(
+                    show_titles=True,
+                    selected='selected',
+                    editable=False,
+                    multi_select=True,
+                    adapter=MultiSelectAdapter()
+                )
+            ),
+            UItem(
+                'selected',
+                editor=TabularEditor(
+                    show_titles=True,
+                    editable=False,
+                    adapter=MultiSelectAdapter()
+                )
+            )
         ),
         resizable=True,
         width=200,
         height=300
     )
 
+
 # Create the demo:
-demo = MultiSelect(choices=['one', 'two', 'three', 'four', 'five', 'six',
-                            'seven', 'eight', 'nine', 'ten'])
+demo = MultiSelect(
+    choices=[
+        'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine',
+        'ten'
+    ]
+)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':

--- a/examples/demo/Advanced/Multi_select_string_list.py
+++ b/examples/demo/Advanced/Multi_select_string_list.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Creating a multi-select list box
 
 How to use a TabularEditor to create a multi-select list box.
@@ -7,6 +14,7 @@ This demo uses two TabularEditors, side-by-side. Selections from the left table
 are shown in the right table. Each table has only one column.
 
 """
+# Issue related to the demo warning: enthought/traitsui#960
 
 from traits.api import HasPrivateTraits, List, Str, Property
 from traitsui.api import View, HGroup, UItem, TabularAdapter, TabularEditor

--- a/examples/demo/Advanced/Multi_select_string_list.py
+++ b/examples/demo/Advanced/Multi_select_string_list.py
@@ -14,7 +14,8 @@ This demo uses two TabularEditors, side-by-side. Selections from the left table
 are shown in the right table. Each table has only one column.
 
 """
-# Issue related to the demo warning: enthought/traitsui#960
+# Issues related to the demo warning: enthought/traitsui#14,
+# enthought/traitsui#15, enthought/traitsui#960
 
 from traits.api import HasPrivateTraits, List, Str, Property
 from traitsui.api import View, HGroup, UItem, TabularAdapter, TabularEditor

--- a/examples/demo/Advanced/NumPy_array_tabular_editor_demo.py
+++ b/examples/demo/Advanced/NumPy_array_tabular_editor_demo.py
@@ -5,29 +5,26 @@ A demonstration of how the TabularEditor can be used to display (large) NumPy
 arrays, in this case 100,000 random 3D points from a unit cube.
 
 In addition to showing the coordinates of each point, it also displays the
-index of each point in the array, as well as a red flag if the point lies within
-0.25 of the center of the cube.
+index of each point in the array, as well as a red flag if the point lies
+within 0.25 of the center of the cube.
 """
-
-#-- Imports --------------------------------------------------------------
 
 from numpy import sqrt
 from numpy.random import random
+
 from traits.api import HasTraits, Property, Array
-from traitsui.api import View, Item, TabularEditor, Font
-from traitsui.tabular_adapter import TabularAdapter
-
-#-- Tabular Adapter Definition -------------------------------------------
+from traitsui.api import View, Item, TabularAdapter, TabularEditor
 
 
+# -- Tabular Adapter Definition -------------------------------------------
 class ArrayAdapter(TabularAdapter):
 
     columns = [('i', 'index'), ('x', 0), ('y', 1), ('z', 2)]
 
-    # Font fails with wx in OSX; see traitsui issue #13:
-    # font        = Font('Courier 10')
+    font = 'Courier 10'
     alignment = 'right'
     format = '%.4f'
+
     index_text = Property()
     index_image = Property()
 
@@ -41,24 +38,29 @@ class ArrayAdapter(TabularAdapter):
 
         return None
 
-#-- ShowArray Class Definition -------------------------------------------
+# -- ShowArray Class Definition -------------------------------------------
 
 
 class ShowArray(HasTraits):
 
     data = Array
 
-    view = View(
-        Item('data',
-             show_label=False,
-             style='readonly',
-             editor=TabularEditor(adapter=ArrayAdapter())
-             ),
+    traits_view = View(
+        Item(
+            'data',
+            show_label=False,
+            style='readonly',
+            editor=TabularEditor(
+                adapter=ArrayAdapter(),
+                auto_resize=True
+            )
+        ),
         title='Array Viewer',
         width=0.3,
         height=0.8,
         resizable=True
     )
+
 
 # Create the demo:
 demo = ShowArray(data=random((100000, 3)))

--- a/examples/demo/Advanced/NumPy_array_tabular_editor_demo.py
+++ b/examples/demo/Advanced/NumPy_array_tabular_editor_demo.py
@@ -49,10 +49,13 @@ class ShowArray(HasTraits):
         Item(
             'data',
             show_label=False,
-            style='readonly',
             editor=TabularEditor(
                 adapter=ArrayAdapter(),
-                auto_resize=True
+                auto_resize=True,
+                # Do not allow any kind of editing of the array:
+                editable=False,
+                operations=[],
+                drag_move=False
             )
         ),
         title='Array Viewer',

--- a/examples/demo/Advanced/String_list_ui_editor.py
+++ b/examples/demo/Advanced/String_list_ui_editor.py
@@ -11,25 +11,22 @@ construct a reusable Traits UI-based editor that can be used in other
 applications.
 """
 
-#-- Imports ------------------------------------------------------------------
-
 from traits.api import HasPrivateTraits, List, Str, Property, on_trait_change
-
-from traitsui.api import View, HGroup, Item, TabularEditor
-from traitsui.tabular_adapter import TabularAdapter
-from traitsui.basic_editor_factory import BasicEditorFactory
-
 from traits.etsconfig.api import ETSConfig
+
+from traitsui.api import (
+    BasicEditorFactory, HGroup, Item, TabularAdapter, TabularEditor, View
+)
+
 if ETSConfig.toolkit == 'wx':
     from traitsui.wx.ui_editor import UIEditor
 else:
     from traitsui.qt4.ui_editor import UIEditor
 
-#-- Define the reusable StringListEditor class and its helper classes --------
+
+# -- Define the reusable StringListEditor class and its helper classes --------
 
 # Define the tabular adapter used by the Traits UI string list editor:
-
-
 class MultiSelectAdapter(TabularAdapter):
 
     # The columns in the table (just the string value):
@@ -41,9 +38,8 @@ class MultiSelectAdapter(TabularAdapter):
     def _get_value_text(self):
         return self.item
 
+
 # Define the actual Traits UI string list editor:
-
-
 class _StringListEditor(UIEditor):
 
     # Indicate that the editor is scrollable/resizable:
@@ -56,35 +52,35 @@ class _StringListEditor(UIEditor):
     selected = List(Str)
 
     # The traits UI view used by the editor:
-    view = View(
-        Item('choices',
-             show_label=False,
-             editor=TabularEditor(
-                 show_titles=False,
-                 selected='selected',
-                 editable=False,
-                 multi_select=True,
-                 adapter=MultiSelectAdapter())
-             ),
+    traits_view = View(
+        Item(
+            'choices',
+            show_label=False,
+            editor=TabularEditor(
+                show_titles=False,
+                selected='selected',
+                editable=False,
+                multi_select=True,
+                adapter=MultiSelectAdapter()
+            )
+        ),
         id='string_list_editor',
         resizable=True
     )
 
     def init_ui(self, parent):
 
-        self.sync_value(self.factory.choices, 'choices', 'from',
-                        is_list=True)
+        self.sync_value(self.factory.choices, 'choices', 'from', is_list=True)
         self.selected = self.value
 
         return self.edit_traits(parent=parent, kind='subpanel')
 
-    @on_trait_change(' selected')
+    @on_trait_change('selected')
     def _selected_modified(self):
         self.value = self.selected
 
+
 # Define the StringListEditor class used by client code:
-
-
 class StringListEditor(BasicEditorFactory):
 
     # The editor implementation class:
@@ -93,9 +89,8 @@ class StringListEditor(BasicEditorFactory):
     # The extended trait name containing the editor's set of choices:
     choices = Str()
 
-#-- Define the demo class ----------------------------------------------------
 
-
+# -- Define the demo class ----------------------------------------------------
 class MultiSelect(HasPrivateTraits):
     """ This class demonstrates using the StringListEditor to select a set
         of string values from a set of choices.
@@ -113,25 +108,32 @@ class MultiSelect(HasPrivateTraits):
 
     # A traits view showing the list of choices on the left-hand side, and
     # the currently selected choices on the right-hand side:
-    view = View(
+    traits_view = View(
         HGroup(
-            Item('selected',
-                 show_label=False,
-                 editor=StringListEditor(choices='choices')
-                 ),
-            Item('result',
-                 show_label=False,
-                 editor=StringListEditor(choices='selected')
-                 )
+            Item(
+                'selected',
+                show_label=False,
+                editor=StringListEditor(choices='choices')
+            ),
+            Item(
+                'result',
+                show_label=False,
+                editor=StringListEditor(choices='selected')
+            )
         ),
         width=0.20,
         height=0.25
     )
 
+
 # Create the demo:
-demo = MultiSelect(choices=['one', 'two', 'three', 'four', 'five', 'six',
-                            'seven', 'eight', 'nine', 'ten'],
-                   selected=['two', 'five', 'nine'])
+demo = MultiSelect(
+    choices=[
+        'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine',
+        'ten'
+    ],
+    selected=['two', 'five', 'nine']
+)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':

--- a/examples/demo/Advanced/String_list_ui_editor.py
+++ b/examples/demo/Advanced/String_list_ui_editor.py
@@ -2,6 +2,13 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Another demo showing how to use a TabularEditor to create a multi-select list
 box. This demo creates a reusable StringListEditor class and uses that instead
 of defining the editor as part of the demo class.
@@ -10,6 +17,7 @@ This approach greatly simplifies the actual demo class and shows how to
 construct a reusable Traits UI-based editor that can be used in other
 applications.
 """
+# Issue related to the demo warning: enthought/traitsui#960
 
 from traits.api import HasPrivateTraits, List, Str, Property, on_trait_change
 from traits.etsconfig.api import ETSConfig

--- a/examples/demo/Advanced/Tabular_editor_demo.py
+++ b/examples/demo/Advanced/Tabular_editor_demo.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Tabular editor
 
 The TabularEditor can be used for many of the same purposes as the TableEditor,
@@ -97,6 +104,7 @@ feels stand out about this approach are:
   the documentation.
 
 """
+# Issue related to the demo warning: enthought/traitsui#960
 
 from functools import partial
 from random import randint, choice, shuffle

--- a/examples/demo/Advanced/Tabular_editor_with_context_menu_demo.py
+++ b/examples/demo/Advanced/Tabular_editor_with_context_menu_demo.py
@@ -1,4 +1,11 @@
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Defining column-specific context menu in a Tabular Editor. Shows how the
 example for the Table Editor (`Table_Editor_with_context_menu_demo.py`) can be
 adapted to work with a Tabular Editor.
@@ -15,6 +22,8 @@ occur on a number of traits into a category of event, which can be handled by
 a single event handler defined for the category (in this case, the category
 is 'affects_average').
 """
+# Issue related to the demo warning: enthought/traitsui#960
+
 
 from random import randint
 from traits.api import HasStrictTraits, Str, Int, Float, List, Property

--- a/examples/demo/Advanced/Tabular_editor_with_context_menu_demo.py
+++ b/examples/demo/Advanced/Tabular_editor_with_context_menu_demo.py
@@ -1,6 +1,7 @@
 """
 Defining column-specific context menu in a Tabular Editor. Shows how the
-example for the Table Editor can be adapted to work with a Tabular Editor.
+example for the Table Editor (`Table_Editor_with_context_menu_demo.py`) can be
+adapted to work with a Tabular Editor.
 
 The demo is a simple baseball scoring system, which lists each player and
 their current batting statistics. After a given player has an at bat, you
@@ -17,27 +18,32 @@ is 'affects_average').
 
 from random import randint
 from traits.api import HasStrictTraits, Str, Int, Float, List, Property
-from traits.etsconfig.api import ETSConfig
-from traitsui.api import View, Item, TabularEditor
-from traitsui.menu import Menu, Action
-from traitsui.tabular_adapter import TabularAdapter
+from traitsui.api import (
+    Action, Item, Menu, TabularAdapter, TabularEditor, View
+)
 
 
 # Define a custom tabular adapter for handling items which affect the player's
 # batting average:
 class PlayerAdapter(TabularAdapter):
 
+    # Overwrite default values
     alignment = 'center'
-
     width = 0.09
 
     def get_menu(self, object, trait, row, column):
         column_name = self.column_map[column]
         if column_name not in ['name', 'average']:
-            menu = Menu(Action(name='Add',
-                               action='editor.adapter.add(item, column)'),
-                        Action(name='Sub',
-                               action='editor.adapter.sub(item, column)'))
+            menu = Menu(
+                Action(
+                    name='Add',
+                    action='editor.adapter.add(item, column)'
+                ),
+                Action(
+                    name='Sub',
+                    action='editor.adapter.sub(item, column)'
+                )
+            )
             return menu
         else:
             return super(PlayerAdapter, self).get_menu(
@@ -84,7 +90,6 @@ player_editor = TabularEditor(
     stretch_last_section=False,
     auto_update=True,
     adapter=PlayerAdapter(columns=columns),
-    show_row_titles=ETSConfig.toolkit == 'qt4',
 )
 
 
@@ -124,10 +129,7 @@ class Team(HasStrictTraits):
 
     # Trait view definitions:
     traits_view = View(
-        Item('players',
-             show_label=False,
-             editor=player_editor
-             ),
+        Item('players', show_label=False, editor=player_editor),
         title='Baseball Scoring Demo',
         width=0.5,
         height=0.5,
@@ -138,27 +140,32 @@ class Team(HasStrictTraits):
 def random_player(name):
     """ Generates and returns a random player.
     """
-    p = Player(name=name,
-               strike_outs=randint(0, 50),
-               singles=randint(0, 50),
-               doubles=randint(0, 20),
-               triples=randint(0, 5),
-               home_runs=randint(0, 30),
-               walks=randint(0, 50))
+    p = Player(
+        name=name,
+        strike_outs=randint(0, 50),
+        singles=randint(0, 50),
+        doubles=randint(0, 20),
+        triples=randint(0, 5),
+        home_runs=randint(0, 30),
+        walks=randint(0, 50)
+    )
     return p.trait_set(
-        at_bats=p.strike_outs +
-        p.singles +
-        p.doubles +
-        p.triples +
-        p.home_runs +
-        randint(
-            100,
-            200))
+        at_bats=(
+            p.strike_outs + p.singles + p.doubles + p.triples + p.home_runs +
+            randint(100, 200)
+        )
+    )
+
 
 # Create the demo:
-demo = view = Team(players=[random_player(name) for name in [
-    'Dave', 'Mike', 'Joe', 'Tom', 'Dick', 'Harry', 'Dirk', 'Fields', 'Stretch'
-]])
+demo = Team(
+    players=[
+        random_player(name) for name in [
+            'Dave', 'Mike', 'Joe', 'Tom', 'Dick', 'Harry', 'Dirk', 'Fields',
+            'Stretch'
+        ]
+    ]
+)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses #866

These are mostly flake8, formatting and other minor stylistic fixes for TabularEditor demos in `demos/Advanced`.

Some of the demos are broken. Warning are added to demos that are broken in some way. Issue references also added as comments.

More important changes:
- Numpy demo had a TabularEditor `readonly` style, but it doesn't disable the editing. Added necessary editor options to disable editing.
- Removed mention of an old closed issue and restored code that was commented out because of it.
- Some minor fixes (e.g. `auto_resize=True`) to improve the appearance of the demos
- Remove the use of `lambda` in `Tabular_editor_demo.py`