### PR TITLE
Skip test for process_cascade_events with Qt <= 5.12.6 and Appveyor

### DIFF
--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -100,7 +100,7 @@ class TestProcessEventsRepeated(unittest.TestCase):
 
         is_appveyor = os.environ.get("APPVEYOR", None) is not None
         if QtCore.__version__info__ <= (5, 12, 6) and is_appveyor:
-            # With Qt4 and Qt 5.12.6 + Appveyor, process_cascade_events may
+            # With Qt + Appveyor, process_cascade_events may
             # _occasionally_ break out of its loop too early. This is only
             # seen on Appveyor but has not been reproducible on other Windows
             # machines (See enthought/traitsui#951)

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -11,6 +11,7 @@
 
 """ Tests for traitsui.tests._tools """
 
+import os
 import sys
 import unittest
 
@@ -95,6 +96,16 @@ class TestProcessEventsRepeated(unittest.TestCase):
             # loop to break too soon. (See enthought/traitsui#951)"
             self.skipTest(
                 "process_cascade_events is not reliable on Qt4 + OSX"
+            )
+
+        is_appveyor = os.environ.get("APPVEYOR", None) is not None
+        if QtCore.__version__info__ <= (5, 12, 6) and is_appveyor:
+            # With Qt4 and Qt 5.12.6 + Appveyor, process_cascade_events may
+            # _occasionally_ break out of its loop too early. This is only
+            # seen on Appveyor but has not been reproducible on other Windows
+            # machines (See enthought/traitsui#951)
+            self.skipTest(
+                "process_cascade_events is not reliable on Qt + Appveyor"
             )
 
         def cleanup(q_object):

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -99,7 +99,7 @@ class TestProcessEventsRepeated(unittest.TestCase):
             )
 
         is_appveyor = os.environ.get("APPVEYOR", None) is not None
-        if QtCore.__version__info__ <= (5, 12, 6) and is_appveyor:
+        if QtCore.__version_info__ <= (5, 12, 6) and is_appveyor:
             # With Qt + Appveyor, process_cascade_events may
             # _occasionally_ break out of its loop too early. This is only
             # seen on Appveyor but has not been reproducible on other Windows


### PR DESCRIPTION
We have now seen more information for the test failure on Appveyor (see #951). For it is either not possible or very costly to try to fix/workaround this specific Qt issue, to avoid slowing down development, this PR skips the relevant test for Qt <= 5.12.6 and Appveyor.

The condition for the skip is set to be very specific so that we can detect whether the issue exists with newer versions of Qt and/or future images of Appveyor and/or other Windows machines. If we need to expand the range and include Windows more generally, we can do that with the relevant incident being tracked.