### PR TITLE
Bring Qt4 back to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,14 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=3.6 TOOLKITS="null pyside2"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt"
+    - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
     - os: osx
-      env: RUNTIME=3.6 TOOLKITS="null pyqt pyside2"
+    - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="wx"
   allow_failures:
     - env: RUNTIME=3.6 TOOLKITS="wx"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
     - os: osx
-    - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
+      env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="wx"
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,13 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "null pyqt pyqt5 pyside2"
+      TOOLKITS: "null"
+    - RUNTIME: '3.6'
+      TOOLKITS: "pyqt"
+    - RUNTIME: '3.6'
+      TOOLKITS: "pyqt5"
+    - RUNTIME: '3.6'
+      TOOLKITS: "pyside2"
     - RUNTIME: '3.6'
       TOOLKITS: "wx"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,7 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "null"
-    - RUNTIME: '3.6'
-      TOOLKITS: "pyside2 pyqt"
+      TOOLKITS: "null pyqt pyqt5 pyside2"
     - RUNTIME: '3.6'
       TOOLKITS: "wx"
 

--- a/etstool.py
+++ b/etstool.py
@@ -140,7 +140,8 @@ doc_dependencies = {
 
 environment_vars = {
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
-    'pyqt': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt5"},
+    'pyqt': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt"},
+    'pyqt5': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt5"},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null'},
 }

--- a/etstool.py
+++ b/etstool.py
@@ -87,8 +87,8 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.5': {'pyside2', 'pyqt', 'null'},
-    '3.6': {'pyside2', 'pyqt', 'wx', 'null'},
+    '3.5': {'pyside2', 'pyqt', 'pyqt5', 'null'},
+    '3.6': {'pyside2', 'pyqt', 'pyqt5', 'wx', 'null'},
 }
 
 # Default Python version to use in the comamnds below if none is specified.

--- a/etstool.py
+++ b/etstool.py
@@ -54,10 +54,10 @@ using::
 
     python etstool.py test_all
 
-Currently supported runtime values are ``2.7`` and ``3.5``, and currently
-supported toolkits are ``null``, ``pyqt``, ``pyside`` and ``wx``.  Not all
-combinations of toolkits and runtimes will work, but the tasks will fail with
-a clear error if that is the case.
+Currently supported runtime values are ``3.5`` and ``3.6``, and currently
+supported toolkits are ``null``, ``pyqt``, ``pyqt5``, ``pyside`` and ``wx``.
+Not all combinations of toolkits and runtimes will work, but the tasks will
+fail with a clear error if that is the case.
 
 Tests can still be run via the usual means in other environments if that suits
 a developer's purpose.
@@ -125,7 +125,8 @@ test_dependencies = {
 extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
-    'pyqt': {'pyqt5'},
+    'pyqt': {'pyqt<4.12'},  # FIXME: build of 4.12-1 appears to be bad
+    'pyqt5': {'pyqt5'},
     # XXX once wxPython 4 is available in EDM, we will want it here
     'wx': set(),
     'null': set()

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -24,6 +24,7 @@ except ImportError:
 __requires__ = ["traits", "pyface>=6.0.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
+    "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt>=5", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
     "demo": ["configobj", "docutils"],


### PR DESCRIPTION
Closes #821 

This PR reverts #815 and #818 but not literally, because `pyside` does not support Python 3 so that does not need to be brought back.

With that `traitsui-test-3.6-pyqt` development environment refers to the PyQt4 environment again! (It is PyQt5 on master currently).