### PR TITLE
Fix symlink path for examples/demo

### DIFF
--- a/examples/demo
+++ b/examples/demo
@@ -1,1 +1,1 @@
-traitsui/examples/demo
+../traitsui/examples/demo


### PR DESCRIPTION
The symbolic link to the new location of the demo files should be relative to where the symbolic link file is.
This PR fixes this. Now GitHub can recognize the symbolic link being a directory (though it still won't bring you directly to the actual folder).