### PR TITLE
TST: Expand test to provide more information for diagnosing

### DIFF
--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -123,8 +123,8 @@ class TestProcessEventsRepeated(unittest.TestCase):
 
         n_left_behind_events = q_object.n_events - actual
         msg = (
-            "Expected {max_n_events} events processed on the objects after "
-            "running process_cascade_events and zero events left. "
+            "Expected {max_n_events} events processed on the objects and zero "
+            "events left on the queue after running process_cascade_events. "
             "Found {actual} processed with {n_left_behind_events} left "
             "behind.".format(
                 max_n_events=max_n_events,

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -115,7 +115,7 @@ class TestProcessEventsRepeated(unittest.TestCase):
         # then
         actual = q_object.n_events
 
-        # If process_cascade_events fails for genuine reasons, then there
+        # If process_cascade_events did not do what it promises, then there
         # are still pending tasks left. Run process events at least the same
         # number of times as max_n_events to verify
         for _ in range(max_n_events):
@@ -133,7 +133,11 @@ class TestProcessEventsRepeated(unittest.TestCase):
             )
         )
         self.assertEqual(n_left_behind_events, 0, msg)
-        self.assertEqual(actual, max_n_events)
+
+        # If the previous assertion passes but this one fails, that means some
+        # events have gone missing, and that would likely be a problem for the
+        # test setup, not for the process_cascade_events.
+        self.assertEqual(actual, max_n_events, msg)
 
     @skip_if_not_wx
     def test_wx_process_events_process_all(self):

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -122,17 +122,18 @@ class TestProcessEventsRepeated(unittest.TestCase):
             QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.AllEvents)
 
         n_left_behind_events = q_object.n_events - actual
-        self.assertEqual(n_left_behind_events, 0)
-        self.assertEqual(
-            actual, max_n_events,
+        msg = (
             "Expected {max_n_events} events processed on the objects after "
-            "running process_cascade_events, found {actual} and there are "
-            "{n_left_behind_events} left behind.".format(
+            "running process_cascade_events and zero events left. "
+            "Found {actual} processed with {n_left_behind_events} left "
+            "behind.".format(
                 max_n_events=max_n_events,
                 actual=actual,
                 n_left_behind_events=n_left_behind_events,
             )
         )
+        self.assertEqual(n_left_behind_events, 0, msg)
+        self.assertEqual(actual, max_n_events)
 
     @skip_if_not_wx
     def test_wx_process_events_process_all(self):


### PR DESCRIPTION
For #951, it was not clear whether it was the test itself being problematic, or whether the test is doing the right thing but the test objective fails.
This PR expands the failure message for the tests on `process_cascade_events`, in order to provide more information for diagnosing the problem, when it does fail.