### PR TITLE
Fix Wx test errors due to comparing None with int

### DIFF
--- a/traitsui/wx/tabular_editor.py
+++ b/traitsui/wx/tabular_editor.py
@@ -937,7 +937,7 @@ class TabularEditor(Editor):
         """
         cws = self._cached_widths
         if cws is not None:
-            cws = [(None, cw)[cw >= 0] for cw in cws]
+            cws = [cw if cw is not None and cw >= 0 else None for cw in cws]
 
         return {"cached_widths": cws}
 


### PR DESCRIPTION
On the CI build for wx (currently allow failures), there are several test errors like this (they started occurring as we make more tests to dispose the UI at the end of the tests):
```
======================================================================
ERROR: test_data_frame_editor_columns (traitsui.tests.ui_editors.test_data_frame_editor.TestDataFrameEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/tests/ui_editors/test_data_frame_editor.py", line 368, in test_data_frame_editor_columns
    pass
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/tests/_tools.py", line 195, in create_ui
    ui.dispose()
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui.py", line 261, in dispose
    self.finish()
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui.py", line 280, in finish
    self.reset(destroy=False)
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui.py", line 318, in reset
    editor.dispose()
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui_editor.py", line 75, in dispose
    self.editor_ui.dispose()
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui.py", line 258, in dispose
    self.save_prefs()
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui.py", line 547, in save_prefs
    toolkit().save_window(self)
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/wx/toolkit.py", line 316, in save_window
    helper.save_window(ui)
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/wx/helper.py", line 142, in save_window
    ui.save_prefs(control.GetPosition() + control.GetSize())
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui.py", line 554, in save_prefs
    db[id] = self.get_prefs(prefs)
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/ui.py", line 571, in get_prefs
    prefs = editor.save_prefs()
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/wx/tabular_editor.py", line 940, in save_prefs
    cws = [(None, cw)[cw >= 0] for cw in cws]
  File "/Users/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/wx/tabular_editor.py", line 940, in <listcomp>
    cws = [(None, cw)[cw >= 0] for cw in cws]
TypeError: '>=' not supported between instances of 'NoneType' and 'int'
```

Comparing `None` with `int` worked on Python 2 but no longer does on Python 3. (`None >= 0` returns `False`)
This PR fixes that.