### PR TITLE
Add a CI job for testing against traits 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt5" TRAITS_REQUIRES="^=6.0"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - os: osx

--- a/etstool.py
+++ b/etstool.py
@@ -94,9 +94,13 @@ DEFAULT_RUNTIME = '3.6'
 # Default toolkit to use if none specified.
 DEFAULT_TOOLKIT = 'null'
 
+# Traits version requirement (empty string to mean no specific requirement).
+# The requirement is to be interpreted by EDM
+TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
+
 dependencies = {
     "numpy",
-    "traits",
+    "traits" + TRAITS_VERSION_REQUIRES,
     "pandas",
     "pygments",
     "pip",


### PR DESCRIPTION
Closes #1054

This PR adds a job for the Travis build to test against Traits 6.0.
I did not multiply the entire matrix with Traits 6.0 because I did not find this necessary. Given most of the GUI tests are skipped on Null or Wx backend, choosing one of the Qt backend exercise most logic that would depend on traits 6.1. Then the choice of PyQt5 over PySide2 is a bit arbitrary.