### PR TITLE
Fix a true division to be integer division

### DIFF
--- a/traitsui/qt4/extra/bounds_editor.py
+++ b/traitsui/qt4/extra/bounds_editor.py
@@ -50,7 +50,7 @@ class _BoundsEditor(Editor):
 
         # The default size is a bit too big and probably doesn't need to grow.
         sh = self._label_lo.sizeHint()
-        sh.setWidth(sh.width() / 2)
+        sh.setWidth(sh.width() // 2)
         self._label_lo.setMaximumSize(sh)
 
         self.control.slider = slider = RangeSlider(QtCore.Qt.Horizontal)
@@ -71,7 +71,7 @@ class _BoundsEditor(Editor):
 
         # The default size is a bit too big and probably doesn't need to grow.
         sh = self._label_hi.sizeHint()
-        sh.setWidth(sh.width() / 2)
+        sh.setWidth(sh.width() // 2)
         self._label_hi.setMaximumSize(sh)
 
         self.set_tooltip(slider)


### PR DESCRIPTION
`setWidth` expects an integer rather than a float.

See also #999.