### PR TITLE
TST: Remove --debug from the eam commmand which isn't available on eam 1.1.0

### DIFF
--- a/ets-demo/etsdemo/tests/test_info.py
+++ b/ets-demo/etsdemo/tests/test_info.py
@@ -30,7 +30,7 @@ class TestInfoForEAM(unittest.TestCase):
     @unittest.skipUnless(EAM_EXISTS, "eam is not available.")
     def test_etsdemo_info(self):
         output = subprocess.check_output(
-            ["eam", "--debug", "info"],
+            ["eam", "info"],
         )
         output = output.decode("utf-8")
         self.assertIn("etsdemo", output)


### PR DESCRIPTION
The current latest version of eam on PyPI is 1.1.0, which does not have this `--debug` option.
This means the test would fail if one installs `etsdemo` and its dependencies all via PyPI.
This PR fixes this by removing the option. The option is not required for the test objective: It only serves to make debugging test failure a bit easier.

This issue has not appeared on CI because `eam` is installed via EDM. And the latest version available has this `--debug` option.
