### PR TITLE
TST: Resolve warnings from QItemSelectionModel with Qt5

### DIFF
--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -227,6 +227,9 @@ class CustomEditor(SimpleTextEditor):
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
+        self._model.beginResetModel()
+        self._model.endResetModel()
+
         if self.control is not None:
             self.control.doubleClicked.disconnect(self._on_dclick)
 

--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -196,6 +196,9 @@ class _ListStrEditor(Editor):
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
+        self.model.beginResetModel()
+        self.model.endResetModel()
+
         self.context_object.on_trait_change(
             self.update_editor, self.extended_name + "_items", remove=True
         )

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -327,6 +327,8 @@ class TableEditor(Editor, BaseTableEditor):
 
     def dispose(self):
         """ Disposes of the contents of an editor."""
+        self.model.beginResetModel()
+        self.model.endResetModel()
 
         # Make sure that the auxiliary UIs are properly disposed
         if self.toolbar_ui is not None:

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -253,6 +253,9 @@ class TabularEditor(Editor):
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
+        self.model.beginResetModel()
+        self.model.endResetModel()
+
         self.context_object.on_trait_change(
             self.update_editor, self.extended_name + "_items", remove=True
         )


### PR DESCRIPTION
With Qt5, running the tests for the editors result in a lot of warnings like this:
```
$ python -m unittest traitsui.tests.editors
.....QItemSelectionModel: Selecting when no model has been set will result in a no-op.
QItemSelectionModel: Selecting when no model has been set will result in a no-op.
QItemSelectionModel: Selecting when no model has been set will result in a no-op.
...
```

This PR resolves these warnings by reseting the QAbstractItemModel used in various editors's `dispose`.
Related to #431 

I have not fully understood the warnings. But it looks like the right to do: If we are disposing the widget, we should be invalidating any data or structure changes have been posted to the model. 

This also resolves some sporadic errors from the test suite I get when I add some new tests for the table editor (in another test branch of mine). 
