### PR TITLE
Fix setup extras_require for PyQt5

### DIFF
--- a/ets-demo/setup.py
+++ b/ets-demo/setup.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
     ]
     extras_require = {
         "wx": ["wxpython>=4", "numpy"],
-        "pyqt5": ["pyqt>=5", "pygments"],
+        "pyqt5": ["pyqt5", "pygments"],
         "pyside2": ["pyside2", "shiboken2", "pygments"],
         "test": ["eam"],
     }

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -25,7 +25,7 @@ __requires__ = ["traits", "pyface>=6.0.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],
-    "pyqt5": ["pyqt>=5", "pygments"],
+    "pyqt5": ["pyqt5", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
     "demo": ["configobj", "docutils"],
     "test": ["packaging"],


### PR DESCRIPTION
It was mentioned before that `pip install pyface[pyqt5]` did not work (see https://github.com/enthought/pyface/issues/446#issuecomment-531195281) and I can confirm this for traitsui and etsdemo.

e.g. Calling `pip install traitsui/ets-demo[pyqt5]` would fail:
```
  ERROR: Could not find a version that satisfies the requirement pyqt>=5
```

This fixes the problem. The distribution name _is_ `pyqt5`