### PR TITLE
Separating Pypi long description and readme 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,8 @@ TraitsUI along with all dependencies can be installed in a straightforward way
 using the `Enthought Deployment Manager <http://docs.enthought.com/edm/>`__,
 ``pip`` or other .
 
+.. end_of_long_description
+
 Running the Test Suite
 ----------------------
 

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
             Topic :: Software Development :: Libraries
             """.splitlines() if len(c.strip()) > 0],
         description='traitsui: traits-capable user interfaces',
-        long_description=open('README.rst').read(),
+        long_description=open("README.rst").read().split(".. end_of_long_description")[0],
         long_description_content_type="text/x-rst",
         url='http://docs.enthought.com/traitsui',
         download_url='https://github.com/enthought/traitsui',


### PR DESCRIPTION
Added an explicit separator before the Running the Test Suite section.
So now, what is rendered on Pypi will simply be the first part of the readme.  Anything found after the seperator will appear on GitHub but not Pypi (content relevant to contributors and less so users such as how to run the test suite)

fixes #1017 