### PR TITLE
Fix deprecation warning about trait_get

### DIFF
--- a/traitsui/key_bindings.py
+++ b/traitsui/key_bindings.py
@@ -194,7 +194,7 @@ class KeyBindings(HasPrivateTraits):
         """ Returns a clone of the KeyBindings object.
         """
         return self.__class__(*self.bindings, **traits).trait_set(
-            **self.get("prefix", "suffix")
+            **self.trait_get("prefix", "suffix")
         )
 
     def dispose(self):


### PR DESCRIPTION
This fixes a deprecation warning visible from running the tests on the examples.
