### PR TITLE
TST: Switch on default warning flag for CI test command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -248,11 +248,11 @@ def test(runtime, toolkit, environment):
 
     parameters["integrationtests"] = os.path.abspath("integrationtests")
     commands = [
-        "edm run -e {environment} -- coverage run -p -m unittest discover -v traitsui",
+        "edm run -e {environment} -- python -W default -m coverage run -p -m unittest discover -v traitsui",
         # coverage run prevents local images to be loaded for demo examples
         # which are not defined in Python packages. Run with python directly
         # instead.
-        "edm run -e {environment} -- python -m unittest discover -v {integrationtests}",
+        "edm run -e {environment} -- python -W default -m unittest discover -v {integrationtests}",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui


### PR DESCRIPTION
Deprecation warnings triggered during test runs are visible, but deprecation warnings triggered prior to when a unittest test case is loaded are by default hidden from the console.

With that, deprecation warnings from trait types definition do not show up from running the current test command, because the warnings occur at import time.

This PR adds the `-W default` flag to make these warnings visible so that we can fix them more easily. 