### PR TITLE
Maint: Rename context manager for capturing exceptions in tests

### DIFF
--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -27,7 +27,7 @@ from traitsui.tests._tools import (
     is_wx,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -227,7 +227,7 @@ def replaced_configure_traits(
         scrollable=scrollable,
         **args,
     )
-    with store_exceptions_on_all_threads():
+    with reraise_exceptions():
         process_cascade_events()
 
         # Temporary fix for enthought/traitsui#907

--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -22,7 +22,7 @@ from traitsui.tests._tools import (
     create_ui,
     is_qt,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 try:
@@ -56,7 +56,7 @@ class TestTabularModel(unittest.TestCase):
         # Test dragging an item in the list and drop it below the last item
         obj = DummyHasTraits(names=["A", "B", "C", "D"])
         view = get_view(TabularAdapter(columns=["Name"]))
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 
@@ -88,7 +88,7 @@ class TestTabularModel(unittest.TestCase):
         obj = DummyHasTraits(names=["A", "B", "C", "D"])
         view = get_view(TabularAdapter(columns=["Name"]))
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 
@@ -119,7 +119,7 @@ class TestTabularModel(unittest.TestCase):
         obj = DummyHasTraits(names=["A", "B", "C"])
         view = get_view(TabularAdapter(columns=["Name"], can_drop=True))
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 
@@ -152,7 +152,7 @@ class TestTabularModel(unittest.TestCase):
         obj = DummyHasTraits(names=["A", "B", "C"])
         view = get_view(TabularAdapter(columns=["Name"]))
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=view)) as ui:
             editor, = ui.get_editors("names")
 

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -101,10 +101,6 @@ def reraise_exceptions(logger=_TRAITSUI_LOGGER):
             raise RuntimeError(msg)
 
 
-# Temporary alias to avoid conflicts across PRs.
-store_exceptions_on_all_threads = reraise_exceptions
-
-
 # Toolkit constants
 
 class ToolkitName(enum.Enum):

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -17,7 +17,7 @@ from traitsui.api import BooleanEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -36,6 +36,6 @@ class TestBooleanEditor(unittest.TestCase):
         # Test init and dispose of the editor.
         view = View(Item("true_or_false", editor=BooleanEditor()))
         obj = BoolModel()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=view)):
             pass

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -10,7 +10,7 @@ from traitsui.tests._tools import (
     is_wx,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -60,7 +60,7 @@ class TestButtonEditor(unittest.TestCase):
     def check_button_text_update(self, view):
         button_text_edit = ButtonTextEdit()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(button_text_edit, dict(view=view)) as ui:
 
             process_cascade_events()
@@ -75,7 +75,7 @@ class TestButtonEditor(unittest.TestCase):
     def test_styles(self):
         # simple smoke test of buttons
         button_text_edit = ButtonTextEdit()
-        with store_exceptions_on_all_threads(), create_ui(button_text_edit):
+        with reraise_exceptions(), create_ui(button_text_edit):
             pass
 
     def test_simple_button_editor(self):
@@ -105,7 +105,7 @@ class TestButtonEditorValuesTrait(unittest.TestCase):
         # Smoke test to check init and dispose when values_trait is used.
         instance = ButtonTextEdit(values=["Item1", "Item2"])
         view = self.get_view(style=style)
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with create_ui(instance, dict(view=view)):
                 pass
 

--- a/traitsui/tests/editors/test_check_list_editor.py
+++ b/traitsui/tests/editors/test_check_list_editor.py
@@ -10,7 +10,7 @@ from traitsui.tests._tools import (
     is_wx,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -140,7 +140,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
         )
         model = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             self.assertEqual(editor.names, ["ONE", "TWO"])
@@ -163,7 +163,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
         )
         model = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             # FIXME issue enthought/traitsui#841
@@ -196,7 +196,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
         )
         model = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             self.assertEqual(editor.names, ["ONE", "TWO"])
@@ -223,7 +223,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
         )
         model = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             # FIXME issue enthought/traitsui#841
@@ -257,7 +257,7 @@ class TestCheckListEditorMapping(unittest.TestCase):
         )
         model = ListModel()
 
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with create_ui(model, dict(view=view)):
                 pass
 
@@ -335,7 +335,7 @@ class TestSimpleCheckListEditor(unittest.TestCase):
     def test_simple_check_list_editor_text(self):
         list_edit = ListModel(value=["one"])
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view("simple")) as editor:
 
             self.assertEqual(get_combobox_text(editor.control), "One")
@@ -349,7 +349,7 @@ class TestSimpleCheckListEditor(unittest.TestCase):
         view = get_mapped_view("simple")
         list_edit = ListModel(value=[1])
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, view) as editor:
 
             # FIXME issue enthought/traitsui#841
@@ -368,7 +368,7 @@ class TestSimpleCheckListEditor(unittest.TestCase):
     def test_simple_check_list_editor_index(self):
         list_edit = ListModel(value=["one"])
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view("simple")) as editor:
 
             self.assertEqual(list_edit.value, ["one"])
@@ -386,7 +386,7 @@ class TestSimpleCheckListEditor(unittest.TestCase):
     def test_simple_check_list_editor_invalid_current_values(self):
         list_edit = ListModel(value=[1, "two", "a", object(), "one"])
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view("simple")):
 
             self.assertEqual(list_edit.value, ["two", "one"])
@@ -397,7 +397,7 @@ class TestSimpleCheckListEditor(unittest.TestCase):
 
         str_edit = StrModel(value="alpha, \ttwo, beta,\n lambda, one")
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(str_edit, get_view("simple")):
 
             self.assertEqual(str_edit.value, "two,one")
@@ -416,7 +416,7 @@ class TestCustomCheckListEditor(unittest.TestCase):
     def test_custom_check_list_editor_button_update(self):
         list_edit = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view("custom")) as editor:
 
             self.assertEqual(
@@ -443,7 +443,7 @@ class TestCustomCheckListEditor(unittest.TestCase):
     def test_custom_check_list_editor_click(self):
         list_edit = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view("custom")) as editor:
 
             self.assertEqual(list_edit.value, [])
@@ -461,7 +461,7 @@ class TestCustomCheckListEditor(unittest.TestCase):
     def test_custom_check_list_editor_click_initial_value(self):
         list_edit = ListModel(value=["two"])
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view("custom")) as editor:
 
             self.assertEqual(list_edit.value, ["two"])
@@ -477,7 +477,7 @@ class TestCustomCheckListEditor(unittest.TestCase):
 
         str_edit = StrModel(value="alpha, \ttwo, three,\n lambda, one")
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(str_edit, get_view("custom")) as editor:
 
             self.assertEqual(str_edit.value, "two,three,one")
@@ -502,7 +502,7 @@ class TestTextCheckListEditor(unittest.TestCase):
     def test_text_check_list_object_list(self):
         list_edit = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view("text")) as editor:
 
             self.assertEqual(list_edit.value, [])
@@ -518,7 +518,7 @@ class TestTextCheckListEditor(unittest.TestCase):
 
         str_edit = StrModel(value="three, four")
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(str_edit, get_view("text")) as editor:
 
             self.assertEqual(str_edit.value, "three, four")

--- a/traitsui/tests/editors/test_code_editor.py
+++ b/traitsui/tests/editors/test_code_editor.py
@@ -23,7 +23,7 @@ from traitsui.editors.code_editor import CodeEditor
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -64,7 +64,7 @@ class TestCodeEditor(unittest.TestCase):
         def test_line_numbers_visibility(show=True):
             code_model = CodeModel()
             code_view = CodeView(model=code_model, show_line_numbers=show)
-            with store_exceptions_on_all_threads(), create_ui(code_view) as ui:
+            with reraise_exceptions(), create_ui(code_view) as ui:
                 self.assertEqual(is_line_numbers_visible(ui), show)
                 ui.control.close()
 
@@ -79,7 +79,7 @@ class TestCodeEditor(unittest.TestCase):
 
         code_model = CodeModel()
         code_view = CodeView(model=code_model, style="readonly")
-        with store_exceptions_on_all_threads(), create_ui(code_view) as ui:
+        with reraise_exceptions(), create_ui(code_view) as ui:
             txt_ctrl = ui.control.findChild(qt.QtGui.QPlainTextEdit)
             self.assertTrue(txt_ctrl.isReadOnly())
 

--- a/traitsui/tests/editors/test_csv_editor.py
+++ b/traitsui/tests/editors/test_csv_editor.py
@@ -30,7 +30,7 @@ from traitsui.tests._tools import (
     is_qt,
     press_ok_button,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -60,7 +60,7 @@ class TestCSVEditor(unittest.TestCase):
         list_of_floats = ListOfFloats(data=[1, 2, 3])
         csv_view = ListOfFloatsWithCSVEditor(model=list_of_floats)
         try:
-            with store_exceptions_on_all_threads():
+            with reraise_exceptions():
                 with create_ui(csv_view) as ui:
                     pass
                 # raise an exception if still hooked
@@ -87,7 +87,7 @@ class TestCSVEditor(unittest.TestCase):
 
         list_of_floats = ListOfFloats(data=[1.0])
         csv_view = ListOfFloatsWithCSVEditor(model=list_of_floats)
-        with store_exceptions_on_all_threads(), create_ui(csv_view) as ui:
+        with reraise_exceptions(), create_ui(csv_view) as ui:
 
             # add element to list, make sure that editor knows about it
             list_of_floats.data.append(3.14)

--- a/traitsui/tests/editors/test_date_editor.py
+++ b/traitsui/tests/editors/test_date_editor.py
@@ -9,7 +9,7 @@ from traitsui.editors.date_editor import CellFormat
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -168,7 +168,7 @@ class TestDateEditorInitDispose(unittest.TestCase):
     """ Test the init and dispose of date editor."""
 
     def check_init_and_dispose(self, view):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(Foo(), dict(view=view)):
             pass
 

--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -9,7 +9,7 @@ from traitsui.tests._tools import (
     GuiTestAssistant,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
     no_gui_test_assistant,
 )
@@ -46,7 +46,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
     def test_datetime_editor_simple(self):
         view = get_date_time_simple_view(DatetimeEditor())
         instance = InstanceWithDatetime(date_time=datetime.datetime.now())
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view):
             pass
 
@@ -58,7 +58,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
             q_minimum_datetime = editor.control.minimumDateTime()
             actual_minimum_datetime = to_datetime(q_minimum_datetime)
@@ -74,7 +74,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
             instance.date_time = datetime.datetime(1980, 1, 1)
 
@@ -94,7 +94,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
 
             # This value is in-range
@@ -122,7 +122,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
 
             # This value is in-range
@@ -150,7 +150,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
             q_maximum_datetime = editor.control.maximumDateTime()
 
@@ -168,7 +168,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
             # out-of-bound
             instance.date_time = datetime.datetime(2020, 1, 1)
@@ -189,7 +189,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         )
         view = get_date_time_simple_view(editor_factory)
         instance = InstanceWithDatetime()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
 
             # This value is in-range
@@ -215,7 +215,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         view = get_date_time_simple_view(editor_factory)
         init_datetime = datetime.datetime(1900, 1, 1)
         instance = InstanceWithDatetime(date_time=init_datetime)
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
             # This value is too early and is not supported by Qt
             # But the editor should not crash
@@ -238,7 +238,7 @@ class TestDatetimeEditorQt(GuiTestAssistant, unittest.TestCase):
         view = get_date_time_simple_view(editor_factory)
         init_datetime = datetime.datetime(1900, 1, 1)
         instance = InstanceWithDatetime(date_time=init_datetime)
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.launch_editor(instance, view) as editor:
             # the user set the datetime on the Qt widget to a value
             # too large for Python

--- a/traitsui/tests/editors/test_directory_editor.py
+++ b/traitsui/tests/editors/test_directory_editor.py
@@ -15,7 +15,7 @@ from traitsui.api import DirectoryEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -36,7 +36,7 @@ class TestDirectoryEditor(unittest.TestCase):
         # Test init and dispose by opening and closing the UI
         view = View(Item("dir_path", editor=DirectoryEditor(), style=style))
         obj = DirectoryModel()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=view)):
             pass
 
@@ -57,7 +57,7 @@ class TestDirectoryEditor(unittest.TestCase):
             ),
         )
         obj = DirectoryModel()
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with create_ui(obj, dict(view=view)):
                 pass
             # should not fail.

--- a/traitsui/tests/editors/test_drop_editor.py
+++ b/traitsui/tests/editors/test_drop_editor.py
@@ -15,7 +15,7 @@ from traitsui.api import DropEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -34,7 +34,7 @@ class TestDropEditor(unittest.TestCase):
 
         obj = Model()
         view = View(Item("value", editor=DropEditor(readonly=False)))
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with create_ui(obj, dict(view=view)):
                 pass
             # Mutating value after UI is closed should be okay.
@@ -44,7 +44,7 @@ class TestDropEditor(unittest.TestCase):
 
         obj = Model()
         view = View(Item("value", editor=DropEditor(readonly=True)))
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with create_ui(obj, dict(view=view)):
                 pass
             # Mutating value after UI is closed should be okay.

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -11,7 +11,7 @@ from traitsui.tests._tools import (
     is_wx,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -195,7 +195,7 @@ class TestEnumEditorMapping(unittest.TestCase):
             )
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(IntEnumModel(), formatted_view) as editor:
 
             self.assertEqual(editor.names, ["FALSE", "TRUE"])
@@ -230,7 +230,7 @@ class TestEnumEditorMapping(unittest.TestCase):
         )
         model = IntEnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             self.assertEqual(editor.names, ["FALSE", "TRUE"])
@@ -293,7 +293,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
     def check_enum_text_update(self, view):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view) as editor:
 
             self.assertEqual(get_combobox_text(editor.control), "one")
@@ -306,7 +306,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
     def check_enum_object_update(self, view):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view) as editor:
 
             self.assertEqual(enum_edit.value, "one")
@@ -319,7 +319,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
     def check_enum_index_update(self, view):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view) as editor:
 
             self.assertEqual(enum_edit.value, "one")
@@ -332,7 +332,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
     def check_enum_text_bad_update(self, view):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view) as editor:
 
             self.assertEqual(enum_edit.value, "one")
@@ -367,7 +367,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
         view = get_evaluate_view("simple", auto_set=False)
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view) as editor:
 
             self.assertEqual(enum_edit.value, "one")
@@ -389,7 +389,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
         enum_edit = EnumModel()
         resizable_view = View(UItem("value", style="simple", resizable=True))
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(enum_edit, dict(view=resizable_view)):
             pass
 
@@ -401,7 +401,7 @@ class TestSimpleEnumEditor(unittest.TestCase):
         )
         view = View(UItem("value", editor=enum_editor_factory, style="simple"))
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(EnumModel(), dict(view=view)):
 
             enum_editor_factory.values = ["one", "two", "three"]
@@ -420,7 +420,7 @@ class TestRadioEnumEditor(unittest.TestCase):
     def test_radio_enum_editor_button_update(self):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, get_view("custom")) as editor:
 
             # The layout is: one, three, four \n two
@@ -440,7 +440,7 @@ class TestRadioEnumEditor(unittest.TestCase):
     def test_radio_enum_editor_pick(self):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, get_view("custom")) as editor:
 
             self.assertEqual(enum_edit.value, "one")
@@ -465,7 +465,7 @@ class TestListEnumEditor(unittest.TestCase):
     def check_enum_text_update(self, view):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view) as editor:
 
             self.assertEqual(get_list_widget_text(editor.control), "one")
@@ -478,7 +478,7 @@ class TestListEnumEditor(unittest.TestCase):
     def check_enum_index_update(self, view):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view) as editor:
 
             self.assertEqual(enum_edit.value, "one")

--- a/traitsui/tests/editors/test_file_editor.py
+++ b/traitsui/tests/editors/test_file_editor.py
@@ -15,7 +15,7 @@ from traitsui.api import FileEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -36,7 +36,7 @@ class TestFileEditor(unittest.TestCase):
         # Test init and dispose by opening and closing the UI
         view = View(Item("filepath", editor=FileEditor(), style=style))
         obj = FileModel()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=view)):
             pass
 
@@ -57,7 +57,7 @@ class TestFileEditor(unittest.TestCase):
             ),
         )
         obj = FileModel()
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with create_ui(obj, dict(view=view)):
                 pass
             # should not fail.

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -15,7 +15,7 @@ from traitsui.api import HTMLEditor, Item, View
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -49,7 +49,7 @@ class TestHTMLEditor(unittest.TestCase):
         # Smoke test to check init and dispose do not fail.
         model = HTMLModel()
         view = get_view(base_url_name="")
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(model, dict(view=view)):
             pass
 
@@ -58,7 +58,7 @@ class TestHTMLEditor(unittest.TestCase):
         # fails because sync_value is unhooked in the base class.
         model = HTMLModel()
         view = get_view(base_url_name="model_base_url")
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with create_ui(model, dict(view=view)):
                 pass
             # It is okay to modify base_url after the UI is closed

--- a/traitsui/tests/editors/test_image_enum_editor.py
+++ b/traitsui/tests/editors/test_image_enum_editor.py
@@ -11,7 +11,7 @@ from traitsui.tests._tools import (
     is_wx,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -152,7 +152,7 @@ class TestImageEnumEditorMapping(unittest.TestCase):
             )
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(EnumModel(), formatted_view) as editor:
 
             self.assertEqual(editor.names, ["TOP LEFT", "TOP RIGHT"])
@@ -197,7 +197,7 @@ class TestImageEnumEditorMapping(unittest.TestCase):
         )
         model = PossibleEnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             self.assertEqual(editor.names, ["TOP LEFT", "TOP RIGHT"])
@@ -259,7 +259,7 @@ class TestImageEnumEditorMapping(unittest.TestCase):
         )
         model = PossibleEnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             # Readonly editor doesn't set up full mapping, only check that
@@ -297,14 +297,14 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
             resizable=True,
         )
 
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             self.setup_gui(enum_edit, view)
 
     @requires_toolkit([ToolkitName.wx])
     def test_simple_editor_popup_editor(self):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, get_view("simple")) as editor:
 
             self.assertEqual(enum_edit.value, 'top left')
@@ -335,7 +335,7 @@ class TestSimpleImageEnumEditor(unittest.TestCase):
     def test_simple_editor_combobox(self):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, get_view("simple")) as editor:
 
             self.assertEqual(enum_edit.value, 'top left')
@@ -380,14 +380,14 @@ class TestCustomImageEnumEditor(unittest.TestCase):
             resizable=True,
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, view):
             pass
 
     def test_custom_editor_selection(self):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, get_view("custom")) as editor:
             self.assertEqual(
                 get_button_strings(editor.control),
@@ -408,7 +408,7 @@ class TestCustomImageEnumEditor(unittest.TestCase):
     def test_custom_editor_value_changed(self):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(enum_edit, get_view("custom")) as editor:
             self.assertEqual(
                 get_button_strings(editor.control),
@@ -436,7 +436,7 @@ class TestReadOnlyImageEnumEditor(unittest.TestCase):
     def test_readonly_editor_value_changed(self):
         enum_edit = EnumModel()
 
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             with patch(cache_to_patch, wraps=image_cache) as patched_cache, \
                     create_ui(enum_edit, dict(view=get_view("readonly"))):
 

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -7,7 +7,7 @@ from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -27,7 +27,7 @@ class TestInstanceEditor(unittest.TestCase):
     @requires_toolkit([ToolkitName.qt])
     def test_simple_editor(self):
         obj = NonmodalInstanceEditor()
-        with store_exceptions_on_all_threads(), create_ui(obj) as ui:
+        with reraise_exceptions(), create_ui(obj) as ui:
             editor = ui.get_editors("inst")[0]
 
             # make the dialog appear
@@ -39,7 +39,7 @@ class TestInstanceEditor(unittest.TestCase):
     @requires_toolkit([ToolkitName.qt])
     def test_simple_editor_parent_closed(self):
         obj = NonmodalInstanceEditor()
-        with store_exceptions_on_all_threads(), create_ui(obj) as ui:
+        with reraise_exceptions(), create_ui(obj) as ui:
             editor = ui.get_editors("inst")[0]
 
             # make the dialog appear

--- a/traitsui/tests/editors/test_liststr_editor_selection.py
+++ b/traitsui/tests/editors/test_liststr_editor_selection.py
@@ -36,7 +36,7 @@ from traitsui.tests._tools import (
     press_ok_button,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -212,7 +212,7 @@ class TestListStrEditor(unittest.TestCase):
             yield editor
 
     def test_list_str_editor_single_selection(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
 
             if is_qt():  # No initial selection
@@ -243,7 +243,7 @@ class TestListStrEditor(unittest.TestCase):
     def test_list_str_editor_multi_selection(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), view) as editor:
 
             self.assertEqual(editor.multi_selected_indices, [])
@@ -268,7 +268,7 @@ class TestListStrEditor(unittest.TestCase):
             self.assertEqual(editor.multi_selected, [])
 
     def test_list_str_editor_single_selection_changed(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
 
             if is_qt():  # No initial selection
@@ -311,7 +311,7 @@ class TestListStrEditor(unittest.TestCase):
     def test_list_str_editor_multi_selection_changed(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), view) as editor:
 
             self.assertEqual(get_selected_indices(editor), [])
@@ -350,7 +350,7 @@ class TestListStrEditor(unittest.TestCase):
     def test_list_str_editor_multi_selection_items_changed(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), view) as editor:
 
             self.assertEqual(get_selected_indices(editor), [])
@@ -385,14 +385,14 @@ class TestListStrEditor(unittest.TestCase):
         model = ListStrModel()
 
         # Without auto_add
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(model, dict(view=get_view())) as ui:
             process_cascade_events()
             editor = ui.get_editors("value")[0]
             self.assertEqual(editor.item_count, 3)
 
         # With auto_add
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(model, dict(view=get_view(auto_add=True))) as ui:
             process_cascade_events()
             editor = ui.get_editors("value")[0]
@@ -400,7 +400,7 @@ class TestListStrEditor(unittest.TestCase):
 
     def test_list_str_editor_refresh_editor(self):
         # Smoke test for refresh_editor/refresh_
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
             if is_qt():
                 editor.refresh_editor()
@@ -413,7 +413,7 @@ class TestListStrEditor(unittest.TestCase):
         # QT editor uses selected items as the source of truth when updating
         model = ListStrModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, get_view()) as editor:
 
             set_selected_single(editor, 0)
@@ -445,7 +445,7 @@ class TestListStrEditor(unittest.TestCase):
         # WX editor uses selected indices as the source of truth when updating
         model = ListStrModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, get_view()) as editor:
 
             set_selected_single(editor, 0)
@@ -478,7 +478,7 @@ class TestListStrEditor(unittest.TestCase):
         model = ListStrModel()
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, view) as editor:
 
             set_selected_multiple(editor, [0])
@@ -511,7 +511,7 @@ class TestListStrEditor(unittest.TestCase):
         model = ListStrModel()
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, view) as editor:
 
             set_selected_multiple(editor, [0])
@@ -546,7 +546,7 @@ class TestListStrEditor(unittest.TestCase):
         def change_value(model, value):
             model.value = value
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, get_view()) as editor:
 
             set_selected_single(editor, 0)
@@ -566,7 +566,7 @@ class TestListStrEditor(unittest.TestCase):
     # wx editor doesn't have a `setx` method
     @requires_toolkit([ToolkitName.qt])
     def test_list_str_editor_setx(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), get_view()) as editor:
 
             set_selected_single(editor, 0)
@@ -591,13 +591,13 @@ class TestListStrEditor(unittest.TestCase):
     def test_list_str_editor_horizontal_lines(self):
         # Smoke test for painting horizontal lines
         view = get_view(horizontal_lines=True)
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), view):
             pass
 
     def test_list_str_editor_title(self):
         # Smoke test for adding a title
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListStrModel(), get_view(title="testing")):
             pass
 
@@ -615,7 +615,7 @@ class TestListStrEditor(unittest.TestCase):
             right_clicked_index="object.right_clicked_index",
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, view) as editor:
 
             self.assertEqual(model.right_clicked, "")
@@ -637,7 +637,7 @@ class TestListStrEditorSelection(unittest.TestCase):
         obj = ListStrEditorWithSelectedIndex(
             values=["value1", "value2"], selected_index=1
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=single_select_view)) as ui:
             editor = ui.get_editors("values")[0]
             # the following is equivalent to setting the text in the text
@@ -659,7 +659,7 @@ class TestListStrEditorSelection(unittest.TestCase):
         obj = ListStrEditorWithSelectedIndex(
             values=["value1", "value2"], selected_indices=[1]
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(obj, dict(view=multi_select_view)) as ui:
             editor = ui.get_editors("values")[0]
             # the following is equivalent to setting the text in the text
@@ -684,7 +684,7 @@ class TestListStrEditorSelection(unittest.TestCase):
 
         obj = ListStrEditorWithSelectedIndex(values=["value1", "value2"])
 
-        with store_exceptions_on_all_threads():
+        with reraise_exceptions():
             qt_app = QApplication.instance()
             if qt_app is None:
                 qt_app = QApplication([])

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -5,7 +5,7 @@ from traitsui.api import RangeEditor, UItem, View
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -33,7 +33,7 @@ class TestRangeEditor(unittest.TestCase):
             )
         )
 
-        with store_exceptions_on_all_threads(),\
+        with reraise_exceptions(),\
                 create_ui(obj, dict(view=view)) as ui:
             editor = ui.get_editors("value")[0]
 

--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -36,7 +36,7 @@ from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -63,7 +63,7 @@ class TestRangeEditorSpinner(unittest.TestCase):
 
         num = NumberWithSpinnerEditor()
         try:
-            with store_exceptions_on_all_threads(), create_ui(num) as ui:
+            with reraise_exceptions(), create_ui(num) as ui:
 
                 # the following is equivalent to clicking in the text control
                 # of the range editor, enter a number, and clicking ok without
@@ -99,7 +99,7 @@ class TestRangeEditorSpinner(unittest.TestCase):
             return
 
         num = NumberWithSpinnerEditor()
-        with store_exceptions_on_all_threads(), create_ui(num) as ui:
+        with reraise_exceptions(), create_ui(num) as ui:
 
             # the following is equivalent to clicking in the text control of
             # the range editor, enter a number, and clicking ok without
@@ -130,7 +130,7 @@ class TestRangeEditorSpinner(unittest.TestCase):
         from pyface import qt
 
         num = NumberWithSpinnerEditor()
-        with store_exceptions_on_all_threads(), create_ui(num) as ui:
+        with reraise_exceptions(), create_ui(num) as ui:
 
             # the following is equivalent to clicking in the text control of
             # the range editor, enter a number, and clicking ok without

--- a/traitsui/tests/editors/test_range_editor_text.py
+++ b/traitsui/tests/editors/test_range_editor_text.py
@@ -30,7 +30,7 @@ from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -68,7 +68,7 @@ class TestRangeEditorText(unittest.TestCase):
         # (tests a bug where this fails with an AttributeError)
 
         num = NumberWithRangeEditor()
-        with store_exceptions_on_all_threads(), create_ui(num) as ui:
+        with reraise_exceptions(), create_ui(num) as ui:
 
             # the following is equivalent to setting the text in the text
             # control, then pressing OK
@@ -86,7 +86,7 @@ class TestRangeEditorText(unittest.TestCase):
         from pyface import qt
 
         num = FloatWithRangeEditor()
-        with store_exceptions_on_all_threads(), create_ui(num) as ui:
+        with reraise_exceptions(), create_ui(num) as ui:
 
             # the following is equivalent to setting the text in the text
             # control, then pressing OK

--- a/traitsui/tests/editors/test_set_editor.py
+++ b/traitsui/tests/editors/test_set_editor.py
@@ -11,7 +11,7 @@ from traitsui.tests._tools import (
     is_wx,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -169,7 +169,7 @@ class TestSetEditorMapping(unittest.TestCase):
             )
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(IntListModel(), formatted_view) as editor:
 
             self.assertEqual(editor.names, ["FALSE", "TRUE"])
@@ -203,7 +203,7 @@ class TestSetEditorMapping(unittest.TestCase):
         )
         model = IntListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_ui(model, formatted_view) as editor:
 
             self.assertEqual(editor.names, ["FALSE", "TRUE"])
@@ -232,7 +232,7 @@ class TestSimpleSetEditor(unittest.TestCase):
     def test_simple_set_editor_use_button(self):
         # Initiate with non-alphabetical list
         model = ListModel(value=["two", "one"])
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -256,7 +256,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(editor._get_selected_strings(editor._used), [])
 
     def test_simple_set_editor_unuse_button(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -278,7 +278,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), ["two"])
 
     def test_simple_set_editor_use_dclick(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -295,7 +295,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(editor._get_selected_strings(editor._used), [])
 
     def test_simple_set_editor_unuse_dclick(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -311,7 +311,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), ["two"])
 
     def test_simple_set_editor_use_all(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -333,7 +333,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             )
 
     def test_simple_set_editor_unuse_all(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -355,7 +355,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), [])
 
     def test_simple_set_editor_move_up(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view(ordered=True)) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -374,7 +374,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), ["two", "one"])
 
     def test_simple_set_editor_move_down(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view(ordered=True)) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -393,7 +393,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), ["two", "one"])
 
     def test_simple_set_editor_use_all_button(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -415,7 +415,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             )
 
     def test_simple_set_editor_unuse_all_button(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -437,7 +437,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             self.assertEqual(get_list_items(editor._used), [])
 
     def test_simple_set_editor_default_selection_unused(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -458,7 +458,7 @@ class TestSimpleSetEditor(unittest.TestCase):
         # When all items are used, top used item is selected by default
         list_edit = ListModel(value=["one", "two", "three", "four"])
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, get_view()) as editor:
 
             self.assertEqual(get_list_items(editor._unused), [])
@@ -479,7 +479,7 @@ class TestSimpleSetEditor(unittest.TestCase):
         view = View(UItem("value", editor=editor_factory, style="simple",))
         list_edit = ListModel()
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(list_edit, view) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -501,7 +501,7 @@ class TestSimpleSetEditor(unittest.TestCase):
     def test_simple_set_editor_use_ordered_selected(self):
         # Initiate with non-alphabetical list
         model = ListModel(value=["two", "one"])
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(model, get_view(ordered=True)) as editor:
 
             self.assertEqual(get_list_items(editor._unused), ["four", "three"])
@@ -527,7 +527,7 @@ class TestSimpleSetEditor(unittest.TestCase):
             )
 
     def test_simple_set_editor_unordeder_button_existence(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), get_view()) as editor:
 
             self.assertIsNone(editor._up)
@@ -535,7 +535,7 @@ class TestSimpleSetEditor(unittest.TestCase):
 
     def test_simple_set_editor_cant_move_all_button_existence(self):
         view = get_view(can_move_all=False)
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.setup_gui(ListModel(), view) as editor:
 
             self.assertIsNone(editor._use_all)

--- a/traitsui/tests/editors/test_styled_date_editor.py
+++ b/traitsui/tests/editors/test_styled_date_editor.py
@@ -8,7 +8,7 @@ from traitsui.editors.date_editor import CellFormat
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -50,6 +50,6 @@ class TestStyledDateEditor(unittest.TestCase):
                 style="custom",
             )
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(instance, dict(view=view)):
             pass

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -10,7 +10,7 @@ from traitsui.tests._tools import (
     process_cascade_events,
     press_ok_button,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -267,7 +267,7 @@ class TestTableEditor(unittest.TestCase):
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=simple_view)) as ui:
             process_cascade_events()
 
@@ -277,7 +277,7 @@ class TestTableEditor(unittest.TestCase):
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=filtered_view)) as ui:
             process_cascade_events()
 
@@ -294,7 +294,7 @@ class TestTableEditor(unittest.TestCase):
         )
         object_list.selected = object_list.values[5]
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=select_row_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -314,7 +314,7 @@ class TestTableEditor(unittest.TestCase):
         )
         object_list.selections = object_list.values[5:7]
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=select_rows_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -334,7 +334,7 @@ class TestTableEditor(unittest.TestCase):
         )
         object_list.selected_index = 5
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=select_row_index_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -355,7 +355,7 @@ class TestTableEditor(unittest.TestCase):
         object_list.selected_indices = [5, 7, 8]
 
         view = select_row_indices_view
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -375,7 +375,7 @@ class TestTableEditor(unittest.TestCase):
         )
         object_list.selected_column = "value"
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=select_column_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -395,7 +395,7 @@ class TestTableEditor(unittest.TestCase):
         )
         object_list.selected_columns = ["value", "other_value"]
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=select_columns_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -416,7 +416,7 @@ class TestTableEditor(unittest.TestCase):
         object_list.selected_index = 1
 
         view = select_column_index_view
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -437,7 +437,7 @@ class TestTableEditor(unittest.TestCase):
         object_list.selected_indices = [0, 1]
 
         view = select_column_indices_view
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -457,7 +457,7 @@ class TestTableEditor(unittest.TestCase):
         )
         object_list.selected_cell = (object_list.values[5], "value")
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=select_cell_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -481,7 +481,7 @@ class TestTableEditor(unittest.TestCase):
             (object_list.values[8], "value"),
         ]
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=select_cells_view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -506,7 +506,7 @@ class TestTableEditor(unittest.TestCase):
         object_list.selected_cell_index = (5, 1)
 
         view = select_cell_index_view
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -527,7 +527,7 @@ class TestTableEditor(unittest.TestCase):
         object_list.selected_cell_indices = [(5, 0), (6, 1), (8, 0)]
 
         view = select_cell_indices_view
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
             process_cascade_events()
@@ -561,6 +561,6 @@ class TestTableEditor(unittest.TestCase):
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(object_list, dict(view=progress_view)) as ui:
             process_cascade_events()

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -24,7 +24,7 @@ from traitsui.tests._tools import (
     is_qt,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -185,7 +185,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
     @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_single_selection(self):
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.report_and_editor(get_view()) as (report, editor):
             process_cascade_events()
             people = report.people
@@ -211,7 +211,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
     def test_tabular_editor_multi_selection(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.report_and_editor(view) as (report, editor):
             process_cascade_events()
             people = report.people
@@ -240,7 +240,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
     @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_tabular_editor_single_selection_changed(self):
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.report_and_editor(get_view()) as (report, editor):
             process_cascade_events()
             people = report.people
@@ -277,7 +277,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
     def test_tabular_editor_multi_selection_changed(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.report_and_editor(view) as (report, editor):
             process_cascade_events()
             people = report.people
@@ -315,7 +315,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
     def test_tabular_editor_multi_selection_items_changed(self):
         view = get_view(multi_select=True)
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.report_and_editor(view) as (report, editor):
             process_cascade_events()
             people = report.people
@@ -385,7 +385,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
 
     def test_adapter_columns_changes(self):
         # Regression test for enthought/traitsui#894
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.report_and_editor(get_view()) as (report, editor):
 
             # Reproduce the scenario when the column count is reduced.
@@ -404,7 +404,7 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
         # using it while resizing the columns.
         # The resize event is processed after UI.dispose is called.
         # Maybe related to enthought/traits#431
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 self.report_and_editor(get_view()) as (_, editor):
             editor.adapter.columns = [("Name", "name")]
 

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -27,7 +27,7 @@ from traitsui.tests._tools import (
     no_gui_test_assistant,
     process_cascade_events,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -173,7 +173,7 @@ class TestTextEditor(unittest.TestCase):
         # Smoke test to test setup and tear down of an editor.
         foo = Foo()
         view = get_view(style=style, auto_set=auto_set)
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(foo, dict(view=view)):
             pass
 
@@ -196,7 +196,7 @@ class TestTextEditor(unittest.TestCase):
     def test_simple_auto_set_update_text(self):
         foo = Foo()
         view = get_view(style="simple", auto_set=True)
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
             set_text(editor, "NEW")
@@ -207,7 +207,7 @@ class TestTextEditor(unittest.TestCase):
     def test_simple_auto_set_false_do_not_update(self):
         foo = Foo(name="")
         view = get_view(style="simple", auto_set=False)
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
@@ -225,7 +225,7 @@ class TestTextEditor(unittest.TestCase):
         # the auto_set flag is disregard for custom editor.
         foo = Foo()
         view = get_view(auto_set=True, style="custom")
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
@@ -238,7 +238,7 @@ class TestTextEditor(unittest.TestCase):
         # the auto_set flag is disregard for custom editor.
         foo = Foo()
         view = get_view(auto_set=False, style="custom")
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(foo, dict(view=view)) as ui:
             editor, = ui.get_editors("name")
 
@@ -264,7 +264,7 @@ class TestTextEditor(unittest.TestCase):
             Item("name", format_func=lambda s: s.upper()),
             Item("nickname"),
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(foo, dict(view=view)) as ui:
             name_editor, = ui.get_editors("name")
             nickname_editor, = ui.get_editors("nickname")

--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -29,7 +29,7 @@ from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -134,7 +134,7 @@ class TestTreeView(unittest.TestCase):
         tree_editor_view = BogusTreeView(
             bogus=bogus, hide_root=hide_root, nodes=nodes
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(tree_editor_view) as ui:
 
             # The TreeEditor sets a listener on the bogus object's
@@ -157,7 +157,7 @@ class TestTreeView(unittest.TestCase):
         tree_editor_view = BogusTreeNodeObjectView(
             bogus=bogus, hide_root=hide_root, nodes=nodes
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(tree_editor_view) as ui:
 
             # The TreeEditor sets a listener on the bogus object's

--- a/traitsui/tests/editors/test_tuple_editor.py
+++ b/traitsui/tests/editors/test_tuple_editor.py
@@ -20,7 +20,7 @@ from traitsui.tests._tools import (
     create_ui,
     press_ok_button,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -54,7 +54,7 @@ class TestTupleEditor(unittest.TestCase, UnittestTools):
         from pyface import qt
 
         val = TupleEditor()
-        with store_exceptions_on_all_threads(), create_ui(val) as ui:
+        with reraise_exceptions(), create_ui(val) as ui:
 
             # the following is equivalent to clicking in the text control of
             # the range editor, enter a number, and clicking ok without

--- a/traitsui/tests/test_actions.py
+++ b/traitsui/tests/test_actions.py
@@ -32,7 +32,7 @@ from traitsui.tests._tools import (
     is_mac_os,
     is_null,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -95,7 +95,7 @@ class TestActions(unittest.TestCase):
 
         # create dialog with toolbar adn menu
         dialog = DialogWithToolbar()
-        with store_exceptions_on_all_threads(), create_ui(dialog) as ui:
+        with reraise_exceptions(), create_ui(dialog) as ui:
 
             # press toolbar or menu button
             trigger_action_func(ui)

--- a/traitsui/tests/test_color_column.py
+++ b/traitsui/tests/test_color_column.py
@@ -7,7 +7,7 @@ from traitsui.color_column import ColorColumn
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -47,5 +47,5 @@ class TestColorColumn(TestCase):
         d1 = MyEntry(name="a", value=2, color=(1.0, 0.3, 0.1))
         d2 = MyEntry(name="b", value=3, color=(0.1, 0.0, 0.9))
         data = MyData(data_list=[d1, d2])
-        with store_exceptions_on_all_threads(), create_ui(data):
+        with reraise_exceptions(), create_ui(data):
             pass

--- a/traitsui/tests/test_labels.py
+++ b/traitsui/tests/test_labels.py
@@ -29,7 +29,7 @@ from traitsui.tests._tools import (
     is_control_enabled,
     is_qt,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -134,7 +134,7 @@ class TestLabels(unittest.TestCase):
 
         from pyface import qt
         dialog = ShowRightLabelsDialog()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(dialog) as ui:
 
             # get reference to label objects
@@ -157,7 +157,7 @@ class TestLabels(unittest.TestCase):
 
         from pyface import qt
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(dialog_class()) as ui:
 
             # all labels
@@ -201,7 +201,7 @@ class TestLabels(unittest.TestCase):
         # Behaviour: label should enable/disable along with editor
 
         dialog = EnableWhenDialog()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(dialog) as ui:
 
             labelled_editor = ui.get_editors("labelled_item")[0]
@@ -224,17 +224,17 @@ class TestAnyToolkit(unittest.TestCase):
     """ Toolkit-agnostic tests for labels with different orientations."""
 
     def test_group_show_right_labels(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(ShowRightLabelsDialog()):
             pass
 
     def test_horizontal_resizable_and_labels(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(HResizeTestDialog()):
             pass
 
     def test_all_resizable_with_labels(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(VResizeTestDialog()):
             pass
 
@@ -242,12 +242,12 @@ class TestAnyToolkit(unittest.TestCase):
         # Bug: If one set show_left=False, show_label=False on a non-resizable
         # item like a checkbox, the Qt backend tried to set the label's size
         # policy and failed because label=None.
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(NoLabelResizeTestDialog()):
             pass
 
     def test_enable_when_flag(self):
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(EnableWhenDialog()):
             pass
 

--- a/traitsui/tests/test_layout.py
+++ b/traitsui/tests/test_layout.py
@@ -29,7 +29,7 @@ from traitsui.group import HGroup, VGroup
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -80,7 +80,7 @@ class TestLayout(unittest.TestCase):
 
         from pyface import qt
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(VResizeDialog()) as ui:
             editor, = ui.get_editors("txt")
             text = editor.control
@@ -99,7 +99,7 @@ class TestLayout(unittest.TestCase):
 
         from pyface import qt
 
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(HResizeDialog()) as ui:
 
             editor, = ui.get_editors("txt")
@@ -125,7 +125,7 @@ class TestOrientation(unittest.TestCase):
                 Item("txt2"),
             )
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(MultipleTrait(), ui_kwargs=dict(view=view)):
             pass
 
@@ -137,7 +137,7 @@ class TestOrientation(unittest.TestCase):
                 Item("txt2"),
             )
         )
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(MultipleTrait(), ui_kwargs=dict(view=view)):
             pass
 

--- a/traitsui/tests/test_visible_when_layout.py
+++ b/traitsui/tests/test_visible_when_layout.py
@@ -31,7 +31,7 @@ from traitsui.tests._tools import (
     create_ui,
     get_dialog_size,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -89,7 +89,7 @@ class TestVisibleWhenLayout(unittest.TestCase):
         # most the size of the largest combination of elements.
 
         dialog = VisibleWhenProblem()
-        with store_exceptions_on_all_threads(), create_ui(dialog) as ui:
+        with reraise_exceptions(), create_ui(dialog) as ui:
 
             # have the dialog switch from group one to two and back to one
             dialog.which = "two"

--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -28,7 +28,7 @@ from traitsui.view import View
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
-    store_exceptions_on_all_threads,
+    reraise_exceptions,
     ToolkitName,
 )
 
@@ -315,7 +315,7 @@ class TestDataFrameEditor(unittest.TestCase):
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads(), create_ui(viewer):
+        with reraise_exceptions(), create_ui(viewer):
             pass
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
@@ -331,40 +331,40 @@ class TestDataFrameEditor(unittest.TestCase):
             )
         )
         viewer = sample_data()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(viewer, dict(view=alternate_adapter_view)):
             pass
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_numerical_index(self):
         viewer = sample_data_numerical_index()
-        with store_exceptions_on_all_threads(), create_ui(viewer):
+        with reraise_exceptions(), create_ui(viewer):
             pass
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_text_data(self):
         viewer = sample_text_data()
-        with store_exceptions_on_all_threads(), create_ui(viewer):
+        with reraise_exceptions(), create_ui(viewer):
             pass
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_format_mapping(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(viewer, dict(view=format_mapping_view)):
             pass
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_font_mapping(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(viewer, dict(view=font_mapping_view)):
             pass
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_data_frame_editor_columns(self):
         viewer = sample_data()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(viewer, dict(view=columns_view)):
             pass
 
@@ -383,7 +383,7 @@ class TestDataFrameEditor(unittest.TestCase):
             columns=["X", "Y", "Z"]
         )
         viewer = DataFrameViewer(data=df)
-        with store_exceptions_on_all_threads(), create_ui(viewer) as ui:
+        with reraise_exceptions(), create_ui(viewer) as ui:
             viewer.df_updated = True
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
@@ -401,7 +401,7 @@ class TestDataFrameEditor(unittest.TestCase):
             columns=["X", "Y", "Z"]
         )
         viewer = DataFrameViewer(data=df)
-        with store_exceptions_on_all_threads(), create_ui(viewer) as ui:
+        with reraise_exceptions(), create_ui(viewer) as ui:
             viewer.df_refreshed = True
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
@@ -410,7 +410,7 @@ class TestDataFrameEditor(unittest.TestCase):
             Item("data", editor=DataFrameEditor(multi_select=True), width=400)
         )
         viewer = sample_data()
-        with store_exceptions_on_all_threads(), \
+        with reraise_exceptions(), \
                 create_ui(viewer, dict(view=view)):
             pass
 


### PR DESCRIPTION
This PR:

- The first commit does a plain rename from `store_exceptions_on_all_threads` to `reraise_exceptions`.
- The second commit removes the `store_exceptions_on_all_threads` alias defined in `_tools`.