### PR TITLE
Switch to console_scripts to workaround crash on Windows

### DIFF
--- a/ets-demo/setup.py
+++ b/ets-demo/setup.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
         license="BSD",
         python_requires=">=3.5",
         entry_points={
-            "gui_scripts": [
+            "console_scripts": [
                 "etsdemo = etsdemo.main:main",
             ],
             "enthought_app_metadata": [


### PR DESCRIPTION
This is not a fix but a workaround for #1032

Crashing on Windows is bad enough we should avoid that. The one downside is that if one tries to run this application from a desktop shortcut on Windows, it will result in a command line shell being open as well (which is a bit ugly), but that is better than crashing.