### PR TITLE
Set an icon for the demo app main window

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -1090,6 +1090,7 @@ class Demo(ModelView):
             resizable=True,
             width=1200,
             height=700,
+            icon=ImageResource("enthought-icon"),
         )
 
 


### PR DESCRIPTION
Closes #1028

This PR sets the application main window icon.
I decided not to use Python logo to avoid trademark issue, see https://github.com/enthought/traitsui/issues/1028#issuecomment-661980408