### PR TITLE
Remove desktop shortcut for etsdemo EAM application

### DIFF
--- a/ets-demo/etsdemo/info.py
+++ b/ets-demo/etsdemo/info.py
@@ -28,7 +28,6 @@ def info():
             {
                 "name": "ETS Demo",
                 "command": "etsdemo",
-                "shortcut": "desktop",
                 "icon": ICON,
             },
         ],


### PR DESCRIPTION
This PR removes the desktop shortcut defined in the EAM metadata.
Currently installing an application bundle via the EDM GUI or the command line does not have the option for skipping the shortcuts. For now, we will remove the desktop shortcut until the installer provides an option to skip it.

Closes #1043