### PR TITLE
FIX: Fix for PyQt 5.15 int

### DIFF
--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -141,7 +141,7 @@ class SimpleSliderEditor(BaseRangeEditor):
 
         # The default size is a bit too big and probably doesn't need to grow.
         sh = text.sizeHint()
-        sh.setWidth(sh.width() / 2)
+        sh.setWidth(sh.width() // 2)
         text.setMaximumSize(sh)
 
         panel.addWidget(text)
@@ -417,7 +417,7 @@ class LargeRangeSliderEditor(BaseRangeEditor):
 
         # The default size is a bit too big and probably doesn't need to grow.
         sh = text.sizeHint()
-        sh.setWidth(sh.width() / 2)
+        sh.setWidth(sh.width() // 2)
         text.setMaximumSize(sh)
 
         panel.addWidget(text)


### PR DESCRIPTION
Fixes this error I get on PyQt 5.15:
```
  File "/home/larsoner/python/traitsui/traitsui/qt4/range_editor.py", line 144, in init
    sh.setWidth(sh.width() / 2)
TypeError: setWidth(self, int): argument 1 has unexpected type 'float'
```