### PR TITLE
replace AnimationCtrl object with GenericAnimationCtrl in animated_gif_editor.py

### DIFF
--- a/traitsui/examples/demo/Extras/animated_GIF.py
+++ b/traitsui/examples/demo/Extras/animated_GIF.py
@@ -3,6 +3,7 @@
 
 """
 This demo shows you how to use animated GIF files in a traits user interface.
+Note that this demo only works with wx backend.
 """
 
 from os.path import join, dirname, abspath

--- a/traitsui/tests/editors/test_animatedGIF_editor.py
+++ b/traitsui/tests/editors/test_animatedGIF_editor.py
@@ -8,14 +8,14 @@
 #
 #  Thanks for using Enthought open source!
 #
-""" Tests to exercise logic for layouts, e.g. VGroup, HGroup.
+""" Tests pertaining to the AnimatedGIFEditor
 """
 
 import unittest
 
 import pkg_resources
 
-from traits.api import Bool, File, HasTraits,
+from traits.api import Bool, File, HasTraits
 from traitsui.api import Item, View
 from traitsui.tests._tools import (
     create_ui,

--- a/traitsui/tests/test_animatedGIF_editor.py
+++ b/traitsui/tests/test_animatedGIF_editor.py
@@ -37,7 +37,6 @@ class TestAnimatedGIFEditor(unittest.TestCase):
         obj1 = AnimatedGIF()
         view = View(
             Item('gif_file', editor=AnimatedGIFEditor(playing='playing')),
-            Item('playing'),
         )
         
         # This should not fail.

--- a/traitsui/tests/test_animatedGIF_editor.py
+++ b/traitsui/tests/test_animatedGIF_editor.py
@@ -35,7 +35,7 @@ class AnimatedGIF(HasTraits):
 class TestAnimatedGIFEditor(unittest.TestCase):
 
     def test_animated_gif_editor(self):
-        # Regression test for enthought/traitsui#1087
+        # Regression test for enthought/traitsui#1071
         obj1 = AnimatedGIF()
         view = View(
             Item('gif_file', editor=AnimatedGIFEditor(playing='playing')),

--- a/traitsui/tests/test_animatedGIF_editor.py
+++ b/traitsui/tests/test_animatedGIF_editor.py
@@ -1,0 +1,48 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+""" Tests to exercise logic for layouts, e.g. VGroup, HGroup.
+"""
+
+import unittest
+
+from traits.api import HasTraits, File, Bool
+from traitsui.api import View, Item
+from traitsui.wx.animated_gif_editor import AnimatedGIFEditor
+import pkg_resources
+
+from traitsui.tests._tools import (
+    create_ui,
+    skip_if_not_wx,
+)
+
+filename = pkg_resources.resource_filename("traitsui", "examples/demo/Extras/images/logo_32x32.gif")
+
+class AnimatedGIF(HasTraits):
+
+    gif_file = File(filename)
+
+    playing = Bool(True)
+
+
+@skip_if_not_wx
+class TestAnimatedGIFEditor(unittest.TestCase):
+
+    def test_animated_gif_editor(self):
+        # Regression test for enthought/traitsui#1087
+        obj1 = AnimatedGIF()
+        view = View(
+            Item('gif_file', editor=AnimatedGIFEditor(playing='playing')),
+            Item('playing'),
+        )
+        
+        # This should not fail.
+        with create_ui(obj1, dict(view=view)):
+            pass

--- a/traitsui/tests/test_animatedGIF_editor.py
+++ b/traitsui/tests/test_animatedGIF_editor.py
@@ -28,8 +28,6 @@ class AnimatedGIF(HasTraits):
 
     gif_file = File(filename)
 
-    playing = Bool(True)
-
 
 @skip_if_not_wx
 class TestAnimatedGIFEditor(unittest.TestCase):

--- a/traitsui/tests/test_animatedGIF_editor.py
+++ b/traitsui/tests/test_animatedGIF_editor.py
@@ -33,6 +33,7 @@ class AnimatedGIF(HasTraits):
 class TestAnimatedGIFEditor(unittest.TestCase):
 
     def test_animated_gif_editor(self):
+        from traitsui.wx.animated_gif_editor import AnimatedGIFEditor
         # Regression test for enthought/traitsui#1071
         obj1 = AnimatedGIF()
         view = View(

--- a/traitsui/tests/test_animatedGIF_editor.py
+++ b/traitsui/tests/test_animatedGIF_editor.py
@@ -13,11 +13,10 @@
 
 import unittest
 
-from traits.api import HasTraits, File, Bool
-from traitsui.api import View, Item
-from traitsui.wx.animated_gif_editor import AnimatedGIFEditor
 import pkg_resources
 
+from traits.api import Bool, File, HasTraits,
+from traitsui.api import Item, View
 from traitsui.tests._tools import (
     create_ui,
     skip_if_not_wx,

--- a/traitsui/wx/animated_gif_editor.py
+++ b/traitsui/wx/animated_gif_editor.py
@@ -19,7 +19,7 @@
 """
 
 
-from wx.adv import Animation, AnimationCtrl
+from wx.adv import Animation, GenericAnimationCtrl
 
 from traits.api import Bool, Str
 
@@ -44,7 +44,7 @@ class _AnimatedGIFEditor(Editor):
             widget.
         """
         self._animate = Animation(self.value)
-        self.control = AnimationCtrl(parent, -1, self._animate)
+        self.control = GenericAnimationCtrl(parent, -1, self._animate)
         self.control.SetUseWindowBackgroundColour()
         self.sync_value(self.factory.playing, "playing", "from")
         self.set_tooltip()


### PR DESCRIPTION
fixes #1071 

wx.adv.GenericAnimationCtrl is a subclass of wx.adv.AnimationCtrl but it has the SetUseWindowBackgroundColour() method.  I believe this was the intended class from the beginning - after the change the demo seems to run fine. 