### PR TITLE
Relax test assertion for etsdemo main function

### DIFF
--- a/ets-demo/etsdemo/tests/test_main.py
+++ b/ets-demo/etsdemo/tests/test_main.py
@@ -47,7 +47,7 @@ class TestMain(unittest.TestCase):
     @require_gui
     def test_main(self):
         # Main function must be launchable even if there are no data available.
-        # In normal running situation, the console should be clean
+        # In normal running situation, no loggings should be emitted
         argv = ["etsdemo"]
         mocked_io = io.StringIO()
         with mock_iter_entry_points({}), \
@@ -59,7 +59,7 @@ class TestMain(unittest.TestCase):
             main_module.main()
             console_output = mocked_io.getvalue()
 
-        self.assertEqual(console_output, "")
+        self.assertNotIn("Found 0 resource(s).", console_output)
 
     @require_gui
     def test_main_with_log(self):


### PR DESCRIPTION
The test for running `main` in the normal condition is too strict: It could fail if there were warnings ~printed to the console through code outside of our control~ (Edited:  but the test is about testing logging settings.)
For purpose of the test, we can just assert the log message (asserted in the next test) is not emitted for the normal run condition. 