### PR TITLE
Fix image enum test due to combo box's model reacting to events post dispose

### DIFF
--- a/traitsui/qt4/image_enum_editor.py
+++ b/traitsui/qt4/image_enum_editor.py
@@ -89,6 +89,10 @@ class SimpleEditor(BaseEditor, SimpleEnumEditor):
         )
         return control
 
+    def dispose(self):
+        self.control._dispose()
+        super().dispose()
+
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
             editor.
@@ -169,6 +173,18 @@ class ImageEnumComboBox(QtGui.QComboBox):
             view.setMinimumWidth(width)
         else:
             self.setItemDelegate(delegate)
+
+    def _dispose(self):
+        """ Dispose objects on this widget. To be called by editors.
+        """
+        # Replace the model with the standard one.
+        # After the editor has disposed itself, the widget may not have been
+        # garbage collected and the model still reacts to events fired
+        # afterwards (e.g. rowCount will be called) and runs into exceptions.
+        # QComboBox requires that the model must not be None.
+        # QStandardItemModel is the default model type when a QComboxBox is
+        # created.
+        self.setModel(QtGui.QStandardItemModel())
 
     def paintEvent(self, event):
         """ Reimplemented to draw the ComboBox frame and paint the image

--- a/traitsui/tests/editors/test_image_enum_editor.py
+++ b/traitsui/tests/editors/test_image_enum_editor.py
@@ -333,10 +333,6 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
             self.assertEqual(list(editor.control.GetChildren()), [])
 
     @skip_if_not_qt4
-    @unittest.skipIf(
-        is_linux,
-        "Issue enthought/traitsui#854, possible test interactions on Linux"
-    )
     def test_simple_editor_combobox(self):
         enum_edit = EnumModel()
 

--- a/traitsui/tests/editors/test_image_enum_editor.py
+++ b/traitsui/tests/editors/test_image_enum_editor.py
@@ -278,10 +278,6 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
             process_cascade_events()
             yield ui.get_editors("value")[0]
 
-    @unittest.skipIf(
-        is_linux and is_current_backend_qt4(),
-        "Issue enthought/traitsui#854, possible test interactions on Linux"
-    )
     def test_simple_editor_more_cols(self):
         # Smoke test for setting up an editor with more than one column
         enum_edit = EnumModel()

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -201,10 +201,6 @@ def right_click_item(control, index):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@unittest.skipIf(
-    is_windows and is_current_backend_qt4(),
-    "Issue enthought/traitsui#854; possible test interactions on Windows"
-)
 @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
 @skip_if_null
 class TestListStrEditor(unittest.TestCase):

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -402,7 +402,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
         # This tests the workaround which checks if `factory` is None before
         # using it while resizing the columns.
         # The resize event is processed after UI.dispose is called.
-        # Maybe related to enthought/traitsui#854 and enthought/traits#431
+        # Maybe related to enthought/traits#431
         with store_exceptions_on_all_threads(), \
                 self.report_and_editor(get_view()) as (_, editor):
             editor.adapter.columns = [("Name", "name")]


### PR DESCRIPTION
With Qt4 and Mac OSX, I can reliably reproduce the error seen in https://github.com/enthought/traitsui/issues/854#issuecomment-636715072

Closes #854

This PR fixes the issue by unsetting the item model held by the QComboBox in the ImageEnumEditor.
The issue observed here is that after the test run and the editor is disposed, the `QComboBox` is still kept alive (ideally it should have garbage collected, but that's a separate issue). Consequently its model (an instance of `QAbstractItemModel`) is still responding to events, e.g. its `rowCount` could be called. Calling these methods after the editor is disposed results in attribute error, because the editor factory is no longer available.

As for the larger issue with cleaning widgets, see #431 