### PR TITLE
Maintenance of date and time editor demos in demos/Advanced

### DIFF
--- a/examples/demo/Advanced/Date_editor_demo.py
+++ b/examples/demo/Advanced/Date_editor_demo.py
@@ -2,7 +2,10 @@
 #  License: BSD Style.
 
 """
-A Traits UI editor that wraps a WX calendar panel.
+Implementation of a DateEditor demo plugin for Traits UI demo program.
+
+This demo shows a few different styles of the DateEditor and how it can be
+customized.
 """
 
 from traits.api import HasTraits, Date, List, Str
@@ -16,38 +19,44 @@ class DateEditorDemo(HasTraits):
     info_string = Str('The editors for Traits Date objects.  Showing both '
                       'the defaults, and one with alternate options.')
 
-    multi_select_editor = DateEditor(multi_select=True,
-                                     months=2,
-                                     allow_future=False,
-                                     padding=30,
-                                     on_mixed_select='max_change',
-                                     shift_to_select=False)
+    multi_select_editor = DateEditor(
+        allow_future=False,
+        multi_select=True,
+        shift_to_select=False,
+        on_mixed_select='max_change',
+        # Qt ignores these setting and always shows only 1 month:
+        months=2,
+        padding=30,
+    )
 
-    view = View(Item('info_string',
-                     show_label=False,
-                     style='readonly'),
-
-                Group(Item('single_date',
-                           label='Simple date editor'),
-                      Item('single_date',
-                           style='custom',
-                           label='Default custom editor'),
-                      Item('single_date',
-                           style='readonly',
-                           editor=DateEditor(strftime='You picked %B %d %Y',
-                                             message='Click a date above.'),
-                           label='ReadOnly editor'),
-                      label='Default settings for editors'),
-
-                Group(Item('multi_date',
-                           editor=multi_select_editor,
-                           style='custom',
-                           label='Multi-select custom editor'),
-                      label='More customized editor: multi-select; disallow '
-                            'future; two months; padding; selection '
-                            'style; etc.'),
-
-                resizable=True)
+    traits_view = View(
+        Item('info_string', show_label=False, style='readonly'),
+        Group(
+            Item('single_date', label='Simple date editor'),
+            Item('single_date', style='custom', label='Default custom editor'),
+            Item(
+                'single_date',
+                style='readonly',
+                editor=DateEditor(
+                    strftime='You picked %B %d %Y',
+                    message='Click a date above.'
+                ),
+                label='ReadOnly editor'
+            ),
+            label='Default settings for editors'
+        ),
+        Group(
+            Item(
+                'multi_date',
+                editor=multi_select_editor,
+                style='custom',
+                label='Multi-select custom editor'
+            ),
+            label='More customized editor: multi-select; disallow '
+                  'future; selection style; etc.'
+        ),
+        resizable=True
+    )
 
     def _multi_date_changed(self):
         """ Print each time the date value is changed in the editor. """
@@ -62,11 +71,9 @@ class DateEditorDemo(HasTraits):
         print(self.single_date)
 
 
-#-- Set Up The Demo ------------------------------------------------------
+# -- Set Up The Demo ------------------------------------------------------
 
 demo = DateEditorDemo()
 
 if __name__ == "__main__":
     demo.configure_traits()
-
-#-- eof -----------------------------------------------------------------------

--- a/examples/demo/Advanced/Date_editor_demo.py
+++ b/examples/demo/Advanced/Date_editor_demo.py
@@ -2,11 +2,19 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a DateEditor demo plugin for Traits UI demo program.
 
 This demo shows a few different styles of the DateEditor and how it can be
 customized.
 """
+# Issue related to the demo warning: enthought/traitsui#962
 
 from traits.api import HasTraits, Date, List, Str
 from traitsui.api import View, Item, DateEditor, Group

--- a/examples/demo/Advanced/Date_range_editor_demo.py
+++ b/examples/demo/Advanced/Date_range_editor_demo.py
@@ -2,16 +2,10 @@
 #  License: BSD Style.
 
 """
-**WARNING**
-
-  This demo might not work as expected and some documented features might be
-  missing.
-
--------------------------------------------------------------------------------
-
 Implementation of a DateRangeEditor demo plugin for Traits UI demo program.
 
-This demo shows a custom style DateRaneEditor.
+This demo shows a custom style DateRangeEditor. Note that this demo only works
+with qt backend.
 """
 # Issue related to the demo warning: enthought/traitsui#962
 

--- a/examples/demo/Advanced/Date_range_editor_demo.py
+++ b/examples/demo/Advanced/Date_range_editor_demo.py
@@ -2,10 +2,13 @@
 #  License: BSD Style.
 
 """
-A Traits UI editor that wraps a Qt calendar panel.
+Implementation of a DateRangeEditor demo plugin for Traits UI demo program.
+
+This demo shows a custom style DateRaneEditor.
 """
 
 from traits.api import HasTraits, Date, Tuple
+from traits.etsconfig.api import ETSConfig
 from traitsui.api import View, Item, DateRangeEditor, Group
 
 
@@ -13,23 +16,28 @@ class DateRangeEditorDemo(HasTraits):
     """ Demo class to show DateRangeEditor. """
     date_range = Tuple(Date, Date)
 
-    view = View(
-                Group(Item('date_range',
-                           editor=DateRangeEditor(),
-                           style='custom',
-                           label='Date range'),
-                      label='Date range'),
-                resizable=True)
+    traits_view = View(
+        Group(
+            Item(
+                'date_range',
+                editor=DateRangeEditor(),
+                style='custom',
+                label='Date range'
+            ),
+            label='Date range'
+        ),
+        resizable=True
+    )
 
     def _date_range_changed(self):
         print(self.date_range)
 
 
-#-- Set Up The Demo ------------------------------------------------------
+# -- Set Up The Demo ------------------------------------------------------
 
-demo = DateRangeEditorDemo()
 
 if __name__ == "__main__":
-    demo.configure_traits()
-
-#-- eof -----------------------------------------------------------------------
+    if ETSConfig.toolkit == "qt4":
+        # DateRangeEditor is currently only available for qt backend.
+        demo = DateRangeEditorDemo()
+        demo.configure_traits()

--- a/examples/demo/Advanced/Date_range_editor_demo.py
+++ b/examples/demo/Advanced/Date_range_editor_demo.py
@@ -2,10 +2,18 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 Implementation of a DateRangeEditor demo plugin for Traits UI demo program.
 
 This demo shows a custom style DateRaneEditor.
 """
+# Issue related to the demo warning: enthought/traitsui#962
 
 from traits.api import HasTraits, Date, Tuple
 from traits.etsconfig.api import ETSConfig

--- a/examples/demo/Advanced/Time_editor_demo.py
+++ b/examples/demo/Advanced/Time_editor_demo.py
@@ -17,20 +17,25 @@ from traitsui.api import View, Item, TimeEditor
 class TimeEditorDemo(HasTraits):
     """ Demo class. """
     time = Time(datetime.time(12, 0, 0))
-    view = View(Item('time', label='Simple Editor'),
-                Item('time', label='Readonly Editor',
-                     style='readonly',
-                     # Show 24-hour mode instead of default 12 hour.
-                     editor=TimeEditor(strftime='%H:%M:%S')
-                     ),
-                resizable=True)
+
+    traits_view = View(
+        Item('time', label='Simple Editor'),
+        Item(
+            'time',
+            label='Readonly Editor',
+            style='readonly',
+            # Show 24-hour mode instead of default 12 hour.
+            editor=TimeEditor(strftime='%H:%M:%S')
+        ),
+        resizable=True
+    )
 
     def _time_changed(self):
         """ Print each time the time value is changed in the editor. """
         print(self.time)
 
 
-#-- Set Up The Demo ------------------------------------------------------
+# -- Set Up The Demo ------------------------------------------------------
 
 demo = TimeEditorDemo()
 


### PR DESCRIPTION
Addresses #866

These are mostly flake8, formatting and other minor stylistic fixes for time and date editor demos in `demos/Advanced`.

Some of the demos are broken. Warning are added to demos that are broken in some way. Issue references also added as comments.

More important changes:
- Updated docstrings
- Added explanation about options ignored by qt
- Add protection against launching `DateRangeEditor` demo with wx backend because the editor isn't implemented