### PR TITLE
Add test for nested group and spring in UI 

### DIFF
--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -1,0 +1,47 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+""" Tests to exercise logic for layouts, e.g. VGroup, HGroup.
+"""
+
+import unittest
+
+from traits.api import HasTraits, Int
+from traitsui.api import HGroup, Item, spring, VGroup, View
+from traitsui.tests._tools import (
+    create_ui,
+)
+
+
+class ObjectWithNumber(HasTraits):
+    number1 = Int()
+    number2 = Int()
+    number3 = Int()
+
+
+class TestUIPanel(unittest.TestCase):
+
+    def test_grouped_layout_with_springy(self):
+        # Regression test for enthought/traitsui#1066
+        obj1 = ObjectWithNumber()
+        view = View(
+            HGroup(
+                VGroup(
+                    Item("number1"),
+                ),
+                VGroup(
+                    Item("number2"),
+                ),
+                spring,
+            )
+        )
+        # This should not fail.
+        with create_ui(obj1, dict(view=view)):
+            pass

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -17,6 +17,7 @@ from traits.api import HasTraits, Int
 from traitsui.api import HGroup, Item, spring, VGroup, View
 from traitsui.tests._tools import (
     create_ui,
+    skip_if_null,
 )
 
 
@@ -26,6 +27,7 @@ class ObjectWithNumber(HasTraits):
     number3 = Int()
 
 
+@skip_if_null
 class TestUIPanel(unittest.TestCase):
 
     def test_grouped_layout_with_springy(self):


### PR DESCRIPTION
[Targeting #1067]

This PR adds a test that fails on wx and master, in an effort to reproduce #1066
The test failure was the following:
```
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/tests/test_ui_panel.py", line 45, in test_grouped_layout_with_springy
    with create_ui(obj1, dict(view=view)):
  File "/Users/kchoi/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/tests/_tools.py", line 177, in create_ui
    ui = object.edit_traits(**ui_kwargs)
  File "/Users/kchoi/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traits/has_traits.py", line 1678, in edit_traits
    args,
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/view.py", line 462, in ui
    ui.ui(parent, kind)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/ui.py", line 246, in ui
    self.rebuild(self, parent)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/toolkit.py", line 125, in ui_live
    ui_live.ui_live(ui, parent)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_live.py", line 52, in ui_live
    _ui_dialog(ui, parent, BaseDialog.NONMODAL)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_live.py", line 88, in _ui_dialog
    BaseDialog.display_ui(ui, parent, style)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_base.py", line 71, in display_ui
    ui.owner.init(ui, parent, style)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_live.py", line 203, in init
    sw = panel(ui, window)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_panel.py", line 272, in panel
    panel, content[0], ui
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_panel.py", line 431, in fill_panel_for_group
    panel, group, ui, suppress_label, is_dock_window, create_panel
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_panel.py", line 585, in __init__
    self.add_groups(content, panel)
  File "/Users/kchoi/Work/ETS/traitsui/traitsui/wx/ui_panel.py", line 729, in add_groups
    sizer.Add(sg_sizer, growable, style, 2)
wx._core.wxAssertionError: C++ assertion "!(flags & (wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL))" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/sizer.cpp(2114) in DoInsert(): Vertical alignment flags are ignored with wxEXPAND
```

The test then passes with the changes in #1067