### PR TITLE
Doc: Remove dynamic date tied to the release date

### DIFF
--- a/docs/source/tutorials/traits_ui_scientific_app.rst
+++ b/docs/source/tutorials/traits_ui_scientific_app.rst
@@ -6,12 +6,8 @@ Writing a graphical application for scientific programming using TraitsUI |versi
 
 **A step by step guide for a non-programmer**
 
-.. |date| date::
-
 :Author:
-    Gael Varoquaux
-:Date:
-    |date|
+    Gael Varoquaux    
 :License:
     BSD
 


### PR DESCRIPTION
The date in this section is created with the release: https://docs.enthought.com/traitsui/tutorials/traits_ui_scientific_app.html

This sends a misleading message that the article was written as recently as the last release was made, which isn't true. Since it is at best misleading, this PR removes the date. We can add the original date back later or a last update date later if there is value in doing so.