### PR TITLE
Update appveyor setting to include maint/7.0 branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ matrix:
 branches:
   only:
     - master
-    - maint/6.1
+    - maint/7.0
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt


### PR DESCRIPTION
Targeting `maint/7.0` so that we can run the test suites on Appveyor.
In preparation for 7.0.1 release.