### PR TITLE
Maint: Improve how we capture and re-raise errors in GUI tests

### DIFF
--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -12,7 +12,6 @@
 """ Tests for traitsui.tests._tools """
 
 import os
-import sys
 import unittest
 
 from pyface.api import GUI

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -188,8 +188,11 @@ class TestExceptionHandling(unittest.TestCase):
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_error_from_gui_captured_and_raise(self):
 
-        def raise_error():
+        def raise_error_1():
             raise ZeroDivisionError()
+
+        def raise_error_2():
+            raise IndexError()
 
         # without the context manager:
         #   - with Qt5, the test run will be aborted prematurely.
@@ -200,13 +203,16 @@ class TestExceptionHandling(unittest.TestCase):
         with self.assertRaises(RuntimeError) as exception_context, \
                 self.assertLogs("traitsui") as watcher:
             with reraise_exceptions():
-                gui.invoke_later(raise_error)
+                gui.invoke_later(raise_error_1)
+                gui.invoke_later(raise_error_2)
                 gui.process_events()
 
         error_msg = str(exception_context.exception)
         self.assertIn("ZeroDivisionError", error_msg)
-        log_content, = watcher.output
-        self.assertIn("ZeroDivisionError", log_content)
+        self.assertIn("IndexError", error_msg)
+        log_content1, log_content2 = watcher.output
+        self.assertIn("ZeroDivisionError", log_content1)
+        self.assertIn("IndexError", log_content2)
 
     def test_error_from_trait_change_captured(self):
 

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -22,8 +22,8 @@ from traitsui.tests._tools import (
     is_wx,
     is_mac_os,
     process_cascade_events,
-    reraise_exceptions,
     requires_toolkit,
+    reraise_exceptions,
     ToolkitName,
 )
 

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -217,12 +217,10 @@ class TestExceptionHandling(unittest.TestCase):
                 raise ZeroDivisionError()
 
         obj = Foo()
-        gui = GUI()
         with self.assertRaises(RuntimeError) as exception_context, \
                 self.assertLogs("traitsui") as watcher:
             with reraise_exceptions():
-                gui.set_trait_later(obj, "value", 2)
-                gui.process_events()
+                obj.value = 2
 
         error_msg = str(exception_context.exception)
         self.assertIn("ZeroDivisionError", error_msg)

--- a/traitsui/tests/test__tools.py
+++ b/traitsui/tests/test__tools.py
@@ -191,10 +191,10 @@ class TestExceptionHandling(unittest.TestCase):
             raise ZeroDivisionError()
 
         # without the context manager:
-        # with Qt5, the test run will be aborted prematurely.
-        # with Qt4, the traceback is printed and the test passes.
-        # with Wx, the traceback is printed and the test passes.
-        # With the context manager, the exception is reraised.
+        #   - with Qt5, the test run will be aborted prematurely.
+        #   - with Qt4, the traceback is printed and the test passes.
+        #   - with Wx, the traceback is printed and the test passes.
+        # With the context manager, the exception is always reraised.
         gui = GUI()
         with self.assertRaises(RuntimeError) as exception_context, \
                 self.assertLogs("traitsui") as watcher:


### PR DESCRIPTION
This PR improves the context manager we used for capturing exceptions that occur in the GUI event loop as a test is run.

- Change `print` to logging
- Instead of re-raising the first exception as is, serialize all the exceptions and re-raise RuntimeError instead. 
    - It is problematic to re-raise the first one regardless of its type, e.g. it could be a `SystemExit` or it could be a `StopIteration` (see [PEP 479](https://www.python.org/dev/peps/pep-0479/)). When we re-raise, we meant to make the test error, rather than propagating the intended side effect of the captured exception.
    - If more than one exception occurs, we get to see all of them.
