### PR TITLE
TST: Replace Qt4 with Qt in tests and clarify test requirements

### DIFF
--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -23,11 +23,12 @@ import pkg_resources
 from traits.api import HasTraits
 
 from traitsui.tests._tools import (
-    is_current_backend_wx,
-    is_current_backend_qt4,
+    is_qt,
+    is_wx,
     process_cascade_events,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 # This test file is not distributed nor is it in a package.
@@ -153,31 +154,31 @@ SOURCE_DIRS = [
 SEARCHER = ExampleSearcher(source_dirs=SOURCE_DIRS)
 SEARCHER.skip_file_if(
     os.path.join(DEMO, "Advanced", "Table_editor_with_progress_column.py"),
-    is_current_backend_wx, "ProgressRenderer is not implemented in wx.",
+    is_wx, "ProgressRenderer is not implemented in wx.",
 )
 SEARCHER.skip_file_if(
     os.path.join(DEMO, "Advanced", "Scrubber_editor_demo.py"),
-    is_current_backend_qt4, "ScrubberEditor is not implemented in qt.",
+    is_qt, "ScrubberEditor is not implemented in qt.",
 )
 SEARCHER.skip_file_if(
     os.path.join(DEMO, "Extras", "animated_GIF.py"),
-    lambda: not is_current_backend_wx(), "Only support wx",
+    lambda: not is_wx(), "Only support wx",
 )
 SEARCHER.skip_file_if(
     os.path.join(DEMO, "Extras", "Tree_editor_with_TreeNodeRenderer.py"),
-    lambda: not is_current_backend_qt4(), "Only support Qt",
+    lambda: not is_qt(), "Only support Qt",
 )
 SEARCHER.skip_file_if(
     os.path.join(DEMO, "Extras", "windows", "flash.py"),
-    lambda: not is_current_backend_wx(), "Only support wx",
+    lambda: not is_wx(), "Only support wx",
 )
 SEARCHER.skip_file_if(
     os.path.join(DEMO, "Extras", "windows", "internet_explorer.py"),
-    lambda: not is_current_backend_wx(), "Only support wx",
+    lambda: not is_wx(), "Only support wx",
 )
 SEARCHER.skip_file_if(
     os.path.join(DEMO, "Useful", "demo_group_size.py"),
-    is_current_backend_wx,
+    is_wx,
     "enable tries to import a missing constant. See enthought/enable#307",
 )
 SEARCHER.skip_file_if(
@@ -190,7 +191,7 @@ SEARCHER.skip_file_if(
 )
 SEARCHER.skip_file_if(
     os.path.join(TUTORIALS, "wizard.py"),
-    is_current_backend_qt4, "Failing on Qt, see enthought/traitsui#773",
+    is_qt, "Failing on Qt, see enthought/traitsui#773",
 )
 
 # Validate configuration.
@@ -230,9 +231,9 @@ def replaced_configure_traits(
         process_cascade_events()
 
         # Temporary fix for enthought/traitsui#907
-        if is_current_backend_qt4():
+        if is_qt():
             ui.control.hide()
-        if is_current_backend_wx():
+        if is_wx():
             ui.control.Hide()
 
         ui.dispose()
@@ -282,7 +283,7 @@ def run_file(file_path):
 # Test cases
 # =============================================================================
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestExample(unittest.TestCase):
 
     def test_run(self):

--- a/traitsui/qt4/tests/test_helper.py
+++ b/traitsui/qt4/tests/test_helper.py
@@ -12,7 +12,7 @@ import textwrap
 import unittest
 
 from pyface.qt import QtGui
-from traitsui.tests._tools import skip_if_not_qt4
+from traitsui.tests._tools import requires_toolkit, ToolkitName
 from traitsui.qt4.helper import wrap_text_with_elision
 from traitsui.qt4.font_trait import create_traitsfont
 
@@ -40,7 +40,7 @@ def get_expected_lines(text, width):
     return expected_lines
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestWrapText(unittest.TestCase):
     def test_wrap_text_basic(self):
         font = create_traitsfont("Courier")

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -20,16 +20,17 @@ from traitsui.tabular_adapter import TabularAdapter
 
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_qt4,
-    skip_if_not_qt4,
+    is_qt,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 try:
     from pyface.qt import QtCore
 except ImportError:
     # The entire test case should be skipped if the current backend is not Qt
     # But if it is Qt, then re-raise
-    if is_current_backend_qt4():
+    if is_qt():
         raise
 
 
@@ -48,7 +49,7 @@ def get_view(adapter):
     )
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestTabularModel(unittest.TestCase):
 
     def test_drop_mime_data_below_list(self):

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -6,8 +6,9 @@ from traitsui.menu import ToolBar, Action
 
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     process_cascade_events,
+    ToolkitName,
 )
 
 
@@ -47,7 +48,7 @@ class FooDialog(HasTraits):
         return FooPanel()
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestUIPanel(unittest.TestCase):
     def setup_qt4_dock_window(self):
         from pyface.qt import QtGui

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -121,7 +121,7 @@ def _deprecated(func):
     def wrapped(*args, **kwargs):
         warnings.warn(
             "{!r} will be removed. "
-            "Use is_wx, is_qt or is_null or requires_toolkit instead.".format(
+            "Use is_wx, is_qt, is_null or requires_toolkit instead.".format(
                 func
             ),
             DeprecationWarning,

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -218,7 +218,7 @@ def process_cascade_events():
       posted prior to calling this function will be processed.
       See enthought/traitsui#951
     """
-    if is_current_backend_qt4():
+    if is_qt():
         from pyface.qt import QtCore
         event_loop = QtCore.QEventLoop()
         while event_loop.processEvents(QtCore.QEventLoop.AllEvents):
@@ -264,7 +264,7 @@ def create_ui(object, ui_kwargs=None):
 
 
 def get_children(node):
-    if ETSConfig.toolkit == "wx":
+    if is_wx():
         return node.GetChildren()
     else:
         return node.children()
@@ -273,7 +273,7 @@ def get_children(node):
 def press_ok_button(ui):
     """Press the OK button in a wx or qt dialog."""
 
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         ok_button = ui.control.FindWindowByName("button", ui.control)
@@ -282,7 +282,7 @@ def press_ok_button(ui):
         )
         ok_button.ProcessEvent(click_event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         from pyface import qt
 
         # press the OK button and close the dialog
@@ -293,14 +293,14 @@ def press_ok_button(ui):
 def click_button(button):
     """Click the button given its control."""
 
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         event = wx.CommandEvent(wx.EVT_BUTTON.typeId, button.GetId())
         event.SetEventObject(button)
         wx.PostEvent(button, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         button.click()
 
     else:
@@ -310,10 +310,10 @@ def click_button(button):
 def is_control_enabled(control):
     """Return if the given control is enabled or not."""
 
-    if is_current_backend_wx():
+    if is_wx():
         return control.IsEnabled()
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         return control.isEnabled()
 
     else:
@@ -329,10 +329,10 @@ def get_dialog_size(ui_control):
         >>> get_dialog_size(ui.control)
     """
 
-    if is_current_backend_wx():
+    if is_wx():
         return ui_control.GetSize()
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         return ui_control.size().width(), ui_control.size().height()
 
 
@@ -344,14 +344,14 @@ def get_all_button_status(control):
     """
     button_status = []
 
-    if is_current_backend_wx():
+    if is_wx():
         for item in control.GetSizer().GetChildren():
             button = item.GetWindow()
             # Ignore empty buttons (assumption that they are invisible)
             if button.value != "":
                 button_status.append(button.GetValue())
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         layout = control.layout()
         for i in range(layout.count()):
             button = layout.itemAt(i).widget()

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -16,8 +16,9 @@ from traits.api import HasTraits, Bool
 from traitsui.api import BooleanEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -28,7 +29,7 @@ class BoolModel(HasTraits):
 
 # Run this against wx once enthought/traitsui#752 is also fixed for
 # BooleanEditor
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestBooleanEditor(unittest.TestCase):
 
     def test_init_dispose(self):

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -9,9 +9,9 @@ from traitsui.tests._tools import (
     is_qt,
     is_wx,
     process_cascade_events,
-    skip_if_null,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -55,6 +55,7 @@ def get_button_text(button):
         return button.text()
 
 
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestButtonEditor(unittest.TestCase):
     def check_button_text_update(self, view):
         button_text_edit = ButtonTextEdit()
@@ -71,23 +72,20 @@ class TestButtonEditor(unittest.TestCase):
             button_text_edit.play_button_label = "New Label"
             self.assertEqual(get_button_text(button), "New Label")
 
-    @skip_if_null
     def test_styles(self):
         # simple smoke test of buttons
         button_text_edit = ButtonTextEdit()
         with store_exceptions_on_all_threads(), create_ui(button_text_edit):
             pass
 
-    @skip_if_null
     def test_simple_button_editor(self):
         self.check_button_text_update(simple_view)
 
-    @skip_if_null
     def test_custom_button_editor(self):
         self.check_button_text_update(custom_view)
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestButtonEditorValuesTrait(unittest.TestCase):
     """ The values_trait is only supported by Qt.
 

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -6,8 +6,8 @@ from traits.api import Button, HasTraits, List, Str
 from traitsui.api import ButtonEditor, Item, UItem, View
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_qt4,
-    is_current_backend_wx,
+    is_qt,
+    is_wx,
     process_cascade_events,
     skip_if_null,
     skip_if_not_qt4,
@@ -48,10 +48,10 @@ custom_view = View(
 
 def get_button_text(button):
     """ Return the button text given a button control """
-    if is_current_backend_wx():
+    if is_wx():
         return button.GetLabel()
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         return button.text()
 
 

--- a/traitsui/tests/editors/test_check_list_editor.py
+++ b/traitsui/tests/editors/test_check_list_editor.py
@@ -9,8 +9,9 @@ from traitsui.tests._tools import (
     is_qt,
     is_wx,
     process_cascade_events,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -117,7 +118,7 @@ def set_text_in_line_edit(line_edit, text):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestCheckListEditorMapping(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -321,7 +322,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
         self.check_checklist_values_change_after_ui_dispose("custom")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestSimpleCheckListEditor(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -402,7 +403,7 @@ class TestSimpleCheckListEditor(unittest.TestCase):
             self.assertEqual(str_edit.value, "two,one")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestCustomCheckListEditor(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -487,7 +488,7 @@ class TestCustomCheckListEditor(unittest.TestCase):
             self.assertEqual(str_edit.value, "three,one")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestTextCheckListEditor(unittest.TestCase):
 
     @contextlib.contextmanager

--- a/traitsui/tests/editors/test_check_list_editor.py
+++ b/traitsui/tests/editors/test_check_list_editor.py
@@ -6,8 +6,8 @@ from traitsui.api import CheckListEditor, UItem, View
 from traitsui.tests._tools import (
     create_ui,
     get_all_button_status,
-    is_current_backend_qt4,
-    is_current_backend_wx,
+    is_qt,
+    is_wx,
     process_cascade_events,
     skip_if_null,
     store_exceptions_on_all_threads,
@@ -47,10 +47,10 @@ def get_mapped_view(style):
 
 def get_combobox_text(combobox):
     """ Return the text given a combobox control. """
-    if is_current_backend_wx():
+    if is_wx():
         return combobox.GetString(combobox.GetSelection())
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         return combobox.currentText()
 
     else:
@@ -60,7 +60,7 @@ def get_combobox_text(combobox):
 def set_combobox_index(editor, idx):
     """ Set the choice index of a combobox control given editor and index
     number. """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         choice = editor.control
@@ -69,7 +69,7 @@ def set_combobox_index(editor, idx):
         event.SetString(choice.GetString(idx))
         wx.PostEvent(choice, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         # Cannot initiate update programatically because of `activated`
         # event. At least check that it updates as expected when done
         # manually
@@ -82,7 +82,7 @@ def set_combobox_index(editor, idx):
 def click_checkbox_button(widget, button_idx):
     """ Simulate a checkbox click given widget and button number. Assumes
     all sizer children (wx) or layout items (qt) are buttons."""
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         sizer_items = widget.GetSizer().GetChildren()
@@ -92,7 +92,7 @@ def click_checkbox_button(widget, button_idx):
         event.SetEventObject(button)
         wx.PostEvent(widget, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         layout = widget.layout()
         layout.itemAt(button_idx).widget().click()
 
@@ -102,14 +102,14 @@ def click_checkbox_button(widget, button_idx):
 
 def set_text_in_line_edit(line_edit, text):
     """ Set text in text widget and complete editing. """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         line_edit.SetValue(text)
         event = wx.CommandEvent(wx.EVT_TEXT_ENTER.typeId, line_edit.GetId())
         wx.PostEvent(line_edit, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         line_edit.setText(text)
         line_edit.editingFinished.emit()
 
@@ -276,7 +276,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
 
     def test_custom_editor_mapping_values(self):
         # FIXME issue enthought/traitsui#842
-        if is_current_backend_wx():
+        if is_wx():
             import wx
 
             with self.assertRaises(wx._core.wxAssertionError):
@@ -286,7 +286,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
 
     def test_custom_editor_mapping_values_tuple(self):
         # FIXME issue enthought/traitsui#842
-        if is_current_backend_wx():
+        if is_wx():
             import wx
 
             with self.assertRaises(wx._core.wxAssertionError):
@@ -296,7 +296,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
 
     def test_custom_editor_mapping_name(self):
         # FIXME issue enthought/traitsui#842
-        if is_current_backend_wx():
+        if is_wx():
             import wx
 
             with self.assertRaises(wx._core.wxAssertionError):
@@ -306,7 +306,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
 
     def test_custom_editor_mapping_name_tuple(self):
         # FIXME issue enthought/traitsui#842
-        if is_current_backend_wx():
+        if is_wx():
             import wx
 
             with self.assertRaises(wx._core.wxAssertionError):

--- a/traitsui/tests/editors/test_code_editor.py
+++ b/traitsui/tests/editors/test_code_editor.py
@@ -22,8 +22,9 @@ from traitsui.editors.code_editor import CodeEditor
 
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -49,7 +50,7 @@ class CodeView(ModelView):
 
 class TestCodeEditor(unittest.TestCase):
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_code_editor_show_line_numbers(self):
         """ CodeEditor should honor the `show_line_numbers` setting
         """
@@ -70,7 +71,7 @@ class TestCodeEditor(unittest.TestCase):
         test_line_numbers_visibility(True)
         test_line_numbers_visibility(False)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_code_editor_readonly(self):
         """ Test readonly editor style for CodeEditor
         """

--- a/traitsui/tests/editors/test_csv_editor.py
+++ b/traitsui/tests/editors/test_csv_editor.py
@@ -26,8 +26,8 @@ import traitsui.editors.csv_list_editor as csv_list_editor
 
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_wx,
-    is_current_backend_qt4,
+    is_wx,
+    is_qt,
     press_ok_button,
     skip_if_null,
     store_exceptions_on_all_threads,
@@ -92,9 +92,9 @@ class TestCSVEditor(unittest.TestCase):
             list_of_floats.data.append(3.14)
 
             # get current value from editor
-            if is_current_backend_wx():
+            if is_wx():
                 value_str = _wx_get_text_value(ui)
-            elif is_current_backend_qt4():
+            elif is_qt():
                 value_str = _qt_get_text_value(ui)
 
             expected = csv_list_editor._format_list_str([1.0, 3.14])

--- a/traitsui/tests/editors/test_csv_editor.py
+++ b/traitsui/tests/editors/test_csv_editor.py
@@ -29,8 +29,9 @@ from traitsui.tests._tools import (
     is_wx,
     is_qt,
     press_ok_button,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -50,7 +51,7 @@ class ListOfFloatsWithCSVEditor(ModelView):
 
 class TestCSVEditor(unittest.TestCase):
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_csv_editor_disposal(self):
         # Bug: CSVListEditor does not un-hook the traits notifications after
         # its disposal, causing errors when the hooked data is accessed after
@@ -69,7 +70,7 @@ class TestCSVEditor(unittest.TestCase):
             # if all went well, we should not be here
             self.fail("AttributeError raised")
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_csv_editor_external_append(self):
         # Behavior: CSV editor is notified when an element is appended to the
         # list externally

--- a/traitsui/tests/editors/test_date_editor.py
+++ b/traitsui/tests/editors/test_date_editor.py
@@ -8,8 +8,9 @@ from traitsui.editors.date_editor import CellFormat
 
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -54,7 +55,7 @@ def multi_select_selected_color_view():
     return view
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestDateEditorCustomQt(unittest.TestCase):
     def test_single_select_qt4(self):
         with self.launch_editor(single_select_custom_view) as (foo, editor):
@@ -162,7 +163,7 @@ class TestDateEditorCustomQt(unittest.TestCase):
 
 
 # Run this test case against wx too once enthought/traitsui#752 is fixed.
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestDateEditorInitDispose(unittest.TestCase):
     """ Test the init and dispose of date editor."""
 

--- a/traitsui/tests/editors/test_date_range_editor.py
+++ b/traitsui/tests/editors/test_date_range_editor.py
@@ -14,7 +14,8 @@ from traitsui.api import DateRangeEditor, View, Item
 
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
+    ToolkitName,
 )
 
 
@@ -51,7 +52,7 @@ class TestDateRangeEditorGeneric(unittest.TestCase):
             DateRangeEditor(multi_select=False)
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestDateRangeEditorQt(unittest.TestCase):
     def setUp(self):
         push_exception_handler(reraise_exceptions=True)

--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -8,8 +8,9 @@ from traitsui.tests._tools import (
     create_ui,
     GuiTestAssistant,
     process_cascade_events,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
     no_gui_test_assistant,
 )
 
@@ -37,7 +38,7 @@ def get_date_time_simple_view(editor_factory):
     return view
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
 class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
     """ Tests for DatetimeEditor using Qt. """

--- a/traitsui/tests/editors/test_directory_editor.py
+++ b/traitsui/tests/editors/test_directory_editor.py
@@ -14,8 +14,9 @@ from traits.api import Directory, Event, HasTraits
 from traitsui.api import DirectoryEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -27,7 +28,7 @@ class DirectoryModel(HasTraits):
 
 
 # Run this against wx too when enthought/traitsui#752 is also fixed.
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestDirectoryEditor(unittest.TestCase):
     """ Test DirectoryEditor. """
 

--- a/traitsui/tests/editors/test_drop_editor.py
+++ b/traitsui/tests/editors/test_drop_editor.py
@@ -14,8 +14,9 @@ from traits.api import HasTraits, Str
 from traitsui.api import DropEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -25,7 +26,7 @@ class Model(HasTraits):
 
 
 # Run this test against wx when enthought/traitsui#752 is fixed.
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestDropEditor(unittest.TestCase):
     """ Test DropEditor. """
 

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -10,8 +10,9 @@ from traitsui.tests._tools import (
     is_qt,
     is_wx,
     process_cascade_events,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -169,7 +170,7 @@ def set_list_widget_selected_index(list_widget, idx):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestEnumEditorMapping(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -279,7 +280,7 @@ class TestEnumEditorMapping(unittest.TestCase):
         self.check_enum_mappings_name_change("custom", "list")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestSimpleEnumEditor(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -406,7 +407,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
             enum_editor_factory.values = ["one", "two", "three"]
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestRadioEnumEditor(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -451,7 +452,7 @@ class TestRadioEnumEditor(unittest.TestCase):
             self.assertEqual(enum_edit.value, "two")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestListEnumEditor(unittest.TestCase):
 
     @contextlib.contextmanager

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -7,8 +7,8 @@ from traitsui.api import EnumEditor, UItem, View
 from traitsui.tests._tools import (
     create_ui,
     get_all_button_status,
-    is_current_backend_qt4,
-    is_current_backend_wx,
+    is_qt,
+    is_wx,
     process_cascade_events,
     skip_if_null,
     store_exceptions_on_all_threads,
@@ -45,7 +45,7 @@ def get_evaluate_view(style, auto_set=True, mode="radio"):
 
 def get_combobox_text(combobox):
     """ Return the text given a combobox control """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         if isinstance(combobox, wx.Choice):
@@ -53,7 +53,7 @@ def get_combobox_text(combobox):
         else:
             return combobox.GetValue()
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         return combobox.currentText()
 
     else:
@@ -62,7 +62,7 @@ def get_combobox_text(combobox):
 
 def set_combobox_text(combobox, text):
     """ Set the text given a combobox control """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         if isinstance(combobox, wx.Choice):
@@ -77,7 +77,7 @@ def set_combobox_text(combobox, text):
             event.SetString(text)
             wx.PostEvent(combobox, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         combobox.setEditText(text)
 
     else:
@@ -86,7 +86,7 @@ def set_combobox_text(combobox, text):
 
 def set_combobox_index(combobox, idx):
     """ Set the choice index given a combobox control and index number """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         if isinstance(combobox, wx.Choice):
@@ -99,7 +99,7 @@ def set_combobox_index(combobox, idx):
         event.SetInt(idx)
         wx.PostEvent(combobox, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         combobox.setCurrentIndex(idx)
 
     else:
@@ -108,13 +108,13 @@ def set_combobox_index(combobox, idx):
 
 def finish_combobox_text_entry(combobox):
     """ Finish text entry given combobox. """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         event = wx.CommandEvent(wx.EVT_TEXT_ENTER.typeId, combobox.GetId())
         wx.PostEvent(combobox, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         combobox.lineEdit().editingFinished.emit()
 
     else:
@@ -124,7 +124,7 @@ def finish_combobox_text_entry(combobox):
 def click_radio_button(widget, button_idx):
     """ Simulate a radio button click given widget and button number. Assumes
     all sizer children (wx) or layout items (qt) are buttons."""
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         sizer_items = widget.GetSizer().GetChildren()
@@ -133,7 +133,7 @@ def click_radio_button(widget, button_idx):
         event.SetEventObject(button)
         wx.PostEvent(widget, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         widget.layout().itemAt(button_idx).widget().click()
 
     else:
@@ -142,11 +142,11 @@ def click_radio_button(widget, button_idx):
 
 def get_list_widget_text(list_widget):
     """ Return the text of currently selected item in given list widget. """
-    if is_current_backend_wx():
+    if is_wx():
         selected_item_idx = list_widget.GetSelection()
         return list_widget.GetString(selected_item_idx)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         return list_widget.currentItem().text()
 
     else:
@@ -155,14 +155,14 @@ def get_list_widget_text(list_widget):
 
 def set_list_widget_selected_index(list_widget, idx):
     """ Set the choice index given a list widget control and index number. """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         list_widget.SetSelection(idx)
         event = wx.CommandEvent(wx.EVT_LISTBOX.typeId, list_widget.GetId())
         wx.PostEvent(list_widget, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         list_widget.setCurrentRow(idx)
 
     else:
@@ -254,7 +254,7 @@ class TestEnumEditorMapping(unittest.TestCase):
 
     def test_radio_editor_mapping_values(self):
         # FIXME issue enthought/traitsui#842
-        if is_current_backend_wx():
+        if is_wx():
             import wx
 
             with self.assertRaises(wx._core.wxAssertionError):
@@ -264,7 +264,7 @@ class TestEnumEditorMapping(unittest.TestCase):
 
     def test_radio_editor_mapping_name(self):
         # FIXME issue enthought/traitsui#842
-        if is_current_backend_wx():
+        if is_wx():
             import wx
 
             with self.assertRaises(wx._core.wxAssertionError):
@@ -375,7 +375,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
             process_cascade_events()
 
             # wx modifies the value without the need to finish entry
-            if is_current_backend_qt4():
+            if is_qt():
                 self.assertEqual(enum_edit.value, "one")
 
                 finish_combobox_text_entry(editor.control)

--- a/traitsui/tests/editors/test_file_editor.py
+++ b/traitsui/tests/editors/test_file_editor.py
@@ -14,8 +14,9 @@ from traits.api import Directory, Event, File, HasTraits
 from traitsui.api import FileEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -27,7 +28,7 @@ class FileModel(HasTraits):
 
 
 # Run this against wx too when enthought/traitsui#752 is also fixed.
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestFileEditor(unittest.TestCase):
     """ Test FileEditor. """
 

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -14,8 +14,9 @@ from traits.api import HasTraits, Str
 from traitsui.api import HTMLEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -40,7 +41,7 @@ def get_view(base_url_name):
 
 
 # Run this against wx as well once enthought/traitsui#752 is fixed.
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestHTMLEditor(unittest.TestCase):
     """ Test HTMLEditor """
 

--- a/traitsui/tests/editors/test_image_enum_editor.py
+++ b/traitsui/tests/editors/test_image_enum_editor.py
@@ -7,8 +7,8 @@ from traits.api import Enum, HasTraits, List
 from traitsui.api import ImageEnumEditor, UItem, View
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_qt4,
-    is_current_backend_wx,
+    is_qt,
+    is_wx,
     process_cascade_events,
     skip_if_null,
     skip_if_not_qt4,
@@ -17,10 +17,10 @@ from traitsui.tests._tools import (
 )
 
 # Import needed bitmap/pixmap cache and prepare for patching
-if is_current_backend_wx():
+if is_wx():
     from traitsui.wx.helper import bitmap_cache as image_cache
     cache_to_patch = "traitsui.wx.image_enum_editor.bitmap_cache"
-elif is_current_backend_qt4():
+elif is_qt():
     from traitsui.qt4.helper import pixmap_cache as image_cache
     cache_to_patch = "traitsui.qt4.image_enum_editor.pixmap_cache"
 
@@ -52,7 +52,7 @@ def get_view(style):
 
 def click_on_image(image_control):
     """ Click on the image controlled by given image_control."""
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         event_down = wx.MouseEvent(wx.EVT_LEFT_DOWN.typeId)
@@ -62,7 +62,7 @@ def click_on_image(image_control):
         event_up.SetY(0)
         wx.PostEvent(image_control, event_up)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         image_control.click()
 
     else:
@@ -75,12 +75,12 @@ def get_button_strings(control):
     """
     button_strings = []
 
-    if is_current_backend_wx():
+    if is_wx():
         for item in control.GetSizer().GetChildren():
             button = item.GetWindow()
             button_strings.append(button.value)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         layout = control.layout()
         for i in range(layout.count()):
             button = layout.itemAt(i).widget()
@@ -99,11 +99,11 @@ def get_all_button_selected_status(control):
     """
     button_status = []
 
-    if is_current_backend_wx():
+    if is_wx():
         for item in control.GetSizer().GetChildren():
             button_status.append(item.GetWindow().Selected())
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         layout = control.layout()
         for i in range(layout.count()):
             button_status.append(layout.itemAt(i).widget().isChecked())
@@ -118,10 +118,10 @@ def get_button_control(control, button_idx):
     """ Get button control from a specified parent control given a button index.
     Assumes all sizer children (wx) or layout items (qt) are buttons.
     """
-    if is_current_backend_wx():
+    if is_wx():
         return control.GetSizer().GetChildren()[button_idx].GetWindow()
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         return control.layout().itemAt(button_idx).widget()
 
     else:

--- a/traitsui/tests/editors/test_image_enum_editor.py
+++ b/traitsui/tests/editors/test_image_enum_editor.py
@@ -10,10 +10,9 @@ from traitsui.tests._tools import (
     is_qt,
     is_wx,
     process_cascade_events,
-    skip_if_null,
-    skip_if_not_qt4,
-    skip_if_not_wx,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 # Import needed bitmap/pixmap cache and prepare for patching
@@ -128,7 +127,7 @@ def get_button_control(control, button_idx):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestImageEnumEditorMapping(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -269,7 +268,6 @@ class TestImageEnumEditorMapping(unittest.TestCase):
             self.assertEqual(editor.str_value, "TOP LEFT")
 
 
-@skip_if_null
 class TestSimpleImageEnumEditor(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -278,6 +276,7 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
             process_cascade_events()
             yield ui.get_editors("value")[0]
 
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_simple_editor_more_cols(self):
         # Smoke test for setting up an editor with more than one column
         enum_edit = EnumModel()
@@ -301,7 +300,7 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
         with store_exceptions_on_all_threads():
             self.setup_gui(enum_edit, view)
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_simple_editor_popup_editor(self):
         enum_edit = EnumModel()
 
@@ -332,7 +331,7 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
             # Check that dialog window is closed
             self.assertEqual(list(editor.control.GetChildren()), [])
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_simple_editor_combobox(self):
         enum_edit = EnumModel()
 
@@ -352,7 +351,7 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
             self.assertEqual(enum_edit.value, 'top right')
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestCustomImageEnumEditor(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -431,7 +430,7 @@ class TestCustomImageEnumEditor(unittest.TestCase):
             )
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestReadOnlyImageEnumEditor(unittest.TestCase):
 
     def test_readonly_editor_value_changed(self):

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -6,8 +6,9 @@ from traitsui.view import View
 from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -23,7 +24,7 @@ class NonmodalInstanceEditor(HasTraits):
 
 class TestInstanceEditor(unittest.TestCase):
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_simple_editor(self):
         obj = NonmodalInstanceEditor()
         with store_exceptions_on_all_threads(), create_ui(obj) as ui:
@@ -35,7 +36,7 @@ class TestInstanceEditor(unittest.TestCase):
             # close the ui dialog
             press_ok_button(editor._dialog_ui)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_simple_editor_parent_closed(self):
         obj = NonmodalInstanceEditor()
         with store_exceptions_on_all_threads(), create_ui(obj) as ui:

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -31,8 +31,8 @@ from traitsui.editors.list_str_editor import ListStrEditor
 
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_wx,
-    is_current_backend_qt4,
+    is_wx,
+    is_qt,
     press_ok_button,
     process_cascade_events,
     skip_if_not_qt4,
@@ -99,7 +99,7 @@ single_select_item_view = View(
 def get_selected_indices(editor):
     """ Returns a list of the indices of all currently selected list items.
     """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
         # "item" in this context means "index of the item"
         item = -1
@@ -113,7 +113,7 @@ def get_selected_indices(editor):
             selected.append(item)
         return selected
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         indices = editor.list_view.selectionModel().selectedRows()
         return [i.row() for i in indices]
 
@@ -124,10 +124,10 @@ def get_selected_indices(editor):
 def set_selected_single(editor, index):
     """ Selects a specified item in an editor with multi_select=False.
     """
-    if is_current_backend_wx():
+    if is_wx():
         editor.control.Select(index)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         from pyface.qt.QtGui import QItemSelectionModel
 
         smodel = editor.list_view.selectionModel()
@@ -142,12 +142,12 @@ def set_selected_multiple(editor, indices):
     """ Clears old selection and selects specified items in an editor with
     multi_select=True.
     """
-    if is_current_backend_wx():
+    if is_wx():
         clear_selection(editor)
         for index in indices:
             editor.control.Select(index)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         from pyface.qt.QtGui import QItemSelectionModel
 
         clear_selection(editor)
@@ -163,7 +163,7 @@ def set_selected_multiple(editor, indices):
 def clear_selection(editor):
     """ Clears existing selection.
     """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         currently_selected = get_selected_indices(editor)
@@ -173,7 +173,7 @@ def clear_selection(editor):
                 selected_index, 0, wx.LIST_STATE_SELECTED
             )
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         editor.list_view.selectionModel().clearSelection()
 
     else:
@@ -184,7 +184,7 @@ def right_click_item(control, index):
     """ Right clicks on the specified item.
     """
 
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         event = wx.ListEvent(
@@ -193,7 +193,7 @@ def right_click_item(control, index):
         event.SetIndex(index)
         wx.PostEvent(control, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         # Couldn't figure out how to close the context menu programatically
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
@@ -201,7 +201,7 @@ def right_click_item(control, index):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
+@unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
 @skip_if_null
 class TestListStrEditor(unittest.TestCase):
 
@@ -216,10 +216,10 @@ class TestListStrEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
 
-            if is_current_backend_qt4():  # No initial selection
+            if is_qt():  # No initial selection
                 self.assertEqual(editor.selected_index, -1)
                 self.assertEqual(editor.selected, None)
-            elif is_current_backend_wx():  # First element selected initially
+            elif is_wx():  # First element selected initially
                 self.assertEqual(editor.selected_index, 0)
                 self.assertEqual(editor.selected, "one")
 
@@ -272,9 +272,9 @@ class TestListStrEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
 
-            if is_current_backend_qt4():  # No initial selection
+            if is_qt():  # No initial selection
                 self.assertEqual(get_selected_indices(editor), [])
-            elif is_current_backend_wx():  # First element selected initially
+            elif is_wx():  # First element selected initially
                 self.assertEqual(get_selected_indices(editor), [0])
 
             editor.selected_index = 1
@@ -300,11 +300,11 @@ class TestListStrEditor(unittest.TestCase):
             editor.selected_index = -1
             process_cascade_events()
 
-            if is_current_backend_qt4():
+            if is_qt():
                 # -1 clears selection
                 self.assertEqual(get_selected_indices(editor), [])
                 self.assertEqual(editor.selected, None)
-            elif is_current_backend_wx():
+            elif is_wx():
                 # Visually selects everything but doesn't update `selected`
                 self.assertEqual(editor.selected, "four")
                 self.assertEqual(get_selected_indices(editor), [0, 1, 2])
@@ -332,11 +332,11 @@ class TestListStrEditor(unittest.TestCase):
             editor.multi_selected = ["three", "four"]
             process_cascade_events()
 
-            if is_current_backend_qt4():
+            if is_qt():
                 # Invalid values assigned to multi_selected are ignored
                 self.assertEqual(get_selected_indices(editor), [2])
                 self.assertEqual(editor.multi_selected_indices, [2])
-            elif is_current_backend_wx():
+            elif is_wx():
                 # Selection indices are not updated at all
                 self.assertEqual(get_selected_indices(editor), [0, 2])
                 self.assertEqual(editor.multi_selected_indices, [0, 2])
@@ -403,9 +403,9 @@ class TestListStrEditor(unittest.TestCase):
         # Smoke test for refresh_editor/refresh_
         with store_exceptions_on_all_threads(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
-            if is_current_backend_qt4():
+            if is_qt():
                 editor.refresh_editor()
-            elif is_current_backend_wx():
+            elif is_wx():
                 editor._refresh()
             process_cascade_events()
 

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -538,7 +538,8 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.multi_selected_indices, [0])
             self.assertEqual(editor.multi_selected, ["two"])
 
-    @requires_toolkit([ToolkitName.qt])  # wx editor doesn't have a `callx` method
+    # wx editor doesn't have a `callx` method
+    @requires_toolkit([ToolkitName.qt])
     def test_list_str_editor_callx(self):
         model = ListStrModel()
 
@@ -562,7 +563,8 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "one")
 
-    @requires_toolkit([ToolkitName.qt])  # wx editor doesn't have a `setx` method
+    # wx editor doesn't have a `setx` method
+    @requires_toolkit([ToolkitName.qt])
     def test_list_str_editor_setx(self):
         with store_exceptions_on_all_threads(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
@@ -599,7 +601,8 @@ class TestListStrEditor(unittest.TestCase):
                 self.setup_gui(ListStrModel(), get_view(title="testing")):
             pass
 
-    @requires_toolkit([ToolkitName.wx])  # see `right_click_item` and issue enthought/traitsui#868
+    # see `right_click_item` and issue enthought/traitsui#868
+    @requires_toolkit([ToolkitName.wx])
     def test_list_str_editor_right_click(self):
         class ListStrModelRightClick(HasTraits):
             value = List(["one", "two", "three"])

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -35,10 +35,9 @@ from traitsui.tests._tools import (
     is_qt,
     press_ok_button,
     process_cascade_events,
-    skip_if_not_qt4,
-    skip_if_not_wx,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 is_windows = platform.system() == "Windows"
@@ -202,7 +201,7 @@ def right_click_item(control, index):
 
 
 @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestListStrEditor(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -409,7 +408,7 @@ class TestListStrEditor(unittest.TestCase):
                 editor._refresh()
             process_cascade_events()
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_list_str_editor_update_editor_single_qt(self):
         # QT editor uses selected items as the source of truth when updating
         model = ListStrModel()
@@ -441,7 +440,7 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.selected_index, 1)
             self.assertEqual(editor.selected, "one")
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_list_str_editor_update_editor_single_wx(self):
         # WX editor uses selected indices as the source of truth when updating
         model = ListStrModel()
@@ -473,7 +472,7 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "two")
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_list_str_editor_update_editor_multi_qt(self):
         # QT editor uses selected items as the source of truth when updating
         model = ListStrModel()
@@ -506,7 +505,7 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.multi_selected_indices, [1])
             self.assertEqual(editor.multi_selected, ["one"])
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_list_str_editor_update_editor_multi_wx(self):
         # WX editor uses selected indices as the source of truth when updating
         model = ListStrModel()
@@ -539,7 +538,7 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.multi_selected_indices, [0])
             self.assertEqual(editor.multi_selected, ["two"])
 
-    @skip_if_not_qt4  # wx editor doesn't have a `callx` method
+    @requires_toolkit([ToolkitName.qt])  # wx editor doesn't have a `callx` method
     def test_list_str_editor_callx(self):
         model = ListStrModel()
 
@@ -563,7 +562,7 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.selected_index, 0)
             self.assertEqual(editor.selected, "one")
 
-    @skip_if_not_qt4  # wx editor doesn't have a `setx` method
+    @requires_toolkit([ToolkitName.qt])  # wx editor doesn't have a `setx` method
     def test_list_str_editor_setx(self):
         with store_exceptions_on_all_threads(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
@@ -600,7 +599,7 @@ class TestListStrEditor(unittest.TestCase):
                 self.setup_gui(ListStrModel(), get_view(title="testing")):
             pass
 
-    @skip_if_not_wx  # see `right_click_item` and issue enthought/traitsui#868
+    @requires_toolkit([ToolkitName.wx])  # see `right_click_item` and issue enthought/traitsui#868
     def test_list_str_editor_right_click(self):
         class ListStrModelRightClick(HasTraits):
             value = List(["one", "two", "three"])
@@ -628,7 +627,7 @@ class TestListStrEditor(unittest.TestCase):
 
 class TestListStrEditorSelection(unittest.TestCase):
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_list_str_selected_index(self):
         # behavior: when starting up, the
 
@@ -650,7 +649,7 @@ class TestListStrEditorSelection(unittest.TestCase):
         self.assertEqual(selected_1, [1])
         self.assertEqual(selected_2, [0])
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_list_str_multi_selected_index(self):
         # behavior: when starting up, the
 
@@ -672,7 +671,7 @@ class TestListStrEditorSelection(unittest.TestCase):
         self.assertEqual(selected_1, [1])
         self.assertEqual(selected_2, [0])
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_selection_listener_disconnected(self):
         """ Check that selection listeners get correctly disconnected """
         from pyface.api import GUI

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -4,8 +4,9 @@ from traits.api import HasTraits, Int
 from traitsui.api import RangeEditor, UItem, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -14,7 +15,7 @@ class RangeModel(HasTraits):
     value = Int()
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestRangeEditor(unittest.TestCase):
 
     def check_range_enum_editor_format_func(self, style):

--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -35,9 +35,9 @@ from traitsui.editors.range_editor import RangeEditor
 from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
-    skip_if_not_wx,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -56,7 +56,7 @@ class NumberWithSpinnerEditor(HasTraits):
 
 class TestRangeEditorSpinner(unittest.TestCase):
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_spin_control_editing_should_not_crash(self):
         # Bug: when editing the text part of a spin control box, pressing
         # the OK button raises an AttributeError on Mac OS X
@@ -86,7 +86,7 @@ class TestRangeEditorSpinner(unittest.TestCase):
             # if all went well, we should not be here
             self.fail("AttributeError raised")
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_spin_control_editing_does_not_update(self):
         # Bug: when editing the text part of a spin control box, pressing
         # the OK button does not update the value of the HasTraits class
@@ -122,7 +122,7 @@ class TestRangeEditorSpinner(unittest.TestCase):
             # value is 4
             self.assertEqual(num.number, 4)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_spin_control_editing(self):
         # Behavior: when editing the text part of a spin control box, pressing
         # the OK button updates the value of the HasTraits class

--- a/traitsui/tests/editors/test_range_editor_text.py
+++ b/traitsui/tests/editors/test_range_editor_text.py
@@ -29,9 +29,9 @@ from traitsui.editors.range_editor import RangeEditor
 from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
-    skip_if_not_wx,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -61,7 +61,7 @@ class FloatWithRangeEditor(HasTraits):
 
 class TestRangeEditorText(unittest.TestCase):
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_text_editing(self):
         # behavior: when editing the text part of a spin control box, pressing
         # the OK button should update the value of the HasTraits class
@@ -79,7 +79,7 @@ class TestRangeEditorText(unittest.TestCase):
         # the number traits should be between 3 and 8
         self.assertTrue(3 <= num.number <= 8)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_avoid_slider_feedback(self):
         # behavior: when editing the text box part of a range editor, the value
         # should not be adjusted by the slider part of the range editor

--- a/traitsui/tests/editors/test_set_editor.py
+++ b/traitsui/tests/editors/test_set_editor.py
@@ -7,8 +7,8 @@ from traitsui.tests._tools import (
     create_ui,
     click_button,
     is_control_enabled,
-    is_current_backend_qt4,
-    is_current_backend_wx,
+    is_qt,
+    is_wx,
     process_cascade_events,
     skip_if_null,
     store_exceptions_on_all_threads,
@@ -38,11 +38,11 @@ def get_list_items(list_widget):
     """ Return a list of strings from the list widget. """
     items = []
 
-    if is_current_backend_wx():
+    if is_wx():
         for i in range(list_widget.GetCount()):
             items.append(list_widget.GetString(i))
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         for i in range(list_widget.count()):
             items.append(list_widget.item(i).text())
 
@@ -63,7 +63,7 @@ def click_on_item(editor, item_idx, in_used=False):
     unused_list = editor._unused
     used_list = editor._used
 
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         # First deselect all items
@@ -80,7 +80,7 @@ def click_on_item(editor, item_idx, in_used=False):
         )
         wx.PostEvent(editor.control, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         for i in range(unused_list.count()):
             status = (not in_used) and (item_idx == i)
             unused_list.item(i).setSelected(status)
@@ -109,7 +109,7 @@ def double_click_on_item(editor, item_idx, in_used=False):
     unused_list = editor._unused
     used_list = editor._used
 
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         # First deselect all items
@@ -126,7 +126,7 @@ def double_click_on_item(editor, item_idx, in_used=False):
         )
         wx.PostEvent(editor.control, event)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         for i in range(unused_list.count()):
             status = (not in_used) and (item_idx == i)
             unused_list.item(i).setSelected(status)
@@ -489,7 +489,7 @@ class TestSimpleSetEditor(unittest.TestCase):
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
             # FIXME issue enthought/traitsui#840
-            if is_current_backend_wx():
+            if is_wx():
                 with self.assertRaises(AssertionError):
                     self.assertEqual(get_list_items(editor._used), ["two"])
                 self.assertEqual(get_list_items(editor._used), ["one", "two"])

--- a/traitsui/tests/editors/test_set_editor.py
+++ b/traitsui/tests/editors/test_set_editor.py
@@ -10,8 +10,9 @@ from traitsui.tests._tools import (
     is_qt,
     is_wx,
     process_cascade_events,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -144,7 +145,7 @@ def double_click_on_item(editor, item_idx, in_used=False):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestSetEditorMapping(unittest.TestCase):
 
     @contextlib.contextmanager
@@ -220,7 +221,7 @@ class TestSetEditorMapping(unittest.TestCase):
             )
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestSimpleSetEditor(unittest.TestCase):
 
     @contextlib.contextmanager

--- a/traitsui/tests/editors/test_styled_date_editor.py
+++ b/traitsui/tests/editors/test_styled_date_editor.py
@@ -33,7 +33,6 @@ def get_example_model():
     )
 
 
-
 # StyledDateEditor is currently only implemented for Qt
 @requires_toolkit([ToolkitName.qt])
 class TestStyledDateEditor(unittest.TestCase):

--- a/traitsui/tests/editors/test_styled_date_editor.py
+++ b/traitsui/tests/editors/test_styled_date_editor.py
@@ -7,8 +7,9 @@ from traitsui.api import Item, StyledDateEditor, View
 from traitsui.editors.date_editor import CellFormat
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -34,7 +35,7 @@ def get_example_model():
 
 
 # StyledDateEditor is currently only implemented for Qt
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestStyledDateEditor(unittest.TestCase):
 
     def test_init_and_dispose(self):

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -9,9 +9,9 @@ from traitsui.tests._tools import (
     is_wx,
     process_cascade_events,
     press_ok_button,
-    skip_if_not_qt4,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -261,7 +261,7 @@ select_cell_indices_view = View(
 
 class TestTableEditor(unittest.TestCase):
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -271,7 +271,7 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=simple_view)) as ui:
             process_cascade_events()
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_filtered_table_editor(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -287,7 +287,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertIsNotNone(filter)
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_row(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -307,7 +307,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertIs(selected, object_list.values[5])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_rows(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -327,7 +327,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, object_list.values[5:7])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_row_index(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -347,7 +347,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, 5)
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_row_indices(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -368,7 +368,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, [5, 7, 8])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_column(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -388,7 +388,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, "value")
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_columns(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -408,7 +408,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, ["value", "other_value"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_column_index(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -429,7 +429,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, 1)
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_column_indices(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -450,7 +450,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, [0, 1])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_cell(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -470,7 +470,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, (object_list.values[5], "value"))
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_cells(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -498,7 +498,7 @@ class TestTableEditor(unittest.TestCase):
             (object_list.values[8], "value"),
         ])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_cell_index(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -519,7 +519,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, (5, 1))
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_cell_indices(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
@@ -540,7 +540,7 @@ class TestTableEditor(unittest.TestCase):
 
         self.assertEqual(selected, [(5, 0), (6, 1), (8, 0)])
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_progress_column(self):
         from traitsui.extras.progress_column import ProgressColumn
 

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -5,8 +5,8 @@ from traits.api import HasTraits, Instance, Int, List, Str, Tuple
 from traitsui.api import EvalTableFilter, Item, ObjectColumn, TableEditor, View
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_qt4,
-    is_current_backend_wx,
+    is_qt,
+    is_wx,
     process_cascade_events,
     press_ok_button,
     skip_if_not_qt4,
@@ -298,9 +298,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=select_row_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_row
 
             process_cascade_events()
@@ -318,9 +318,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=select_rows_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_rows
 
             process_cascade_events()
@@ -338,9 +338,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=select_row_index_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected_indices
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_row_index
 
             process_cascade_events()
@@ -359,9 +359,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected_indices
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_row_indices
 
             process_cascade_events()
@@ -379,9 +379,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=select_column_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_column
 
             process_cascade_events()
@@ -399,9 +399,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=select_columns_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_columns
 
             process_cascade_events()
@@ -420,9 +420,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected_indices
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_column_index
 
             process_cascade_events()
@@ -441,9 +441,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected_indices
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_column_indices
 
             process_cascade_events()
@@ -461,9 +461,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=select_cell_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_cell
 
             process_cascade_events()
@@ -485,9 +485,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=select_cells_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_cells
 
             process_cascade_events()
@@ -510,9 +510,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected_indices
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_cell_index
 
             process_cascade_events()
@@ -531,9 +531,9 @@ class TestTableEditor(unittest.TestCase):
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
-            if is_current_backend_qt4():
+            if is_qt():
                 selected = editor.selected_indices
-            elif is_current_backend_wx():
+            elif is_wx():
                 selected = editor.selected_cell_indices
 
             process_cascade_events()

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -23,8 +23,9 @@ from traitsui.tests._tools import (
     is_wx,
     is_qt,
     process_cascade_events,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -178,7 +179,7 @@ def clear_selection(editor):
         raise unittest.SkipTest("Test not implemented for this toolkit")
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestTabularEditor(UnittestTools, unittest.TestCase):
 
     @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -20,8 +20,8 @@ from traitsui.api import Item, TabularEditor, View
 from traitsui.tabular_adapter import TabularAdapter
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_wx,
-    is_current_backend_qt4,
+    is_wx,
+    is_qt,
     process_cascade_events,
     skip_if_null,
     store_exceptions_on_all_threads,
@@ -91,7 +91,7 @@ def get_view(multi_select=False):
 def get_selected_rows(editor):
     """ Returns a list of all currently selected rows.
     """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
         # "item" in this context means "row number"
         item = -1
@@ -105,7 +105,7 @@ def get_selected_rows(editor):
             selected.append(item)
         return selected
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         rows = editor.control.selectionModel().selectedRows()
         return [r.row() for r in rows]
 
@@ -116,10 +116,10 @@ def get_selected_rows(editor):
 def set_selected_single(editor, row):
     """ Selects a specified row in an editor with multi_select=False.
     """
-    if is_current_backend_wx():
+    if is_wx():
         editor.control.Select(row)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         from pyface.qt.QtGui import QItemSelectionModel
 
         smodel = editor.control.selectionModel()
@@ -137,12 +137,12 @@ def set_selected_multiple(editor, rows):
     """ Clears old selection and selects specified rows in an editor
     with multi_select=True.
     """
-    if is_current_backend_wx():
+    if is_wx():
         clear_selection(editor)
         for row in rows:
             editor.control.Select(row)
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         from pyface.qt.QtGui import QItemSelectionModel
 
         clear_selection(editor)
@@ -161,7 +161,7 @@ def set_selected_multiple(editor, rows):
 def clear_selection(editor):
     """ Clears existing selection.
     """
-    if is_current_backend_wx():
+    if is_wx():
         import wx
 
         currently_selected = get_selected_rows(editor)
@@ -171,7 +171,7 @@ def clear_selection(editor):
                 selected_row, 0, wx.LIST_STATE_SELECTED
             )
 
-    elif is_current_backend_qt4():
+    elif is_qt():
         editor.control.selectionModel().clearSelection()
 
     else:
@@ -181,7 +181,7 @@ def clear_selection(editor):
 @skip_if_null
 class TestTabularEditor(UnittestTools, unittest.TestCase):
 
-    @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_single_selection(self):
 
         with store_exceptions_on_all_threads(), \
@@ -206,7 +206,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
 
             # Can't clear selection via UI when multi_select=False
 
-    @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_multi_selection(self):
         view = get_view(multi_select=True)
 
@@ -236,7 +236,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             self.assertEqual(report.selected_rows, [])
             self.assertEqual(report.multi_selected, [])
 
-    @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_single_selection_changed(self):
 
         with store_exceptions_on_all_threads(), \
@@ -272,7 +272,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             self.assertEqual(get_selected_rows(editor), [])
             self.assertEqual(report.selected, None)
 
-    @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_multi_selection_changed(self):
         view = get_view(multi_select=True)
 
@@ -310,7 +310,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             self.assertEqual(get_selected_rows(editor), [])
             self.assertEqual(report.multi_selected, [])
 
-    @unittest.skipIf(is_current_backend_wx(), "Issue enthought/traitsui#752")
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_multi_selection_items_changed(self):
         view = get_view(multi_select=True)
 

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -24,10 +24,11 @@ from traitsui.tests._tools import (
     create_ui,
     GuiTestAssistant,
     is_qt,
-    process_cascade_events,
-    skip_if_not_qt4,
-    store_exceptions_on_all_threads,
     no_gui_test_assistant,
+    process_cascade_events,
+    requires_toolkit,
+    store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -99,7 +100,7 @@ def key_press_return(editor):
 
 
 # Skips tests if the backend is not either qt4 or qt5
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
 class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
     """ Test on TextEditor with Qt backend."""
@@ -162,7 +163,7 @@ class TestTextEditorQt(GuiTestAssistant, unittest.TestCase):
 
 # We should be able to run this test case against wx.
 # Not running them now to avoid test interaction. See enthought/traitsui#752
-@skip_if_not_qt4
+@requires_toolkit([ToolkitName.qt])
 class TestTextEditor(unittest.TestCase):
     """ Tests that can be run with any toolkit as long as there is an
     implementation for simulating user interactions.

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -23,7 +23,7 @@ from traitsui.api import TextEditor, View, Item
 from traitsui.tests._tools import (
     create_ui,
     GuiTestAssistant,
-    is_current_backend_qt4,
+    is_qt,
     process_cascade_events,
     skip_if_not_qt4,
     store_exceptions_on_all_threads,
@@ -56,7 +56,7 @@ def get_view(style, auto_set):
 def get_text(editor):
     """ Return the text from the widget for checking.
     """
-    if is_current_backend_qt4():
+    if is_qt():
         return editor.control.text()
     else:
         raise unittest.SkipTest("Not implemented for the current toolkit.")
@@ -68,7 +68,7 @@ def set_text(editor, text):
     via pressing a return key or causing the widget to lose focus.
     """
 
-    if is_current_backend_qt4():
+    if is_qt():
         from pyface.qt import QtGui
         if editor.base_style == QtGui.QLineEdit:
             editor.control.clear()
@@ -84,7 +84,7 @@ def set_text(editor, text):
 def key_press_return(editor):
     """ Imitate user pressing the return key.
     """
-    if is_current_backend_qt4():
+    if is_qt():
         from pyface.qt import QtGui
 
         # ideally we should fire keyPressEvent, but the editor does not

--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -28,9 +28,9 @@ from traitsui.api import (
 from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
-    skip_if_null,
-    skip_if_not_qt4,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -176,21 +176,21 @@ class TestTreeView(unittest.TestCase):
         notifiers_list = bogus.trait(trait)._notifiers(False)
         self.assertEqual(0, len(notifiers_list))
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_editor_listeners_with_shown_root(self):
         nodes = [
             TreeNode(node_for=[Bogus], children="bogus_list", label="=Bogus")
         ]
         self._test_tree_editor_releases_listeners(hide_root=False, nodes=nodes)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_editor_listeners_with_hidden_root(self):
         nodes = [
             TreeNode(node_for=[Bogus], children="bogus_list", label="=Bogus")
         ]
         self._test_tree_editor_releases_listeners(hide_root=True, nodes=nodes)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_editor_label_listener(self):
         nodes = [
             TreeNode(node_for=[Bogus], children="bogus_list", label="name")
@@ -199,7 +199,7 @@ class TestTreeView(unittest.TestCase):
             hide_root=False, nodes=nodes, trait="name"
         )
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_editor_xgetattr_label_listener(self):
         nodes = [
             TreeNode(
@@ -215,7 +215,7 @@ class TestTreeView(unittest.TestCase):
             expected_listeners=2,
         )
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_node_object_listeners_with_shown_root(self):
         nodes = [
             ObjectTreeNode(
@@ -228,7 +228,7 @@ class TestTreeView(unittest.TestCase):
             nodes=nodes, hide_root=False
         )
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_node_object_listeners_with_hidden_root(self):
         nodes = [
             ObjectTreeNode(
@@ -241,7 +241,7 @@ class TestTreeView(unittest.TestCase):
             nodes=nodes, hide_root=True
         )
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_node_object_label_listener(self):
         nodes = [
             ObjectTreeNode(
@@ -254,7 +254,7 @@ class TestTreeView(unittest.TestCase):
             nodes=nodes, hide_root=False, trait="name"
         )
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_smoke_save_restore_prefs(self):
         bogus = Bogus(bogus_list=[Bogus()])
         tree_editor_view = BogusTreeView(bogus=bogus)
@@ -262,7 +262,7 @@ class TestTreeView(unittest.TestCase):
             prefs = ui.get_prefs()
             ui.set_prefs(prefs)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_smoke_word_wrap(self):
         bogus = Bogus(bogus_list=[Bogus()])
         tree_editor_view = BogusTreeView(bogus=bogus, word_wrap=True)

--- a/traitsui/tests/editors/test_tuple_editor.py
+++ b/traitsui/tests/editors/test_tuple_editor.py
@@ -19,9 +19,9 @@ from traits.testing.api import UnittestTools
 from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
-    skip_if_not_qt4,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -38,7 +38,7 @@ class TupleEditor(HasTraits):
 
 class TestTupleEditor(unittest.TestCase, UnittestTools):
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_value_update(self):
         # Regression test for #179
         model = TupleEditor()
@@ -46,7 +46,7 @@ class TestTupleEditor(unittest.TestCase, UnittestTools):
             with self.assertTraitChanges(model, "tup", count=1):
                 model.tup = (3, 4, "nono")
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_tuple_editor(self):
         # Behavior: when editing the text of a tuple editor,
         # value get updated immediately.

--- a/traitsui/tests/null_backend/test_font_trait.py
+++ b/traitsui/tests/null_backend/test_font_trait.py
@@ -3,12 +3,12 @@ import unittest
 from traits.api import HasTraits
 
 from traitsui.toolkit_traits import Font
-from traitsui.tests._tools import skip_if_not_null
+from traitsui.tests._tools import requires_toolkit, ToolkitName
 
 
 class TestFontTrait(unittest.TestCase):
 
-    @skip_if_not_null
+    @requires_toolkit([ToolkitName.null])
     def test_font_trait_default(self):
         class Foo(HasTraits):
             font = Font()
@@ -16,7 +16,7 @@ class TestFontTrait(unittest.TestCase):
         f = Foo()
         self.assertEqual(f.font, "10 pt Arial")
 
-    @skip_if_not_null
+    @requires_toolkit([ToolkitName.null])
     def test_font_trait_examples(self):
         """
         An assigned font string is parsed, and the substrings are put

--- a/traitsui/tests/null_backend/test_null_toolkit.py
+++ b/traitsui/tests/null_backend/test_null_toolkit.py
@@ -1,12 +1,12 @@
 import unittest
 
 from traits.api import HasTraits, Int
-from traitsui.tests._tools import skip_if_not_null
+from traitsui.tests._tools import requires_toolkit, ToolkitName
 
 
 class TestNullToolkit(unittest.TestCase):
 
-    @skip_if_not_null
+    @requires_toolkit([ToolkitName.null])
     def test_configure_traits_error(self):
         """ Verify that configure_traits fails with NotImplementedError. """
 

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -21,9 +21,9 @@ from traitsui.tests._tools import (
     is_qt,
     is_wx,
     is_mac_os,
-    skip_if_not_qt4,
-    skip_if_not_wx,
     process_cascade_events,
+    requires_toolkit,
+    ToolkitName,
 )
 
 
@@ -86,7 +86,7 @@ class TestProcessEventsRepeated(unittest.TestCase):
     posted by the processed events.
     """
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_process_events_process_all(self):
         from pyface.qt import QtCore
 
@@ -160,7 +160,7 @@ class TestProcessEventsRepeated(unittest.TestCase):
         # test setup, not for the process_cascade_events.
         self.assertEqual(actual, max_n_events, msg)
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_process_events_process_all(self):
 
         def cleanup(wx_handler):

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -18,8 +18,8 @@ import unittest
 from pyface.api import GUI
 
 from traitsui.tests._tools import (
-    is_current_backend_qt4,
-    is_current_backend_wx,
+    is_qt,
+    is_wx,
     is_mac_os,
     skip_if_not_qt4,
     skip_if_not_wx,
@@ -27,7 +27,7 @@ from traitsui.tests._tools import (
 )
 
 
-if is_current_backend_qt4():
+if is_qt():
 
     # Create a QObject that will emit a new event to itself as long as
     # it has not received enough.
@@ -53,7 +53,7 @@ if is_current_backend_qt4():
             return True
 
 
-if is_current_backend_wx():
+if is_wx():
 
     # Create a wx.EvtHandler that will emit a new event to itself as long as
     # it has not received enough.

--- a/traitsui/tests/test_actions.py
+++ b/traitsui/tests/test_actions.py
@@ -29,14 +29,14 @@ from traitsui.view import View
 
 from traitsui.tests._tools import (
     create_ui,
-    is_current_backend_null,
     is_mac_os,
-    skip_if_not_qt4,
-    skip_if_not_wx,
+    is_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
-if is_current_backend_null():
+if is_null():
     raise unittest.SkipTest("Not supported using the null backend")
 
 
@@ -103,9 +103,9 @@ class TestActions(unittest.TestCase):
             # verify that the action was triggered
             self.assertTrue(dialog.action_successful)
 
-    # ----- Qt4 tests
+    # ----- Qt tests
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_toolbar_action(self):
         # Behavior: when clicking on a toolbar action, the corresponding
         # function should be executed
@@ -120,7 +120,7 @@ class TestActions(unittest.TestCase):
 
         self._test_actions(qt_trigger_toolbar_action)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_menu_action(self):
         # Behavior: when clicking on a menu action, the corresponding function
         # should be executed
@@ -135,7 +135,7 @@ class TestActions(unittest.TestCase):
 
         self._test_actions(qt_trigger_menu_action)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_button_action(self):
         # Behavior: when clicking on a button action, the corresponding
         # function should be executed
@@ -152,7 +152,7 @@ class TestActions(unittest.TestCase):
         not is_mac_os,
         "Problem with triggering toolbar actions on Linux and Windows. Issue #428.",  # noqa: E501
     )
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_toolbar_action(self):
         # Behavior: when clicking on a toolbar action, the corresponding
         # function should be executed
@@ -176,7 +176,7 @@ class TestActions(unittest.TestCase):
 
         self._test_actions(_wx_trigger_toolbar_action)
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_wx_button_action(self):
         # Behavior: when clicking on a button action, the corresponding
         # function should be executed

--- a/traitsui/tests/test_color_column.py
+++ b/traitsui/tests/test_color_column.py
@@ -6,8 +6,9 @@ from traitsui.color_column import ColorColumn
 
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -38,7 +39,8 @@ class MyData(HasTraits):
 
 
 class TestColorColumn(TestCase):
-    @skip_if_null
+
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_color_column(self):
         # Behaviour: column ui should display without error
 

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -28,9 +28,9 @@ from traitsui.tests._tools import (
     create_ui,
     is_control_enabled,
     is_qt,
-    skip_if_not_qt4,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -127,7 +127,7 @@ class EnableWhenDialog(HasTraits):
 
 class TestLabels(unittest.TestCase):
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_show_labels_right_without_colon(self):
         # Behavior: traitsui should not append a colon ':' to labels
         # that are shown to the *right* of the corresponding elements
@@ -188,15 +188,15 @@ class TestLabels(unittest.TestCase):
             # the size of the window should still be 500
             self.assertEqual(ui.control.width(), _DIALOG_WIDTH)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_labels_right_resizing_vertical(self):
         self._test_qt_labels_right_resizing(VResizeTestDialog)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_labels_right_resizing_horizontal(self):
         self._test_qt_labels_right_resizing(HResizeTestDialog)
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_labels_enabled_when(self):
         # Behaviour: label should enable/disable along with editor
 
@@ -219,7 +219,7 @@ class TestLabels(unittest.TestCase):
             dialog.bool_item = True
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestAnyToolkit(unittest.TestCase):
     """ Toolkit-agnostic tests for labels with different orientations."""
 

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -27,7 +27,7 @@ from traitsui.group import VGroup, HGroup
 from traitsui.tests._tools import (
     create_ui,
     is_control_enabled,
-    is_current_backend_qt4,
+    is_qt,
     skip_if_not_qt4,
     skip_if_null,
     store_exceptions_on_all_threads,
@@ -206,7 +206,7 @@ class TestLabels(unittest.TestCase):
 
             labelled_editor = ui.get_editors("labelled_item")[0]
 
-            if is_current_backend_qt4():
+            if is_qt():
                 unlabelled_editor = ui.get_editors("unlabelled_item")[0]
                 self.assertIsNone(unlabelled_editor.label_control)
 

--- a/traitsui/tests/test_layout.py
+++ b/traitsui/tests/test_layout.py
@@ -28,9 +28,9 @@ from traitsui.group import HGroup, VGroup
 
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
-    skip_if_null,
+    requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 
@@ -72,7 +72,7 @@ class HResizeDialog(HasTraits):
 
 class TestLayout(unittest.TestCase):
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_resizable_in_vgroup(self):
         # Behavior: Item.resizable controls whether a component can resize
         # along the non-layout axis of its group. In a VGroup, resizing should
@@ -91,7 +91,7 @@ class TestLayout(unittest.TestCase):
             # vertical size should be unchanged
             self.assertLess(text.height(), 100)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_qt_resizable_in_hgroup(self):
         # Behavior: Item.resizable controls whether a component can resize
         # along the non-layout axis of its group. In a HGroup, resizing should
@@ -114,7 +114,7 @@ class TestLayout(unittest.TestCase):
             # self.assertLess(text.width(), _TXT_WIDTH+100)
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestOrientation(unittest.TestCase):
     """ Toolkit-agnostic tests on the layout orientations."""
 

--- a/traitsui/tests/test_splitter_prefs_restored.py
+++ b/traitsui/tests/test_splitter_prefs_restored.py
@@ -20,7 +20,8 @@ from traits.api import Int
 from traitsui.api import Action, Group, Handler, HSplit, Item, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_not_qt4,
+    requires_toolkit,
+    ToolkitName,
 )
 
 
@@ -84,7 +85,7 @@ class TmpClass(Handler):
 
 class TestSplitterPrefsRestored(unittest.TestCase):
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_splitter_prefs_are_restored(self):
         # the keys for the splitter prefs (i.e. prefs['h_split']['structure'])
         splitter_keys = ("h_split", "structure")

--- a/traitsui/tests/test_theme.py
+++ b/traitsui/tests/test_theme.py
@@ -2,7 +2,7 @@ import pickle
 import unittest
 from unittest.mock import patch
 
-from traitsui.tests._tools import skip_if_not_wx
+from traitsui.tests._tools import requires_toolkit, ToolkitName
 from traitsui.theme import Theme
 
 
@@ -15,7 +15,7 @@ class TestTheme(unittest.TestCase):
         # A regression test for issue enthought/traitsui#825
         pickle.dumps(self.theme)
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_theme_content_color_default(self):
         import wx
         self.assertEqual(self.theme.content_color, wx.BLACK)
@@ -24,7 +24,7 @@ class TestTheme(unittest.TestCase):
         self.theme.content_color = "red"
         self.assertEqual(self.theme.content_color, "red")
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_theme_label_color_default(self):
         import wx
         self.assertEqual(self.theme.label_color, wx.BLACK)
@@ -33,7 +33,7 @@ class TestTheme(unittest.TestCase):
         self.theme.label_color = "red"
         self.assertEqual(self.theme.label_color, "red")
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_theme_get_image_slice(self):
         self.theme.image = "mock_image"
         with patch("traitsui.wx.image_slice.image_slice_for") as slice_func:

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -29,9 +29,8 @@ from traitsui.view import View
 from traitsui.tests._tools import (
     count_calls,
     create_ui,
-    skip_if_not_qt4,
-    skip_if_not_wx,
-    skip_if_null,
+    requires_toolkit,
+    ToolkitName,
 )
 
 
@@ -69,7 +68,7 @@ class MaybeInvalidTrait(HasTraits):
 
 class TestUI(unittest.TestCase):
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_reset_with_destroy_wx(self):
         # Characterization test:
         # UI.reset(destroy=True) destroys all ui children of the top control
@@ -84,7 +83,7 @@ class TestUI(unittest.TestCase):
             # but its children are gone
             self.assertEqual(len(ui.control.GetChildren()), 0)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_reset_with_destroy_qt(self):
         # Characterization test:
         # UI.reset(destroy=True) destroys all ui children of the top control
@@ -111,7 +110,7 @@ class TestUI(unittest.TestCase):
                 if isinstance(c, qt.QtGui.QWidget):
                     self.assertEqual(c.deleteLater._n_calls, 1)
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_reset_without_destroy_wx(self):
         # Characterization test:
         # UI.reset(destroy=False) destroys all editor controls, but leaves
@@ -142,7 +141,7 @@ class TestUI(unittest.TestCase):
             text_ctrl = ui.control.FindWindowByName("text")
             self.assertIsNotNone(text_ctrl)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_reset_without_destroy_qt(self):
         # Characterization test:
         # UI.reset(destroy=False) destroys all editor controls, but leaves
@@ -171,7 +170,7 @@ class TestUI(unittest.TestCase):
             text_ctrl = ui.control.findChild(qt.QtGui.QLineEdit)
             self.assertIsNotNone(text_ctrl)
 
-    @skip_if_not_wx
+    @requires_toolkit([ToolkitName.wx])
     def test_destroy_after_ok_wx(self):
         # Behavior: after pressing 'OK' in a dialog, the method UI.finish is
         # called and the view control and its children are destroyed
@@ -199,7 +198,7 @@ class TestUI(unittest.TestCase):
             self.assertIsNone(ui.control)
             self.assertEqual(control.Destroy._n_calls, 1)
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_destroy_after_ok_qt(self):
         # Behavior: after pressing 'OK' in a dialog, the method UI.finish is
         # called and the view control and its children are destroyed
@@ -223,7 +222,7 @@ class TestUI(unittest.TestCase):
             self.assertIsNone(ui.control)
             self.assertEqual(control.deleteLater._n_calls, 1)
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_no_spring_trait(self):
         obj = DisallowNewTraits()
         with create_ui(obj):
@@ -231,7 +230,7 @@ class TestUI(unittest.TestCase):
 
         self.assertTrue("spring" not in obj.traits())
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_invalid_state(self):
         # Regression test for enthought/traitsui#983
         obj = MaybeInvalidTrait(name="Name long enough to be valid")

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -17,7 +17,8 @@ from traits.api import HasTraits, Int
 from traitsui.api import HGroup, Item, spring, VGroup, View
 from traitsui.tests._tools import (
     create_ui,
-    skip_if_null,
+    requires_toolkit,
+    ToolkitName,
 )
 
 
@@ -27,7 +28,7 @@ class ObjectWithNumber(HasTraits):
     number3 = Int()
 
 
-@skip_if_null
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestUIPanel(unittest.TestCase):
 
     def test_grouped_layout_with_springy(self):

--- a/traitsui/tests/test_view_application.py
+++ b/traitsui/tests/test_view_application.py
@@ -12,7 +12,7 @@ from pyface.timer.api import CallbackTimer
 from traits.api import HasTraits, Instance, Int
 from traitsui.api import Handler, Item, UIInfo, View, toolkit
 
-from ._tools import GuiTestAssistant, is_current_backend_qt4, no_gui_test_assistant
+from ._tools import GuiTestAssistant, is_qt, no_gui_test_assistant
 
 
 class SimpleModel(HasTraits):
@@ -45,7 +45,7 @@ class TestViewApplication(GuiTestAssistant, unittest.TestCase):
         self.event_loop_timeout = False
         self.closed = False
 
-        if is_current_backend_qt4():
+        if is_qt():
             if len(self.qt_app.topLevelWidgets()) > 0:
                 with self.event_loop_with_timeout(repeat=5):
                     self.gui.invoke_later(self.qt_app.closeAllWindows)
@@ -81,14 +81,14 @@ class TestViewApplication(GuiTestAssistant, unittest.TestCase):
             self.gui.invoke_after(100, self.close_dialog)
 
     def close_dialog(self):
-        if is_current_backend_qt4():
+        if is_qt():
             self.handler.info.ui.control.close()
             self.closed = True
         else:
             raise NotImplementedError("Can't close current backend")
 
     def click_button(self, text):
-        if is_current_backend_qt4():
+        if is_qt():
             from pyface.qt.QtGui import QPushButton
             from pyface.ui.qt4.util.testing import find_qt_widget
 

--- a/traitsui/tests/test_visible_when_layout.py
+++ b/traitsui/tests/test_visible_when_layout.py
@@ -30,7 +30,8 @@ from traitsui.view import View
 from traitsui.tests._tools import (
     create_ui,
     get_dialog_size,
-    skip_if_not_qt4,
+    ToolkitName,
+    requires_toolkit,
     store_exceptions_on_all_threads,
 )
 
@@ -78,7 +79,7 @@ class VisibleWhenProblem(HasTraits):
 
 class TestVisibleWhenLayout(unittest.TestCase):
 
-    @skip_if_not_qt4
+    @requires_toolkit([ToolkitName.qt])
     def test_visible_when_layout(self):
         # Bug: The size of a dialog that contains elements that are activated
         # by "visible_when" can end up being the *sum* of the sizes of the

--- a/traitsui/tests/test_visible_when_layout.py
+++ b/traitsui/tests/test_visible_when_layout.py
@@ -30,9 +30,9 @@ from traitsui.view import View
 from traitsui.tests._tools import (
     create_ui,
     get_dialog_size,
-    ToolkitName,
     requires_toolkit,
     store_exceptions_on_all_threads,
+    ToolkitName,
 )
 
 _TEXT_WIDTH = 200

--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -27,8 +27,9 @@ from traitsui.view import View
 
 from traitsui.tests._tools import (
     create_ui,
+    requires_toolkit,
     store_exceptions_on_all_threads,
-    skip_if_null,
+    ToolkitName,
 )
 
 
@@ -93,7 +94,7 @@ def sample_text_data():
 
 class TestDataFrameEditor(unittest.TestCase):
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_get_item(self):
         viewer = sample_data()
         adapter = DataFrameAdapter()
@@ -104,7 +105,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
         self.assertEqual(item_0_df.index[0], "one")
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_empty_dataframe(self):
         data = DataFrame()
         viewer = DataFrameViewer(data=data)
@@ -115,7 +116,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.values, np.array([]).reshape(0, 0))
         assert_array_equal(item_0_df.columns, [])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_no_rows(self):
         data = DataFrame(columns=["X", "Y", "Z"])
         viewer = DataFrameViewer(data=data)
@@ -126,7 +127,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.values, np.array([]).reshape(0, 3))
         assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_get_item_numerical(self):
         viewer = sample_data_numerical_index()
         adapter = DataFrameAdapter()
@@ -137,7 +138,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.columns, ["X", "Y", "Z"])
         self.assertEqual(item_0_df.index[0], 1)
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_delete_start(self):
         viewer = sample_data()
         adapter = DataFrameAdapter()
@@ -149,7 +150,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, ["two", "three", "four"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_delete_start_numerical_index(self):
         viewer = sample_data_numerical_index()
         adapter = DataFrameAdapter()
@@ -161,7 +162,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, [2, 3, 4])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_delete_middle(self):
         viewer = sample_data()
         adapter = DataFrameAdapter()
@@ -173,7 +174,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, ["one", "three", "four"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_delete_middle_numerical_index(self):
         viewer = sample_data_numerical_index()
         adapter = DataFrameAdapter()
@@ -185,7 +186,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, [1, 3, 4])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_delete_end(self):
         viewer = sample_data()
         adapter = DataFrameAdapter()
@@ -197,7 +198,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, ["one", "two", "three"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_delete_end_numerical_index(self):
         viewer = sample_data_numerical_index()
         adapter = DataFrameAdapter()
@@ -209,7 +210,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, [1, 2, 3])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_insert_start(self):
         viewer = sample_data()
         adapter = DataFrameAdapter()
@@ -227,7 +228,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, ["new", "one", "two", "three", "four"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_insert_start_numerical_index(self):
         viewer = sample_data_numerical_index()
         adapter = DataFrameAdapter()
@@ -243,7 +244,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, [0, 1, 2, 3, 4])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_insert_middle(self):
         viewer = sample_data()
         adapter = DataFrameAdapter()
@@ -261,7 +262,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, ["one", "new", "two", "three", "four"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_insert_middle_numerical_index(self):
         viewer = sample_data_numerical_index()
         adapter = DataFrameAdapter()
@@ -277,7 +278,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, [1, 0, 2, 3, 4])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_insert_end(self):
         viewer = sample_data()
         adapter = DataFrameAdapter()
@@ -295,7 +296,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, ["one", "two", "three", "four", "new"])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_insert_end_numerical_index(self):
         viewer = sample_data_numerical_index()
         adapter = DataFrameAdapter()
@@ -311,13 +312,13 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(data.columns, ["X", "Y", "Z"])
         assert_array_equal(data.index, [1, 2, 3, 4, 0])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor(self):
         viewer = sample_data()
         with store_exceptions_on_all_threads(), create_ui(viewer):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_alternate_adapter(self):
         class AlternateAdapter(DataFrameAdapter):
             pass
@@ -334,40 +335,40 @@ class TestDataFrameEditor(unittest.TestCase):
                 create_ui(viewer, dict(view=alternate_adapter_view)):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_numerical_index(self):
         viewer = sample_data_numerical_index()
         with store_exceptions_on_all_threads(), create_ui(viewer):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_text_data(self):
         viewer = sample_text_data()
         with store_exceptions_on_all_threads(), create_ui(viewer):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_format_mapping(self):
         viewer = sample_data()
         with store_exceptions_on_all_threads(), \
                 create_ui(viewer, dict(view=format_mapping_view)):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_font_mapping(self):
         viewer = sample_data()
         with store_exceptions_on_all_threads(), \
                 create_ui(viewer, dict(view=font_mapping_view)):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_columns(self):
         viewer = sample_data()
         with store_exceptions_on_all_threads(), \
                 create_ui(viewer, dict(view=columns_view)):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_with_update_refresh(self):
         class DataFrameViewer(HasTraits):
             data = Instance(DataFrame)
@@ -385,7 +386,7 @@ class TestDataFrameEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), create_ui(viewer) as ui:
             viewer.df_updated = True
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_with_refresh(self):
         class DataFrameViewer(HasTraits):
             data = Instance(DataFrame)
@@ -403,7 +404,7 @@ class TestDataFrameEditor(unittest.TestCase):
         with store_exceptions_on_all_threads(), create_ui(viewer) as ui:
             viewer.df_refreshed = True
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_multi_select(self):
         view = View(
             Item("data", editor=DataFrameEditor(multi_select=True), width=400)
@@ -413,7 +414,7 @@ class TestDataFrameEditor(unittest.TestCase):
                 create_ui(viewer, dict(view=view)):
             pass
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_set_text(self):
         viewer = sample_data()
         columns = [(column, column) for column in viewer.data.columns]
@@ -426,7 +427,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.values, [[10, 1, 2]])
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_set_text_invalid(self):
         viewer = sample_data()
         columns = [(column, column) for column in viewer.data.columns]
@@ -440,7 +441,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.values, [[0, 1, 2]])
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_set_index_text(self):
         viewer = sample_data()
         columns = (
@@ -457,7 +458,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
         self.assertEqual(item_0_df.index[0], 'NewIndex')
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_set_index_text_numeric(self):
         viewer = sample_data_numerical_index()
         columns = (
@@ -474,7 +475,7 @@ class TestDataFrameEditor(unittest.TestCase):
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
         self.assertEqual(item_0_df.index[0], 100)
 
-    @skip_if_null
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_adapter_set_index_text_numeric_invalid(self):
         viewer = sample_data_numerical_index()
         columns = (


### PR DESCRIPTION
Closes #978

It has been a constant source of confusion that `is_current_backend_qt4` actually includes both Qt4 and Qt5. In fact, it is intended for Qt, regardless of its version.

This inevitably has to change a lot of lines of codes in trivial ways. While I am at this, I took the opportunity to flip "skip_if_toolkit" and "skip_if_not_toolkit" with positive assertions. Skips are confusing to read, and `skip_if_not_*` can only exclude one toolkit. Sometimes we use `skip_if_null` to actually mean "this test targets Qt and Wx". For we have three toolkits, skipping "null" gives us the other two. If in the future we should introduce a fourth toolkit support incrementally, this `skip_if_` logic won't work.

In summary, this PR clarifies test requirements with the following changes:
(1) Replace `is_current_backend_qt4` with `is_qt`. This will just mean Qt, regardless of Qt version. A different naming pattern is used to avoid confusion. Likewise, `is_current_backend_wx` is replaced with `is_wx`.
(2) Introduce `@requires_toolkit` to replace `@skip_if_toolkit` and `@skip_if_not_toolkit` decorator. This decorator specifies the toolkit requirements for a test. An enum `ToolkitName` is introduced for supplying toolkit names to `requires_toolkit`.

Note:
I did not actually remove `is_current_backend_*` and `skip_if_*` in this PR. This is to minimize disruptions to other PRs in the meantime while this is reviewed. These functions should be removed when other PRs have settled with the new utility function. This is an internal deprecation.

Discussion:
- Naming: `@requires_toolkit` or `@requires_one_of_toolkits` or `@requires_toolkit_in` or `@support_toolkits` or...?