### PR TITLE
Maint: Expand docstring of process_cascade_events

### DIFF
--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -141,8 +141,11 @@ _TOLERANCE_MILLISECS = 5000
 def process_cascade_events():
     """ Process all events, including events posted by the processed events.
 
-    Use this function with caution, as an infinite cascade of events will
-    cause this function to enter an infinite loop.
+    Cautions:
+    - An infinite cascade of events will cause this function to enter an
+      infinite loop.
+    - There still exists technical difficulties with Qt.
+      See enthought/traitsui#951
     """
     if is_current_backend_qt4():
         from pyface.qt import QtCore


### PR DESCRIPTION
This PR expands the docstring of `process_cascade_events` to refer to #951

I am unable to expand more on that because at this stage I am still not sure what exactly caused the test failure, and what the implications are for when this function is used in other context.
(Note the function is currently just a test utility function private to traitsui)