### PR TITLE
in etsdemo, make demo tab default tab shown as opposed to output

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -898,6 +898,11 @@ demo_file_view = View(
                 ),
             ),
             Tabbed(
+                UItem(
+                    "demo",
+                    style="custom",
+                    resizable=True,
+                ),
                 Item(
                     "log",
                     style="readonly",
@@ -913,11 +918,6 @@ demo_file_view = View(
                     editor=ShellEditor(share=True),
                     label="Shell",
                     show_label=False
-                ),
-                UItem(
-                    "demo",
-                    style="custom",
-                    resizable=True,
                 ),
             ),
             dock="horizontal",


### PR DESCRIPTION
When a demo is selected, it is convenient to have the demo tab be the default tab shown so that a user can immediately see what the demo does, instead of simply seeing the output. 