### PR TITLE
Add install instruction for etsdemo

### DIFF
--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -25,7 +25,7 @@ Or with wxPython dependencies::
 
     $ pip install etsdemo[wx]
 
-(Warning: The application currently suffers from a few issues with the
+(Warning: The application currently suffers from a few major issues with the
 wxPython backend.)
 
 To install with additional test dependencies::

--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -25,6 +25,9 @@ Or with wxPython dependencies::
 
     $ pip install etsdemo[wx]
 
+(Warning: The application currently suffers from a few issues with the
+wxPython backend.)
+
 To install with additional test dependencies::
 
     $ pip install etsdemo[test]

--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -15,19 +15,19 @@ The application requires a GUI backend to run, and a few options are supported.
 
 To install from PyPI with PySide2 dependencies::
 
-    pip install etsdemo[pyside2]
+    $ pip install etsdemo[pyside2]
 
 Or with PyQt5 dependencies::
 
-    pip install etsdemo[pyqt5]
+    $ pip install etsdemo[pyqt5]
 
 Or with wxPython dependencies::
 
-    pip install etsdemo[wx]
+    $ pip install etsdemo[wx]
 
 To install with additional test dependencies::
 
-    pip install etsdemo[test]
+    $ pip install etsdemo[test]
 
 How to run
 ----------

--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -25,7 +25,7 @@ Or with wxPython dependencies::
 
     pip install etsdemo[wx]
 
-To install additional test dependencies::
+To install with additional test dependencies::
 
     pip install etsdemo[test]
 

--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -8,6 +8,27 @@ packages can be used.
 
 The actual demonstration materials are not provided by this package.
 
+Installation
+------------
+
+The application requires a GUI backend to run, and a few options are supported.
+
+To install from PyPI with PySide2 dependencies::
+
+    pip install etsdemo[pyside2]
+
+Or with PyQt5 dependencies::
+
+    pip install etsdemo[pyqt5]
+
+Or with wxPython dependencies::
+
+    pip install etsdemo[wx]
+
+To install additional test dependencies::
+
+    pip install etsdemo[test]
+
 How to run
 ----------
 


### PR DESCRIPTION
`etsdemo` is now live on PyPI, and can be `pip install`-ed.
This PR adds installation instruction on the README so it is shown on the PyPI page for the project.
It will be available on PyPI the next time we release.
