### PR TITLE
Fix demo application's previous and next buttons if no items are selected

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -1028,6 +1028,8 @@ class Demo(ModelView):
         info.ui.title = self.title
 
     def _get__next_node(self):
+        if self.selected_node is None:
+            return None
         next = None
         node = self.selected_node
         children = node.tno_get_children(node)
@@ -1048,6 +1050,8 @@ class Demo(ModelView):
         return next
 
     def _get__previous_node(self):
+        if self.selected_node is None:
+            return None
         previous = None
         node = self.selected_node
         parent = node.parent

--- a/ets-demo/etsdemo/tests/test_app.py
+++ b/ets-demo/etsdemo/tests/test_app.py
@@ -15,9 +15,13 @@ import unittest
 from xml.etree import ElementTree as ET
 
 from etsdemo.app import (
+    Demo,
     DemoPath,
     extract_docstring_from_source,
     parse_source,
+    next_tool,
+    previous_tool,
+    parent_tool,
 )
 
 HTML_NS_PREFIX = "{http://www.w3.org/1999/xhtml}"
@@ -25,6 +29,51 @@ HTML_NS_PREFIX = "{http://www.w3.org/1999/xhtml}"
 
 def get_html_tag(tag):
     return HTML_NS_PREFIX + tag
+
+
+def get_action_enabled(action, model_view):
+    """ Helper funciton to return if a tool is enabled.
+
+    Parameters
+    ----------
+    action : Action
+    model_view : ModelView
+    """
+    context = model_view.trait_get()
+    context.update(model_view.trait_context())
+    return eval(
+        compile(action.enabled_when, "<string>", "eval"),
+        {},
+        context,
+    )
+
+
+class TestDemo(unittest.TestCase):
+    """ Test actions on the Demo class. """
+
+    def test_demo_previous_button_default(self):
+        # Make sure the previous button behaves in the default state.
+        # This ensures the enable flag can be computed (instead of crashing),
+        # and the action allowed by it does not crash.
+        demo = Demo(model=DemoPath())
+        if get_action_enabled(previous_tool, demo):
+            demo.perform(None, next_tool, None)
+
+    def test_demo_next_button_default(self):
+        # Make sure the next button behaves in the default state.
+        # This ensures the enable flag can be computed (instead of crashing),
+        # and the action allowed by it does not crash.
+        demo = Demo(model=DemoPath())
+        if get_action_enabled(next_tool, demo):
+            demo.perform(None, next_tool, None)
+
+    def test_demo_parent_button_default(self):
+        # Make sure the parent button behaves in the default state.
+        # This ensures the enable flag can be computed (instead of crashing),
+        # and the action allowed by it does not crash.
+        demo = Demo(model=DemoPath())
+        if get_action_enabled(parent_tool, demo):
+            demo.perform(None, parent_tool, None)
 
 
 class TestDemoPathDescription(unittest.TestCase):


### PR DESCRIPTION
This PR fixes errors from the demo application if one tries to press the previous or the next button when the selected node is not defined.

Before the fix, these two buttons are erroneously enabled (there is a try-except around the evaluation of `enabled_when`):
![Screenshot 2020-07-17 at 13 23 12](https://user-images.githubusercontent.com/3673984/87785803-b9d5bf80-c830-11ea-8b2f-2b8e2dec0225.png)
If one tries to press any of the previous and next buttons, the app would crash because `selected_node` is None.

After the fix, the buttons are correctly disabled:
![Screenshot 2020-07-17 at 13 24 51](https://user-images.githubusercontent.com/3673984/87785892-e984c780-c830-11ea-99ea-9d20502ef310.png)

The "Parent" action already has this `if self.selected_node is None` guard, but the previous and next buttons don't. This PR adds the same guards and add the tests that fail before the fix.
A similar test is added for the "Parent" action.

I decided not to assert in the tests if the buttons are by default disabled, because they can be enabled in general, e.g. if the `selected_node` is not None by default. 