### PR TITLE
Fix index error when clicking space in wx ListStrEditor

### DIFF
--- a/traitsui/wx/list_str_editor.py
+++ b/traitsui/wx/list_str_editor.py
@@ -556,7 +556,10 @@ class _ListStrEditor(Editor):
     def _right_clicked(self, event):
         """ Handles an item being right clicked.
         """
-        self.right_clicked_index = index = event.GetIndex()
+        index = event.GetIndex()
+        if index == -1:
+            return
+        self.right_clicked_index = index
         self.right_clicked = self.adapter.get_item(
             self.object, self.name, index
         )


### PR DESCRIPTION
Closes #1116

The corresponding test is added in #1115 (`test_list_str_editor_right_click_out_of_bound`). The test is skipped due to another crippling error: https://github.com/enthought/traitsui/issues/752
Before this fix, the test would have failed due to the IndexError. After this fix, the test would error due to #752.

`GetIndex()` could return `-1` when what it actually meant is an invalid index. If not checked, the -1 could have been used incorrectly in places to take the last item of a sequence. I have not confirmed/checked if this scenario has been handled correctly in other places of this editor.