### PR TITLE
Expand caution notes and skip test for process_cascade_events on certain conditions

### DIFF
--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -16,7 +16,6 @@
 
 import re
 import sys
-import timeit
 import traceback
 from functools import partial
 from contextlib import contextmanager
@@ -98,7 +97,7 @@ skip_if_null = skipIf(
 )
 
 #: True if current platform is MacOS
-is_mac_os = sys.platform == "Darwin"
+is_mac_os = sys.platform.startswith("darwin")
 
 
 def count_calls(func):
@@ -133,38 +132,24 @@ def filter_tests(test_suite, exclusion_pattern):
     return filtered_test_suite
 
 
-#: If Qt processEvents returns after this many milliseconds, we try again.
-#: False positive is okay.
-_TOLERANCE_MILLISECS = 5000
-
-
 def process_cascade_events():
-    """ Process all events, including events posted by the processed events.
+    """ Process all posted events, and attempt to process new events posted by
+    the processed events.
 
     Cautions:
     - An infinite cascade of events will cause this function to enter an
       infinite loop.
-    - There still exists technical difficulties with Qt.
-      See enthought/traitsui#951
+    - There still exists technical difficulties with Qt. With certain
+      combinations of Qt versions and platforms, the internal loop may return
+      too early such that there are still cascaded events unprocessed.
+      At the very least, events that are already posted prior to calling this
+      function will be processed. See enthought/traitsui#951
     """
     if is_current_backend_qt4():
         from pyface.qt import QtCore
-        start = None
-        timer = timeit.default_timer
-        # Qt won't raise if there are still events to be processed before
-        # the time limit is reached. There are no other safe way to tell
-        # if there are pending events (`hasPendingEvents` is deprecated).
-        # The offset is to account for precision differences between Python
-        # and Qt, false positive triggers another redundant run that should
-        # return immediately so that is fine.
-        # The precision is worse on Windows, typically around ~15 milliseconds.
-        # Give it a 1% error offset, which should be more than enough.
-        while (start is None
-                or (timer() - start) * 1000 >= _TOLERANCE_MILLISECS - 50):
-            start = timer()
-            QtCore.QCoreApplication.processEvents(
-                QtCore.QEventLoop.AllEvents, _TOLERANCE_MILLISECS
-            )
+        event_loop = QtCore.QEventLoop()
+        while event_loop.processEvents(QtCore.QEventLoop.AllEvents):
+            pass
     else:
         GUI.process_events()
 

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -139,11 +139,14 @@ def process_cascade_events():
     Cautions:
     - An infinite cascade of events will cause this function to enter an
       infinite loop.
-    - There still exists technical difficulties with Qt. With certain
-      combinations of Qt versions and platforms, the internal loop may return
-      too early such that there are still cascaded events unprocessed.
-      At the very least, events that are already posted prior to calling this
-      function will be processed. See enthought/traitsui#951
+    - There still exists technical difficulties with Qt. On Qt4 + OSX,
+      QEventLoop.processEvents may report false saying it had found no events
+      to process even though it actually had processed some.
+      Consequently the internal loop breaks too early such that there are
+      still cascaded events unprocessed. Problems are also observed on
+      Qt5 + Appveyor occasionally. At the very least, events that are already
+      posted prior to calling this function will be processed.
+      See enthought/traitsui#951
     """
     if is_current_backend_qt4():
         from pyface.qt import QtCore

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -11,6 +11,7 @@
 
 """ Tests for traitsui.tests._tools """
 
+import sys
 import unittest
 
 from pyface.api import GUI
@@ -18,6 +19,7 @@ from pyface.api import GUI
 from traitsui.tests._tools import (
     is_current_backend_qt4,
     is_current_backend_wx,
+    is_mac_os,
     skip_if_not_qt4,
     skip_if_not_wx,
     process_cascade_events,
@@ -86,6 +88,23 @@ class TestProcessEventsRepeated(unittest.TestCase):
     @skip_if_not_qt4
     def test_qt_process_events_process_all(self):
         from pyface.qt import QtCore
+
+        if QtCore.__version_info__ < (5, 0, 0) and is_mac_os:
+            # On Qt4 and OSX, Qt QEventLoop.processEvents says nothing was "
+            # processed even when there are events processed, causing the "
+            # loop to break too soon. (See enthought/traitsui#951)"
+            self.skipTest(
+                "process_cascade_events is not reliable on Qt4 + OSX"
+            )
+
+        if QtCore.__version_info__[0] >= 5 and sys.platform.startswith("win"):
+            # On Qt4 and some Windows, Qt QEventLoop.processEvents says
+            # nothing was processed even when there are events processed,
+            # causing the loop to break too soon.
+            # (See enthought/traitsui#951)
+            self.skipTest(
+                "process_cascade_events is not reliable on Qt4 + some windows"
+            )
 
         def cleanup(q_object):
             q_object.deleteLater()

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -97,15 +97,6 @@ class TestProcessEventsRepeated(unittest.TestCase):
                 "process_cascade_events is not reliable on Qt4 + OSX"
             )
 
-        if QtCore.__version_info__[0] == 5 and sys.platform.startswith("win"):
-            # On Qt5 and some Windows, Qt QEventLoop.processEvents says
-            # nothing was processed even when there are events processed,
-            # causing the loop to break too soon.
-            # (See enthought/traitsui#951)
-            self.skipTest(
-                "process_cascade_events is not reliable on Qt5 + some Windows"
-            )
-
         def cleanup(q_object):
             q_object.deleteLater()
             # If the test fails, run process events at least the same

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -97,13 +97,13 @@ class TestProcessEventsRepeated(unittest.TestCase):
                 "process_cascade_events is not reliable on Qt4 + OSX"
             )
 
-        if QtCore.__version_info__[0] >= 5 and sys.platform.startswith("win"):
-            # On Qt4 and some Windows, Qt QEventLoop.processEvents says
+        if QtCore.__version_info__[0] == 5 and sys.platform.startswith("win"):
+            # On Qt5 and some Windows, Qt QEventLoop.processEvents says
             # nothing was processed even when there are events processed,
             # causing the loop to break too soon.
             # (See enthought/traitsui#951)
             self.skipTest(
-                "process_cascade_events is not reliable on Qt4 + some windows"
+                "process_cascade_events is not reliable on Qt5 + some Windows"
             )
 
         def cleanup(q_object):


### PR DESCRIPTION
After some digging, the issue in #951 was due to:

- `QtCore.QEventLoop.processEvents` may misreport whether it has processed some pending events on certain platforms, build conditions and Qt version.
- The ability to process cascade events relies on looping over the result of `QEventLoop.processEvents`: If it returns true, run it again. However, when it erroneously returns false, the loop can break too early, leaving cascaded events unprocessed.

This has been observed on Qt5 + Appveyor, and Qt4 + OSX.

This PR:
- Expand docstring of `process_cascade_events` to note the situation. At worst, it is as good as `processEvents` which process only the current snapshots of events. At best, it can achieve what we often wanted in tests.
- Skip the tests for the problematic Qt version and platform combination. The tests are still run on Linux.
- Rewrote the function to do away with the timer. Using the returned value from `QEventLoop.processEvents` in a loop with a time limit is essentially what `QCoreApplication.processEvents(flags, max_time)` is doing. Here we remove the timer part.

Required for #971 to bring Qt4 back to CI