### PR TITLE
Fix invalid value in Item not being used

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -28,6 +28,7 @@ __extras_require__ = {
     "pyqt5": ["pyqt>=5", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
     "demo": ["configobj", "docutils"],
+    "test": ["packaging"],
 }
 
 

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -120,16 +120,6 @@ class Editor(HasPrivateTraits):
     #: The trait the editor is editing (not its value, but the trait itself):
     value_trait = Property()
 
-    #: Function to use for string formatting
-    format_func = Callable()
-
-    #: Format string to use for formatting (used if **format_func** is not set)
-    format_str = Str()
-
-    #: The extended trait name of the trait containing editor invalid state
-    #: status:
-    invalid_trait_name = Str()
-
     #: The current editor invalid state status:
     invalid = Bool(False)
 
@@ -193,12 +183,7 @@ class Editor(HasPrivateTraits):
     def string_value(self, value, format_func=None):
         """ Returns the text representation of a specified object trait value.
 
-        If the **format_func** attribute is set on the editor, then this method
-        calls that function to do the formatting.  If the **format_str**
-        attribute is set on the editor, then this method uses that string for
-        formatting. If neither attribute is set, then this method just calls
-        the appropriate text type to format.
-
+        This simply delegates to the factory's `string_value` method.
         Sub-classes may choose to override the default implementation.
 
         Parameters
@@ -208,16 +193,7 @@ class Editor(HasPrivateTraits):
         format_func : callable or None
             A function that takes a value and returns a string.
         """
-        if self.format_func is not None:
-            return self.format_func(value)
-
-        if self.format_str != "":
-            return self.format_str % value
-
-        if format_func is not None:
-            return format_func(value)
-
-        return str(value)
+        return self.factory.string_value(value, format_func)
 
     def restore_prefs(self, prefs):
         """ Restores saved user preference information for the editor.
@@ -494,7 +470,7 @@ class Editor(HasPrivateTraits):
                 raise
 
         # Synchronize the application invalid state status with the editor's:
-        self.sync_value(self.invalid_trait_name, "invalid", "from")
+        self.sync_value(self.factory.invalid, "invalid", "from")
 
     # ------------------------------------------------------------------------
     # private methods

--- a/traitsui/editor_factory.py
+++ b/traitsui/editor_factory.py
@@ -135,9 +135,6 @@ class EditorFactory(HasPrivateTraits):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )
 
     def custom_editor(self, ui, object, name, description, parent):
@@ -150,9 +147,6 @@ class EditorFactory(HasPrivateTraits):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )
 
     def text_editor(self, ui, object, name, description, parent):
@@ -165,9 +159,6 @@ class EditorFactory(HasPrivateTraits):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )
 
     def readonly_editor(self, ui, object, name, description, parent):
@@ -180,9 +171,6 @@ class EditorFactory(HasPrivateTraits):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )
 
     # -------------------------------------------------------------------------
@@ -210,6 +198,26 @@ class EditorFactory(HasPrivateTraits):
                 if index == len(editor_factory_modules) - 1:
                     raise e
         return None
+
+    def string_value(self, value, format_func=None):
+        """ Returns the text representation of a specified object trait value.
+
+        If the **format_func** attribute is set on the editor factory, then
+        this method calls that function to do the formatting.  If the
+        **format_str** attribute is set on the editor factory, then this
+        method uses that string for formatting. If neither attribute is
+        set, then this method just calls the appropriate text type to format.
+        """
+        if self.format_func is not None:
+            return self.format_func(value)
+
+        if self.format_str != "":
+            return self.format_str % value
+
+        if format_func is not None:
+            return format_func(value)
+
+        return str(value)
 
     # -------------------------------------------------------------------------
     #  Property getters

--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -110,8 +110,8 @@ class ArrayStructure(HasTraits):
         content = []
         shape = object.shape
         items = []
-        format_func = self.editor.format_func
-        format_str = self.editor.format_str
+        format_func = self.editor.factory.format_func
+        format_str = self.editor.factory.format_str
         for i in range(shape[0]):
             name = "f%d" % i
             self.add_trait(
@@ -146,8 +146,8 @@ class ArrayStructure(HasTraits):
     def _two_dim_view(self, object, style, width, trait):
         content = []
         shape = object.shape
-        format_func = self.editor.format_func
-        format_str = self.editor.format_str
+        format_func = self.editor.factory.format_func
+        format_str = self.editor.factory.format_str
         for i in range(shape[0]):
             items = []
             for j in range(shape[1]):

--- a/traitsui/editors/csv_list_editor.py
+++ b/traitsui/editors/csv_list_editor.py
@@ -357,9 +357,6 @@ class CSVListEditor(TextEditor):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )
 
     def custom_editor(self, ui, object, name, description, parent):
@@ -373,9 +370,6 @@ class CSVListEditor(TextEditor):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )
 
     def text_editor(self, ui, object, name, description, parent):
@@ -389,9 +383,6 @@ class CSVListEditor(TextEditor):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )
 
     def readonly_editor(self, ui, object, name, description, parent):
@@ -405,7 +396,4 @@ class CSVListEditor(TextEditor):
             object=object,
             name=name,
             description=description,
-            format_func=self.format_func,
-            format_str=self.format_str,
-            invalid_trait_name=self.invalid,
         )

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -848,23 +848,24 @@ class _GroupPanel(object):
 
                     editor_factory = ToolkitEditorFactory()
 
+                # If the item has formatting traits set them in the editor
+                # factory:
+                if item.format_func is not None:
+                    editor_factory.format_func = item.format_func
+
+                if item.format_str != "":
+                    editor_factory.format_str = item.format_str
+
+                # If the item has an invalid state extended trait name, set it
+                # in the editor factory:
+                if item.invalid != "":
+                    editor_factory.invalid = item.invalid
+
             # Create the requested type of editor from the editor factory:
             factory_method = getattr(editor_factory, item.style + "_editor")
             editor = factory_method(
                 ui, object, name, item.tooltip, None
             ).trait_set(item=item, object_name=item.object)
-
-            # If the item has formatting traits set them in the editor:
-            if item.format_func is not None:
-                editor.format_func = item.format_func
-
-            if item.format_str != "":
-                editor.format_str = item.format_str
-
-            # If the item has an invalid state extended trait name, set it
-            # in the editor:
-            if item.invalid != "":
-                editor.invalid_trait_name = item.invalid
 
             # Tell the editor to actually build the editing widget.  Note that
             # "inner" is a layout.  This shouldn't matter as individual editors

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -12,6 +12,9 @@
 import contextlib
 import unittest
 
+from packaging.version import Version
+
+from traits import __version__ as TRAITS_VERSION
 from traits.api import (
     HasTraits,
     Str,
@@ -246,8 +249,15 @@ class TestTextEditor(unittest.TestCase):
 
             self.assertEqual(foo.name, "NEW\n")
 
+    @unittest.skipUnless(
+        Version(TRAITS_VERSION) >= Version("6.1.0"),
+        "This test requires traits >= 6.1.0"
+    )
     def test_format_func_used(self):
         # Regression test for enthought/traitsui#790
+        # The test will fail with traits < 6.1.0 because the bug
+        # is fixed in traits, see enthought/traitsui#980 for moving those
+        # relevant code to traitsui.
         foo = Foo(name="william", nickname="bill")
         view = View(
             Item("name", format_func=lambda s: s.upper()),

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -32,6 +32,8 @@ class Foo(HasTraits):
 
     name = Str()
 
+    nickname = Str()
+
 
 def get_view(style, auto_set):
     """ Return the default view for the Foo object.
@@ -46,6 +48,15 @@ def get_view(style, auto_set):
     return View(
         Item("name", editor=TextEditor(auto_set=auto_set), style=style)
     )
+
+
+def get_text(editor):
+    """ Return the text from the widget for checking.
+    """
+    if is_current_backend_qt4():
+        return editor.control.text()
+    else:
+        raise unittest.SkipTest("Not implemented for the current toolkit.")
 
 
 def set_text(editor, text):
@@ -234,3 +245,17 @@ class TestTextEditor(unittest.TestCase):
             process_cascade_events()
 
             self.assertEqual(foo.name, "NEW\n")
+
+    def test_format_func_used(self):
+        # Regression test for enthought/traitsui#790
+        foo = Foo(name="william", nickname="bill")
+        view = View(
+            Item("name", format_func=lambda s: s.upper()),
+            Item("nickname"),
+        )
+        with store_exceptions_on_all_threads(), \
+                create_ui(foo, dict(view=view)) as ui:
+            name_editor, = ui.get_editors("name")
+            nickname_editor, = ui.get_editors("nickname")
+            self.assertEqual(get_text(name_editor), "WILLIAM")
+            self.assertEqual(get_text(nickname_editor), "bill")

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -402,8 +402,8 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
 
         editor.dispose()
 
-    # Test synchronizing built-in trait values between from factory
-    # to editor.
+    # Test synchronizing built-in trait values between factory
+    # and editor.
 
     def test_factory_sync_invalid_state(self):
         # Test when object's trait that sets the invalid state changes,

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -144,6 +144,9 @@ class UserObject(HasTraits):
     #: An event user value
     user_event = Event()
 
+    #: A state that is to be synchronized with the editor.
+    invalid_state = Bool()
+
 
 def create_editor(
         context=None,
@@ -398,6 +401,31 @@ class TestEditor(GuiTestAssistant, unittest.TestCase):
         self.assertEqual(value, "other_test")
 
         editor.dispose()
+
+    # Test synchronizing built-in trait values between from factory
+    # to editor.
+
+    def test_factory_sync_invalid_state(self):
+        # Test when object's trait that sets the invalid state changes,
+        # the invalid state on the editor changes
+        factory = StubEditorFactory(invalid="invalid_state")
+        user_object = UserObject(invalid_state=False)
+        context = {
+            "object": user_object,
+        }
+        editor = create_editor(context=context, factory=factory)
+        editor.prepare(None)
+        self.addCleanup(editor.dispose)
+
+        with self.assertTraitChanges(editor, "invalid", count=1):
+            user_object.invalid_state = True
+
+        self.assertTrue(editor.invalid)
+
+        with self.assertTraitChanges(editor, "invalid", count=1):
+            user_object.invalid_state = False
+
+        self.assertFalse(editor.invalid)
 
     # Testing sync_value "from" ---------------------------------------------
 

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -883,6 +883,19 @@ class FillPanel(object):
 
                     editor_factory = ToolkitEditorFactory()
 
+                # If the item has formatting traits set them in the editor
+                # factory:
+                if item.format_func is not None:
+                    editor_factory.format_func = item.format_func
+
+                if item.format_str != "":
+                    editor_factory.format_str = item.format_str
+
+                # If the item has an invalid state extended trait name, set it
+                # in the editor factory:
+                if item.invalid != "":
+                    editor_factory.invalid = item.invalid
+
             # Set up the background image (if used):
             item_panel = panel
 
@@ -891,18 +904,6 @@ class FillPanel(object):
             editor = factory_method(
                 ui, object, name, item.tooltip, item_panel
             ).trait_set(item=item, object_name=item.object)
-
-            # If the item has formatting traits set them in the editor:
-            if item.format_func is not None:
-                editor.format_func = item.format_func
-
-            if item.format_str != "":
-                editor.format_str = item.format_str
-
-            # If the item has an invalid state extended trait name, set it
-            # in the editor:
-            if item.invalid != "":
-                editor.invalid_trait_name = item.invalid
 
             # Tell editor to actually build the editing widget:
             editor.prepare(item_panel)


### PR DESCRIPTION
Closes #983 
Revert #859

The issue in #790 is fixed by upgrading to traits 6.1 (see [PR in traits](https://github.com/enthought/traits/pull/1032)).  Attempt to fix the issue independently causes breakages as shown in #983. So this PR reverts those changes.  Users who would like #790 being fixed will have to upgrade traits to >= 6.1 instead.

It might be easier to review this commit-by-commit. This PR:
(1) Add a regression test for #790, because this PR will revert the PR that aims at fixing the issue independently of traits. This test passes on master even with traits 6.0
(2) Add failing tests for #983
(3) Revert #859. This allows the tests added for #983 to pass. The test added for #790 still passes if traits version is 6.1, but fails if traits version is less than 6.1
(4) Skip the test added for #790 if the traits in the environment has version < 6.1. (On CI we have traits 6.1, but traits 6.0 is still supported for anyone installing traitsui 7.x from PyPI and therefore the test should account for that)
(5) Add `packaging` in the test dependencies for parsing version strings.

This PR will need to be backported for 7.0.1 release.