### PR TITLE
Set default node in etsdemo if there is data available

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -1043,6 +1043,8 @@ class Demo(ModelView):
 
     def init(self, info):
         info.ui.title = self.title
+        if self.model.has_children():
+            self.selected_node = self.model.get_children()[0]
 
     def _get__next_node(self):
         if self.selected_node is None:

--- a/ets-demo/etsdemo/tests/test_app.py
+++ b/ets-demo/etsdemo/tests/test_app.py
@@ -14,6 +14,8 @@ import textwrap
 import unittest
 from xml.etree import ElementTree as ET
 
+from traitsui.api import Handler, UI, UIInfo
+
 from etsdemo.app import (
     Demo,
     DemoPath,
@@ -75,6 +77,33 @@ class TestDemo(unittest.TestCase):
         demo = Demo(model=DemoPath())
         if get_action_enabled(parent_tool, demo):
             demo.perform(None, parent_tool, None)
+
+    def test_demo_init_set_children(self):
+        # Test if there are children, the first one will be selected.
+        resources = [DemoPath(), DemoPath()]
+        model = DemoVirtualDirectory(resources=resources)
+        demo = Demo(model=model)
+        demo.selected_node = None
+
+        # when
+        info = UIInfo(ui=UI(handler=Handler()))
+        demo.init(info)
+
+        # then
+        self.assertIs(demo.selected_node, resources[0])
+
+    def test_demo_init_no_children_to_be_set(self):
+        # Test if there are no children, nothing is selected.
+        model = DemoVirtualDirectory(resources=[])
+        demo = Demo(model=model)
+        demo.selected_node = None
+
+        # when
+        info = UIInfo(ui=UI(handler=Handler()))
+        demo.init(info)
+
+        # then
+        self.assertIsNone(demo.selected_node)
 
 
 class TestDemoPathDescription(unittest.TestCase):


### PR DESCRIPTION
Closes #1029

(This kind of mitigate #1030 if TraitsUI demo happens to be first one: The demo has a big welcome image for setting the size hint such that the split ratio looks better, but that should not be relied on.)