### PR TITLE
remove the ALIGN_CENTRE_VERTICAL FLAG to avoid error

### DIFF
--- a/traitsui/wx/scrubber_editor.py
+++ b/traitsui/wx/scrubber_editor.py
@@ -333,8 +333,6 @@ class _ScrubberEditor(Editor):
         drop_down.Bind(wx.EVT_KILL_FOCUS, self._enum_completed)
 
     def _pop_up_text(self):
-        print("Im popping up text")
-        print(self.control)
         control = self.control
         self._text = text = wx.TextCtrl(
             control,
@@ -448,16 +446,11 @@ class _ScrubberEditor(Editor):
     def _set_focus(self, event):
         """ Handle the control getting the keyboard focus.
         """
-        print('SETTING FOCUS')
-        print(self._ignore_focus)
-        print(self._x)
-        print(self._text)
         if (
             (not self._ignore_focus)
             and (self._x is None)
             and (self._text is None)
         ):
-            print("Im in an if statement")
             self._pop_up_editor()
 
         event.Skip()
@@ -465,19 +458,11 @@ class _ScrubberEditor(Editor):
     def _enter_window(self, event):
         """ Handles the mouse entering the window.
         """
-        print('Im entering')
-        print(self._ignore_focus)
-        print(self._x)
-        print(self._text)
-        print(self._hover)
-        print(self._pending)
-        print(self.control)
-
         self._hover = True
 
         self.control.SetCursor(wx.Cursor(wx.CURSOR_HAND))
 
-        if not self._ignore_focus and not self._text:
+        if not self._ignore_focus:
             self._ignore_focus = True
             self.control.SetFocus()
 
@@ -492,25 +477,14 @@ class _ScrubberEditor(Editor):
     def _leave_window(self, event):
         """ Handles the mouse leaving the window.
         """
-        print('Im leaving')
-        print(self._ignore_focus)
-        print(self._x)
-        print(self._hover)
-        print(self._pending)
         self._hover = False
 
         if self.factory.hover_color_ != self.factory.color_:
             self.control.Refresh()
 
-
     def _left_down(self, event):
         """ Handles the left mouse being pressed.
         """
-        print("Im clicking")
-        print(self._ignore_focus)
-        print(self._x)
-        print(self._hover)
-        print(self._pending)
         self._x, self._y = event.GetX(), event.GetY()
         self._pending = True
 
@@ -526,11 +500,6 @@ class _ScrubberEditor(Editor):
     def _left_up(self, event):
         """ Handles the left mouse button being released.
         """
-        print("Ive clicked")
-        print(self._ignore_focus)
-        print(self._x)
-        print(self._hover)
-        print(self._pending)
         self.control.ReleaseMouse()
         if self._pending:
             self._pop_up_editor()
@@ -590,13 +559,11 @@ class _ScrubberEditor(Editor):
     def _enter_text(self, event):
         """ Handles the mouse entering the pop-up text control.
         """
-        print("im entering text")
         self._in_text_window = True
 
     def _leave_text(self, event):
         """ Handles the mouse leaving the pop-up text control.
         """
-        print("im leaving text")
         self._in_text_window = False
 
     def _text_completed(self, event):

--- a/traitsui/wx/scrubber_editor.py
+++ b/traitsui/wx/scrubber_editor.py
@@ -333,6 +333,8 @@ class _ScrubberEditor(Editor):
         drop_down.Bind(wx.EVT_KILL_FOCUS, self._enum_completed)
 
     def _pop_up_text(self):
+        print("Im popping up text")
+        print(self.control)
         control = self.control
         self._text = text = wx.TextCtrl(
             control,
@@ -446,11 +448,16 @@ class _ScrubberEditor(Editor):
     def _set_focus(self, event):
         """ Handle the control getting the keyboard focus.
         """
+        print('SETTING FOCUS')
+        print(self._ignore_focus)
+        print(self._x)
+        print(self._text)
         if (
             (not self._ignore_focus)
             and (self._x is None)
             and (self._text is None)
         ):
+            print("Im in an if statement")
             self._pop_up_editor()
 
         event.Skip()
@@ -458,11 +465,19 @@ class _ScrubberEditor(Editor):
     def _enter_window(self, event):
         """ Handles the mouse entering the window.
         """
+        print('Im entering')
+        print(self._ignore_focus)
+        print(self._x)
+        print(self._text)
+        print(self._hover)
+        print(self._pending)
+        print(self.control)
+
         self._hover = True
 
         self.control.SetCursor(wx.Cursor(wx.CURSOR_HAND))
 
-        if not self._ignore_focus:
+        if not self._ignore_focus and not self._text:
             self._ignore_focus = True
             self.control.SetFocus()
 
@@ -477,14 +492,25 @@ class _ScrubberEditor(Editor):
     def _leave_window(self, event):
         """ Handles the mouse leaving the window.
         """
+        print('Im leaving')
+        print(self._ignore_focus)
+        print(self._x)
+        print(self._hover)
+        print(self._pending)
         self._hover = False
 
         if self.factory.hover_color_ != self.factory.color_:
             self.control.Refresh()
 
+
     def _left_down(self, event):
         """ Handles the left mouse being pressed.
         """
+        print("Im clicking")
+        print(self._ignore_focus)
+        print(self._x)
+        print(self._hover)
+        print(self._pending)
         self._x, self._y = event.GetX(), event.GetY()
         self._pending = True
 
@@ -500,6 +526,11 @@ class _ScrubberEditor(Editor):
     def _left_up(self, event):
         """ Handles the left mouse button being released.
         """
+        print("Ive clicked")
+        print(self._ignore_focus)
+        print(self._x)
+        print(self._hover)
+        print(self._pending)
         self.control.ReleaseMouse()
         if self._pending:
             self._pop_up_editor()
@@ -559,11 +590,13 @@ class _ScrubberEditor(Editor):
     def _enter_text(self, event):
         """ Handles the mouse entering the pop-up text control.
         """
+        print("im entering text")
         self._in_text_window = True
 
     def _leave_text(self, event):
         """ Handles the mouse leaving the pop-up text control.
         """
+        print("im leaving text")
         self._in_text_window = False
 
     def _text_completed(self, event):

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -724,8 +724,6 @@ class FillPanel(object):
                 if self.is_horizontal:
                     if subgroup.springy:
                         growable = 1
-                    if subgroup.orientation == "horizontal":
-                        style |= wx.ALIGN_CENTER_VERTICAL
                 sizer.Add(sg_sizer, growable, style, 2)
 
     def add_items(self, content, panel, sizer):


### PR DESCRIPTION
This gets rid of the 
```
wx._core.wxAssertionError: C++ assertion "!(flags & (wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL))" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/sizer.cpp(2114) in DoInsert(): Vertical alignment flags are ignored with wxEXPAND
```
error mentioned in issue #1066  (another example of #828).  However, after this fix is completed, the issue of a segfault on mouseover as mentioned in #434 still occurs.  