### PR TITLE
Demo: Use a smaller directory as the default root for an example script

### DIFF
--- a/examples/demo/Advanced/Table_editor_with_live_search_and_cell_editor.py
+++ b/examples/demo/Advanced/Table_editor_with_live_search_and_cell_editor.py
@@ -77,7 +77,7 @@ Finally:
 #-- Imports --------------------------------------------------------------
 
 from os \
-    import walk, getcwd, listdir
+    import walk, listdir
 
 from os.path \
     import basename, dirname, splitext, join
@@ -103,6 +103,8 @@ FileTypes = {
     'Java': ['.java'],
     'Ruby': ['.rb']
 }
+
+DEFAULT_ROOT = dirname(__file__)
 
 #-- The Live Search table editor definition ------------------------------
 
@@ -171,7 +173,7 @@ table_editor = TableEditor(
 class LiveSearch(HasTraits):
 
     # The currenty root directory being searched:
-    root = Directory(getcwd(), entries=10)
+    root = Directory(DEFAULT_ROOT, entries=10)
 
     # Should sub directories be included in the search:
     recursive = Bool(True)
@@ -288,7 +290,7 @@ class LiveSearch(HasTraits):
     def _get_source_files(self):
         root = self.root
         if root == '':
-            root = getcwd()
+            root = DEFAULT_ROOT
 
         file_types = FileTypes[self.file_type]
         if self.recursive:


### PR DESCRIPTION
Part of #866.

The `examples/demo/Advanced/Table_editor_with_live_search_and_cell_editor.py` example takes a long time to start up if one happens to run it from a directory that contains lots of files (e.g. a directory that contains many python virtual environment).
This PR changes the default folder to the directory where the example is, which is a much smaller folder. Now starting up the example is reasonably fast wherever you run it from.