### PR TITLE
Add change log for etsdemo release 0.1.0

### DIFF
--- a/ets-demo/CHANGES.txt
+++ b/ets-demo/CHANGES.txt
@@ -14,4 +14,4 @@ The application was initially hosted and advertised via
 ``traitsui.extras.demo.demo`` will eventually be deprecated and removed.
 
 See README for further details on how to contribute data and to launch
-the application locally.
+the application.

--- a/ets-demo/CHANGES.txt
+++ b/ets-demo/CHANGES.txt
@@ -1,0 +1,17 @@
+ETS Demo Changelog
+==================
+
+Release 0.1.0
+-------------
+
+This is an initial release of the Enthought Tool Suite Demo GUI application.
+The package itself does not include any demo materials. It relies on other
+projects to contribute data files via entry points.
+
+The application was initially hosted and advertised via
+``traitsui.extras.demo.demo``. The functionality is now supported via
+``etsdemo.main.main`` and projects are encouraged to migrate.
+``traitsui.extras.demo.demo`` will eventually be deprecated and removed.
+
+See README for further details on how to contribute data and to launch
+the application locally.


### PR DESCRIPTION
Preparation for #1031 

This PR adds the changelog file for the release of `etsdemo`.

Since this is the first release, there are technically no "changes". A laundry list of PRs for the migration out of traitsui and preparation for entry points are not particularly useful. I added some description and notes on the intended migration from `traitsui.extras.demo`.  I feel this is the right place as it is close to an announcement.
