### PR TITLE
Unset ListStrModel from the ListStrEditor view upon dispose

### DIFF
--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -123,6 +123,7 @@ class _ListStrEditor(Editor):
 
         if factory.title or factory.title_name:
             header_view = QtGui.QHeaderView(QtCore.Qt.Horizontal, self.control)
+            self._header_view = header_view
             header_view.setModel(self.model)
             header_view.setMaximumHeight(header_view.sizeHint().height())
             if is_qt5:
@@ -130,6 +131,8 @@ class _ListStrEditor(Editor):
             else:
                 header_view.setResizeMode(QtGui.QHeaderView.Stretch)
             layout.addWidget(header_view)
+        else:
+            self._header_view = None
 
         self.list_view = _ListView(self)
         layout.addWidget(self.list_view)
@@ -200,6 +203,11 @@ class _ListStrEditor(Editor):
         self.on_trait_change(
             self.refresh_editor, "adapter.+update", remove=True
         )
+        if self._header_view is not None:
+            self._header_view.setModel(None)
+            self._header_view = None
+
+        self.list_view._dispose()
 
         super(Editor, self).dispose()
 
@@ -511,6 +519,11 @@ class _ListView(QtGui.QListView):
 
         # Configure context menu behavior
         self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+
+    def _dispose(self):
+        """ Clean up states in this view.
+        """
+        self.setModel(None)
 
     def keyPressEvent(self, event):
         """ Reimplemented to support edit, insert, and delete by keyboard.


### PR DESCRIPTION
Related to #431 and resolves part of #986.
The error seen in #986 is revealed by unskipping the test in https://github.com/enthought/traitsui/pull/974.
As it turns out, events are still received by the `ListStrModel` used in the view of `ListStrEditor` after the UI is disposed.
The issue occurs most frequently in Qt4.

This PR attempts to resolve this by doing the same thing in #974: Unset the item model from the view in the editor dispose.
Since the error is sporadic, I might need to rebuild this a few time to verify the issue is fixed. 

This does not completely _fix_ #986 because there are other instances of `QAbstractItemModel` which we are not unsetting. 