### PR TITLE
FIX: Enforce underscore for click command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -148,7 +148,11 @@ environment_vars = {
 }
 
 
-@click.group()
+def normalize(name):
+    return name.replace("_", "-")
+
+
+@click.group(context_settings={"token_normalize_func": normalize})
 def cli():
     pass
 


### PR DESCRIPTION
Applying a quick fix for [Command names with underscores must be invoked with dashes instead when upgrading from 6.7 to 7.0](https://github.com/pallets/click/issues/1123)

This will make the documentation command consistent: ```python etstools.py test_all```