### PR TITLE
Fix display of image file in etsdemo

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -517,7 +517,7 @@ class DemoImageFile(DemoFileBase):
 
     def init(self):
         super(DemoImageFile, self).init()
-        rst_content = ".. image:: {}".format(self.path)
+        rst_content = ".. image:: {}".format(self.name)
         self.description = publish_html_str(rst_content, self.css_filename)
 
 

--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -505,18 +505,6 @@ class DemoFile(DemoFileBase):
         return None
 
 
-# HTML template for displaying an image file:
-_image_template = """<html>
-<head>
-<link rel="stylesheet" type="text/css" href="{}">
-</head>
-<body>
-<img src="{}">
-</body>
-</html>
-"""
-
-
 class DemoContentFile(DemoFileBase):
 
     def init(self):
@@ -529,7 +517,8 @@ class DemoImageFile(DemoFileBase):
 
     def init(self):
         super(DemoImageFile, self).init()
-        self.description = _image_template.format(self.css_filename, self.path)
+        rst_content = ".. image:: {}".format(self.path)
+        self.description = publish_html_str(rst_content, self.css_filename)
 
 
 class DemoPath(DemoTreeNodeObject):

--- a/ets-demo/etsdemo/tests/test_app.py
+++ b/ets-demo/etsdemo/tests/test_app.py
@@ -119,7 +119,8 @@ class TestDemoImageFile(unittest.TestCase):
             image_node.init()
 
             # then
-            self.assertIn(basename, image_node.description)
+            # The path may have been normalized by docutils to confirm to file
+            # URI. That is desirable but difficult to test.
             self.assertIn("<img ", image_node.description)
 
 

--- a/ets-demo/etsdemo/tests/test_app.py
+++ b/ets-demo/etsdemo/tests/test_app.py
@@ -18,6 +18,7 @@ from traitsui.api import Handler, UI, UIInfo
 
 from etsdemo.app import (
     Demo,
+    DemoImageFile,
     DemoPath,
     DemoVirtualDirectory,
     extract_docstring_from_source,
@@ -104,6 +105,22 @@ class TestDemo(unittest.TestCase):
 
         # then
         self.assertIsNone(demo.selected_node)
+
+
+class TestDemoImageFile(unittest.TestCase):
+
+    def test_description_contains_file_uri(self):
+        with tempfile.NamedTemporaryFile() as file_obj:
+            dirname, basename = os.path.split(file_obj.name)
+            parent = DemoPath(name=dirname)
+            image_node = DemoImageFile(parent=parent, name=basename)
+
+            # when
+            image_node.init()
+
+            # then
+            self.assertIn(basename, image_node.description)
+            self.assertIn("<img ", image_node.description)
 
 
 class TestDemoPathDescription(unittest.TestCase):

--- a/ets-demo/etsdemo/tests/test_app.py
+++ b/ets-demo/etsdemo/tests/test_app.py
@@ -117,11 +117,15 @@ class TestDemoImageFile(unittest.TestCase):
 
             # when
             image_node.init()
+            tree = ET.fromstring(image_node.description)
 
-            # then
-            # The path may have been normalized by docutils to confirm to file
-            # URI. That is desirable but difficult to test.
-            self.assertIn("<img ", image_node.description)
+        # then
+        # The image path should be either a fully specified absolute path
+        # following the file scheme, or a file name relative to the
+        # base_url given to the HTML editor.
+        img_xml = next(tree.iter(get_html_tag("img")))
+        self.assertEqual(img_xml.attrib["src"], basename)
+        self.assertEqual(image_node.base_url, dirname)
 
 
 class TestDemoPathDescription(unittest.TestCase):


### PR DESCRIPTION
Closes #1122

There are two ways to fix the issue: 
(1) Sanitize the file path to a conforming file URI with an absolute path
(2) Use the file name directly and rely on the `base_url_name` set on the HTMLEditor.

This PR uses option (2) to fix this issue: it is the least effort one and is also consistent with the handling in other nodes (e.g. the file handler for the index.rst).
