### PR TITLE
Revert "Avoid Qt5 crash from out-of-sync user_widths."

### DIFF
--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -923,9 +923,8 @@ class _TableView(QtGui.QTableView):
         This affects the column widths when not using auto-sizing.
         """
         if not self._is_resizing:
-            num_cols = len(self._editor.adapter.columns)
-            if self._user_widths is None or len(self._user_widths) != num_cols:
-                self._user_widths = [None] * num_cols
+            if self._user_widths is None:
+                self._user_widths = [None] * len(self._editor.adapter.columns)
             self._user_widths[index] = new
             if (self._editor.factory is not None
                     and not self._editor.factory.auto_resize):


### PR DESCRIPTION
Reverts enthought/traitsui#989 since a better fix was made in #897 . My apologies again.

cc @kitchoi @corranwebster 