### PR TITLE
Maintenance of TableEditor demos in demos/Advanced

### DIFF
--- a/examples/demo/Advanced/List_editors_demo.py
+++ b/examples/demo/Advanced/List_editors_demo.py
@@ -2,6 +2,13 @@
 #  License: BSD Style.
 
 """
+**WARNING**
+
+  This demo might not work as expected and some documented features might be
+  missing.
+
+-------------------------------------------------------------------------------
+
 This shows the three different types of editor that can be applied to a list
 of objects:
 
@@ -12,6 +19,7 @@ of objects:
 Each editor style is editing the exact same list of objects. Note that any
 changes made in one editor are automatically reflected in the others.
 """
+# Issue related to the demo warning: enthought/traitsui#948
 
 from traits.api import HasStrictTraits, Str, Int, Regex, List, Instance
 

--- a/examples/demo/Advanced/List_editors_demo.py
+++ b/examples/demo/Advanced/List_editors_demo.py
@@ -13,34 +13,32 @@ Each editor style is editing the exact same list of objects. Note that any
 changes made in one editor are automatically reflected in the others.
 """
 
-# Imports:
-from traits.api \
-    import HasStrictTraits, Str, Int, Regex, List, Instance
+from traits.api import HasStrictTraits, Str, Int, Regex, List, Instance
 
-from traitsui.api \
-    import View, Item, Tabbed, TableEditor, ListEditor
+from traitsui.api import (
+    Item, ListEditor, ObjectColumn, RuleTableFilter, Tabbed, TableEditor, View
+)
 
-from traitsui.table_column \
-    import ObjectColumn
+from traitsui.table_filter import (
+    RuleFilterTemplate, MenuFilterTemplate, EvalFilterTemplate
+)
 
-from traitsui.table_filter \
-    import RuleTableFilter, RuleFilterTemplate, \
-    MenuFilterTemplate, EvalFilterTemplate
 
 # 'Person' class:
-
-
 class Person(HasStrictTraits):
 
     # Trait definitions:
     name = Str()
     age = Int()
-    phone = Regex(value='000-0000', regex='\d\d\d[-]\d\d\d\d')
+    phone = Regex(value='000-0000', regex=r'\d\d\d[-]\d\d\d\d')
 
     # Traits view definition:
-    traits_view = View('name', 'age', 'phone',
-                       width=0.18,
-                       buttons=['OK', 'Cancel'])
+    traits_view = View(
+        'name', 'age', 'phone',
+        width=0.18,
+        buttons=['OK', 'Cancel']
+    )
+
 
 # Sample data:
 people = [
@@ -58,9 +56,11 @@ people = [
 filters = [EvalFilterTemplate, MenuFilterTemplate, RuleFilterTemplate]
 
 table_editor = TableEditor(
-    columns=[ObjectColumn(name='name', width=0.4),
-             ObjectColumn(name='age', width=0.2),
-             ObjectColumn(name='phone', width=0.4)],
+    columns=[
+        ObjectColumn(name='name', width=0.4),
+        ObjectColumn(name='age', width=0.2),
+        ObjectColumn(name='phone', width=0.4)
+    ],
     editable=True,
     deletable=True,
     sortable=True,
@@ -68,12 +68,12 @@ table_editor = TableEditor(
     auto_size=False,
     filters=filters,
     search=RuleTableFilter(),
-    row_factory=Person
+    row_factory=Person,
+    show_toolbar=True
 )
 
+
 # 'ListTraitTest' class:
-
-
 class ListTraitTest(HasStrictTraits):
 
     # Trait definitions:
@@ -82,28 +82,34 @@ class ListTraitTest(HasStrictTraits):
     # Traits view definitions:
     traits_view = View(
         Tabbed(
-            Item('people',
-                 label='Table',
-                 id='table',
-                 editor=table_editor),
-            Item('people',
-                 label='List',
-                 id='list',
-                 style='custom',
-                 editor=ListEditor(style='custom',
-                                   rows=5)),
-            Item('people',
-                 label='Notebook',
-                 id='notebook',
-                 style='custom',
-                 editor=ListEditor(use_notebook=True,
-                                   deletable=True,
-                                   export='DockShellWindow',
-                                   page_name='.name')),
+            Item('people', label='Table', id='table', editor=table_editor),
+            Item(
+                'people',
+                label='List',
+                id='list',
+                style='custom',
+                editor=ListEditor(style='custom', rows=5)
+            ),
+            Item(
+                'people',
+                label='Notebook',
+                id='notebook',
+                style='custom',
+                editor=ListEditor(
+                    use_notebook=True,
+                    deletable=True,
+                    export='DockShellWindow',
+                    page_name='.name'
+                )
+            ),
             id='splitter',
-            show_labels=False),
+            show_labels=False
+        ),
         id='traitsui.demo.Traits UI Demo.Advanced.List_editors_demo',
-        dock='horizontal')
+        dock='horizontal',
+        width=600
+    )
+
 
 # Create the demo:
 demo = ListTraitTest(people=people)

--- a/examples/demo/Advanced/Property_List_demo.py
+++ b/examples/demo/Advanced/Property_List_demo.py
@@ -28,30 +28,21 @@ method to perform the expensive generation of a new list of people only when
 the <i>ticker</i> event fires, not every time it is accessed.
 """
 
-#-- Imports --------------------------------------------------------------
+from random import randint, choice
 
-from random \
-    import randint, choice
+from threading import Thread
 
-from threading \
-    import Thread
+from time import sleep
 
-from time \
-    import sleep
+from traits.api import (
+    HasStrictTraits, HasPrivateTraits, Str, Int, Enum, List, Event, Property,
+    cached_property
+)
 
-from traits.api \
-    import HasStrictTraits, HasPrivateTraits, Str, Int, Enum, List, Event, \
-    Property, cached_property
-
-from traitsui.api \
-    import View, Item, TableEditor
-
-from traitsui.table_column \
-    import ObjectColumn
-
-#-- Person Class ---------------------------------------------------------
+from traitsui.api import ObjectColumn, Item, TableEditor, View
 
 
+# -- Person Class ---------------------------------------------------------
 class Person(HasStrictTraits):
     """ Defines some sample data to display in the TableEditor.
     """
@@ -60,9 +51,8 @@ class Person(HasStrictTraits):
     age = Int()
     gender = Enum('Male', 'Female')
 
-#-- PropertyListDemo Class -----------------------------------------------
 
-
+# -- PropertyListDemo Class -----------------------------------------------
 class PropertyListDemo(HasPrivateTraits):
     """ Displays a random list of Person objects in a TableEditor that is
         refreshed every 3 seconds by a background thread.
@@ -77,47 +67,47 @@ class PropertyListDemo(HasPrivateTraits):
     # Tiny hack to allow starting the background thread easily:
     begin = Int()
 
-    #-- Traits View Definitions ----------------------------------------------
+    # -- Traits View Definitions ----------------------------------------------
 
-    view = View(
-        Item('people',
-             show_label=False,
-             editor=TableEditor(
-                 columns=[
-                     ObjectColumn(name='name', editable=False,
-                                  width=0.50),
-                     ObjectColumn(name='age', editable=False,
-                                  width=0.15),
-                     ObjectColumn(name='gender', editable=False,
-                                  width=0.35)
-                 ],
-                 auto_size=False,
-                 show_toolbar=False
+    traits_view = View(
+        Item(
+            'people',
+            show_label=False,
+            editor=TableEditor(
+                columns=[
+                    ObjectColumn(name='name', editable=False, width=0.50),
+                    ObjectColumn(name='age', editable=False, width=0.15),
+                    ObjectColumn(name='gender', editable=False, width=0.35)
+                ],
+                auto_size=False,
+                show_toolbar=False,
+                sortable=False,
              )
-             ),
+         ),
         title='Property List Demo',
         width=0.25,
         height=0.33,
         resizable=True
     )
 
-    #-- Property Implementations ---------------------------------------------
-
+    # -- Property Implementations ---------------------------------------------
     @cached_property
     def _get_people(self):
         """ Returns the value for the 'people' property.
         """
-        return [Person(
-            name='%s %s' % (
-                choice(['Tom', 'Dick', 'Harry', 'Alice', 'Lia', 'Vibha']),
-                choice(['Thomas', 'Jones', 'Smith', 'Adams', 'Johnson'])),
-            age=randint(21, 75),
-            gender=choice(['Male', 'Female']))
+        return [
+            Person(
+                name='%s %s' % (
+                    choice(['Tom', 'Dick', 'Harry', 'Alice', 'Lia', 'Vibha']),
+                    choice(['Thomas', 'Jones', 'Smith', 'Adams', 'Johnson'])
+                ),
+                age=randint(21, 75),
+                gender=choice(['Male', 'Female'])
+            )
             for i in range(randint(10, 20))
         ]
 
-    #-- Default Value Implementations ----------------------------------------
-
+    # -- Default Value Implementations ----------------------------------------
     def _begin_default(self):
         """ Starts the background thread running.
         """
@@ -127,7 +117,7 @@ class PropertyListDemo(HasPrivateTraits):
 
         return 0
 
-    #-- Private Methods ------------------------------------------------------
+    # -- Private Methods ------------------------------------------------------
 
     def _timer(self):
         """ Triggers a property update every 3 seconds for 30 seconds.
@@ -135,6 +125,7 @@ class PropertyListDemo(HasPrivateTraits):
         for i in range(10):
             sleep(3)
             self.ticker = True
+
 
 # Create the demo:
 demo = PropertyListDemo()

--- a/examples/demo/Advanced/Table_editor_with_checkbox_column.py
+++ b/examples/demo/Advanced/Table_editor_with_checkbox_column.py
@@ -6,21 +6,13 @@ This shows a table editor which has a checkbox column in addition to normal
 data columns.
 """
 
-# Imports:
-from random \
-    import randint
+from random import randint
 
-from traits.api \
-    import HasStrictTraits, Str, Int, Float, List, Bool, Property
+from traits.api import HasStrictTraits, Str, Int, Float, List, Bool, Property
 
-from traitsui.api \
-    import View, Item, TableEditor
+from traitsui.api import Item, ObjectColumn, TableEditor, View
 
-from traitsui.table_column \
-    import ObjectColumn
-
-from traitsui.extras.checkbox_column \
-    import CheckboxColumn
+from traitsui.extras.checkbox_column import CheckboxColumn
 
 
 # Create a specialized column to set the text color differently based upon
@@ -32,7 +24,9 @@ class PlayerColumn(ObjectColumn):
     horizontal_alignment = 'center'
 
     def get_text_color(self, object):
-        return ['light grey', 'black'][object.in_lineup]
+        if object.in_lineup:
+            return 'black'
+        return 'light grey'
 
 
 # The 'players' trait table editor:
@@ -41,21 +35,29 @@ player_editor = TableEditor(
     configurable=False,
     auto_size=False,
     selected_indices='selected_player_indices',
-    columns=[CheckboxColumn(name='in_lineup', label='In Lineup',
-                            width=0.12),
-             PlayerColumn(name='name', editable=False, width=0.24,
-                          horizontal_alignment='left'),
-             PlayerColumn(name='at_bats', label='AB'),
-             PlayerColumn(name='strike_outs', label='SO'),
-             PlayerColumn(name='singles', label='S'),
-             PlayerColumn(name='doubles', label='D'),
-             PlayerColumn(name='triples', label='T'),
-             PlayerColumn(name='home_runs', label='HR'),
-             PlayerColumn(name='walks', label='W'),
-             PlayerColumn(name='average', label='Ave',
-                          editable=False, format='%0.3f')])
-
-# 'Player' class:
+    columns=[
+        CheckboxColumn(name='in_lineup', label='In Lineup', width=0.12),
+        PlayerColumn(
+            name='name',
+            editable=False,
+            width=0.24,
+            horizontal_alignment='left'
+        ),
+        PlayerColumn(name='at_bats', label='AB'),
+        PlayerColumn(name='strike_outs', label='SO'),
+        PlayerColumn(name='singles', label='S'),
+        PlayerColumn(name='doubles', label='D'),
+        PlayerColumn(name='triples', label='T'),
+        PlayerColumn(name='home_runs', label='HR'),
+        PlayerColumn(name='walks', label='W'),
+        PlayerColumn(
+            name='average',
+            label='Ave',
+            editable=False,
+            format='%0.3f'
+        )
+    ]
+)
 
 
 class Player(HasStrictTraits):
@@ -91,10 +93,7 @@ class Team(HasStrictTraits):
 
     # Trait view definitions:
     traits_view = View(
-        Item('players',
-             show_label=False,
-             editor=player_editor
-             ),
+        Item('players', show_label=False, editor=player_editor),
         title='Baseball Team Roster Demo',
         width=0.5,
         height=0.5,
@@ -105,27 +104,32 @@ class Team(HasStrictTraits):
 def random_player(name):
     """ Generates and returns a random player.
     """
-    p = Player(name=name,
-               strike_outs=randint(0, 50),
-               singles=randint(0, 50),
-               doubles=randint(0, 20),
-               triples=randint(0, 5),
-               home_runs=randint(0, 30),
-               walks=randint(0, 50))
+    p = Player(
+        name=name,
+        strike_outs=randint(0, 50),
+        singles=randint(0, 50),
+        doubles=randint(0, 20),
+        triples=randint(0, 5),
+        home_runs=randint(0, 30),
+        walks=randint(0, 50)
+    )
     return p.trait_set(
-        at_bats=p.strike_outs +
-        p.singles +
-        p.doubles +
-        p.triples +
-        p.home_runs +
-        randint(
-            100,
-            200))
+        at_bats=(
+            p.strike_outs + p.singles + p.doubles + p.triples + p.home_runs +
+            randint(100, 200)
+        )
+    )
+
 
 # Create the demo:
-demo = view = Team(players=[random_player(name) for name in [
-    'Dave', 'Mike', 'Joe', 'Tom', 'Dick', 'Harry', 'Dirk', 'Fields', 'Stretch'
-]])
+demo = Team(
+    players=[
+        random_player(name) for name in [
+            'Dave', 'Mike', 'Joe', 'Tom', 'Dick', 'Harry', 'Dirk', 'Fields',
+            'Stretch'
+        ]
+    ]
+)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':

--- a/examples/demo/Advanced/Table_editor_with_context_menu_demo.py
+++ b/examples/demo/Advanced/Table_editor_with_context_menu_demo.py
@@ -18,14 +18,11 @@ is 'affects_average').
 
 from random import randint
 from traits.api import HasStrictTraits, Str, Int, Float, List, Property
-from traitsui.api import View, Item, TableEditor
-from traitsui.menu import Menu, Action
-from traitsui.table_column import ObjectColumn
+from traitsui.api import Action, Item, Menu, ObjectColumn, TableEditor, View
+
 
 # Define a custom table column for handling items which affect the player's
 # batting average:
-
-
 class AffectsAverageColumn(ObjectColumn):
 
     # Define the context menu for the column:
@@ -57,30 +54,26 @@ class AffectsAverageColumn(ObjectColumn):
 # The 'players' trait table editor:
 player_editor = TableEditor(
     editable=True,
-    sortable=True,
+    sortable=False,
     auto_size=False,
-    columns=[ObjectColumn(name='name',
-                          editable=False, width=0.28),
-             AffectsAverageColumn(name='at_bats',
-                                  label='AB'),
-             AffectsAverageColumn(name='strike_outs',
-                                  label='SO'),
-             AffectsAverageColumn(name='singles',
-                                  label='S'),
-             AffectsAverageColumn(name='doubles',
-                                  label='D'),
-             AffectsAverageColumn(name='triples',
-                                  label='T'),
-             AffectsAverageColumn(name='home_runs',
-                                  label='HR'),
-             AffectsAverageColumn(name='walks',
-                                  label='W'),
-             ObjectColumn(name='average',
-                          label='Ave',
-                          editable=False,
-                          width=0.09,
-                          horizontal_alignment='center',
-                          format='%0.3f')]
+    columns=[
+        ObjectColumn(name='name', editable=False, width=0.28),
+        AffectsAverageColumn(name='at_bats', label='AB'),
+        AffectsAverageColumn(name='strike_outs', label='SO'),
+        AffectsAverageColumn(name='singles', label='S'),
+        AffectsAverageColumn(name='doubles', label='D'),
+        AffectsAverageColumn(name='triples', label='T'),
+        AffectsAverageColumn(name='home_runs', label='HR'),
+        AffectsAverageColumn(name='walks', label='W'),
+        ObjectColumn(
+            name='average',
+            label='Ave',
+            editable=False,
+            width=0.09,
+            horizontal_alignment='center',
+            format='%0.3f'
+        )
+    ]
 )
 
 
@@ -120,10 +113,7 @@ class Team(HasStrictTraits):
 
     # Trait view definitions:
     traits_view = View(
-        Item('players',
-             show_label=False,
-             editor=player_editor
-             ),
+        Item('players', show_label=False, editor=player_editor),
         title='Baseball Scoring Demo',
         width=0.5,
         height=0.5,
@@ -134,27 +124,32 @@ class Team(HasStrictTraits):
 def random_player(name):
     """ Generates and returns a random player.
     """
-    p = Player(name=name,
-               strike_outs=randint(0, 50),
-               singles=randint(0, 50),
-               doubles=randint(0, 20),
-               triples=randint(0, 5),
-               home_runs=randint(0, 30),
-               walks=randint(0, 50))
+    p = Player(
+        name=name,
+        strike_outs=randint(0, 50),
+        singles=randint(0, 50),
+        doubles=randint(0, 20),
+        triples=randint(0, 5),
+        home_runs=randint(0, 30),
+        walks=randint(0, 50)
+    )
     return p.trait_set(
-        at_bats=p.strike_outs +
-        p.singles +
-        p.doubles +
-        p.triples +
-        p.home_runs +
-        randint(
-            100,
-            200))
+        at_bats=(
+            p.strike_outs + p.singles + p.doubles + p.triples + p.home_runs +
+            randint(100, 200)
+        )
+    )
+
 
 # Create the demo:
-demo = view = Team(players=[random_player(name) for name in [
-    'Dave', 'Mike', 'Joe', 'Tom', 'Dick', 'Harry', 'Dirk', 'Fields', 'Stretch'
-]])
+demo = Team(
+    players=[
+        random_player(name) for name in [
+            'Dave', 'Mike', 'Joe', 'Tom', 'Dick', 'Harry', 'Dirk', 'Fields',
+            'Stretch'
+        ]
+    ]
+)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':

--- a/examples/demo/Advanced/Table_editor_with_progress_column.py
+++ b/examples/demo/Advanced/Table_editor_with_progress_column.py
@@ -1,3 +1,8 @@
+"""
+A demo to demonstrate the progress column in a TableEditor. The demo only works
+with qt backend.
+"""
+
 import random
 
 from pyface.api import GUI
@@ -37,19 +42,22 @@ class JobManager(HasTraits):
         self.populate()
         GUI.invoke_after(1000, self.process)
 
-    view = View(
-        UItem('jobs', editor=TableEditor(
-            columns=[
-                ObjectColumn(name='name'),
-                ProgressColumn(name='percent_complete'),
-            ]
-        )),
+    traits_view = View(
+        UItem(
+            'jobs',
+            editor=TableEditor(
+                columns=[
+                    ObjectColumn(name='name'),
+                    ProgressColumn(name='percent_complete'),
+                ]
+            )
+        ),
         UItem('start'),
         resizable=True,
     )
 
 
-demo = view = job_manager = JobManager()
+demo = JobManager()
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses #866

These are mostly flake8, formatting and other minor stylistic fixes for `TableEditor` demos in `demos/Advanced`. There are two more `TableEditor` demos that are not dealt with in this PR: `Table_editor_with_live_search_and_cell_editor.py` and `Auto_editable_readonly_table_cells.py` .

`List_editors_demo.py` is broken because of differences between `TableEditor` implementations.

More important changes:
- Added `sortable=False` in demos where this feature isn't important to avoid `TableEditor` implementation differences
- Added `show_toolbar=True` to `List_editors_demo.py` because a lot of the functionality added there wasn't accessible. Now it is accessible but the differences between implementation are more obvious.
- Simplified an expression in demo with checkboxes so that it's easier for beginner programmers to understand.