### PR TITLE
Dedent lists in demo description

### DIFF
--- a/traitsui/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
+++ b/traitsui/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
@@ -13,11 +13,12 @@ which allows the tabular editor to automatically update itself when the content
 of any object in the list associated with the editor is modified.
 
 To interact with the demo:
-  - Select an employee from the list.
-  - Adjust their salary increase.
-  - Click the **Give raise** button.
-  - Observe that the table automatically updates to reflect the employees new
-    salary.
+
+- Select an employee from the list.
+- Adjust their salary increase.
+- Click the **Give raise** button.
+- Observe that the table automatically updates to reflect the employees new
+salary.
 
 In order for auto-update to work correctly, the editor trait should be a list
 of objects derived from HasTraits. Also, performance can be affected when very

--- a/traitsui/examples/demo/Advanced/List_editors_demo.py
+++ b/traitsui/examples/demo/Advanced/List_editors_demo.py
@@ -12,9 +12,9 @@
 This shows the three different types of editor that can be applied to a list
 of objects:
 
- - Table
- - List
- - Dockable notebook (a list variant)
+- Table
+- List
+- Dockable notebook (a list variant)
 
 Each editor style is editing the exact same list of objects. Note that any
 changes made in one editor are automatically reflected in the others.

--- a/traitsui/examples/demo/Advanced/MVC_demo.py
+++ b/traitsui/examples/demo/Advanced/MVC_demo.py
@@ -12,9 +12,8 @@ would separate these.
 
 A few key points:
 
-     - the Controller itself accesses the model as self.model
-
-     - the Controller's View can access model traits directly ('myname')
+- the Controller itself accesses the model as self.model
+- the Controller's View can access model traits directly ('myname')
 """
 
 from traits.api import HasTraits, Str, Bool, TraitError

--- a/traitsui/examples/demo/Advanced/NumPy_array_view_editor_demo.py
+++ b/traitsui/examples/demo/Advanced/NumPy_array_view_editor_demo.py
@@ -25,15 +25,15 @@ If the list of 'titles' is empty, no column headers will be displayed.
 If the number of column headers is less than the number of array columns, then
 there are two cases:
 
-    - If (number of array_columns) % (number of titles) == 0, then the titles
-      are used to construct a series of repeating column headers with increasing
-      subscripts (e.g. an (n x 6) array with titles of ['x','y','z'] would
-      result in column headers of: 'x0', 'y0', 'z0', 'x1', 'y1', 'z1').
+- If (number of array_columns) % (number of titles) == 0, then the titles
+  are used to construct a series of repeating column headers with increasing
+  subscripts (e.g. an (n x 6) array with titles of ['x','y','z'] would
+  result in column headers of: 'x0', 'y0', 'z0', 'x1', 'y1', 'z1').
 
-    - In all other cases the titles are used as the column headers for the
-      first set of columns, and the remaining column headers are set to the
-      empty string (e.g. an (n x 5) array with titles of ['x','y','z'] would
-      result in column headers of: 'x', 'y', 'z', '', '').
+- In all other cases the titles are used as the column headers for the
+  first set of columns, and the remaining column headers are set to the
+  empty string (e.g. an (n x 5) array with titles of ['x','y','z'] would
+  result in column headers of: 'x', 'y', 'z', '', '').
 
 Setting 'transpose' to True will logically transpose the input array (e.g. an
 (3 x n) array will be displayed as an (n x 3) array).

--- a/traitsui/examples/demo/Advanced/Popup_Dialog_demo.py
+++ b/traitsui/examples/demo/Advanced/Popup_Dialog_demo.py
@@ -14,17 +14,19 @@ value. If you click anywhere else outside of the pop-up dialog, the pop-up
 dialog will simply disappear, leaving the person's new gender value as is.
 
 The main items of interest in this demo are:
- - The: kind = 'popup' trait set in the PersonHandler View which marks the view
-   as being a popup view.
- - The parent = info.gender.control value passed to the edit_traits method
-   when the popup dialog is created in the object_gender_changed method. This
-   value specifies the control that the popup dialog should be positioned near.
+
+- The: kind = 'popup' trait set in the PersonHandler View which marks the view
+  as being a popup view.
+- The parent = info.gender.control value passed to the edit_traits method
+  when the popup dialog is created in the object_gender_changed method. This
+  value specifies the control that the popup dialog should be positioned near.
 
 Notes:
- - Traits UI will automatically position the popup dialog near the specified
-   control in such a way that the pop-up dialog will not overlay the control
-   and will be entirely on the screen (as long as these two conditions do not
-   conflict).
+
+- Traits UI will automatically position the popup dialog near the specified
+  control in such a way that the pop-up dialog will not overlay the control
+  and will be entirely on the screen (as long as these two conditions do not
+  conflict).
 """
 
 #-- Imports --------------------------------------------------------------

--- a/traitsui/examples/demo/Advanced/Scrubber_editor_demo.py
+++ b/traitsui/examples/demo/Advanced/Scrubber_editor_demo.py
@@ -29,65 +29,65 @@ than a full-fledged slider in space limited applications.
 
 The Traits UI ScrubberEditor works as follows:
 
-  - When the mouse pointer moves over the scrubber, the cursor pointer changes
-    shape to indicate that the field has some additional control behavior.
+- When the mouse pointer moves over the scrubber, the cursor pointer changes
+  shape to indicate that the field has some additional control behavior.
 
-  - The control may optionally change color as well, to visually indicate that
-    the control is 'live'.
+- The control may optionally change color as well, to visually indicate that
+  the control is 'live'.
 
-  - If you simply click on the scrubber, an active text entry field is
-    displayed, where you can type a new value for the trait, then press the
-    Enter key.
+- If you simply click on the scrubber, an active text entry field is
+  displayed, where you can type a new value for the trait, then press the
+  Enter key.
 
-  - If you click and drag while over the scrubber, the value of the trait is
-    modified based on the direction you move the mouse. Right and/or up
-    increases the value, left and/or down decreases the value. Holding the
-    Shift key down while scrubbing causes the value to change by 10 times its
-    normal amount. Holding the Control key down while scrubbing changes the
-    value by 0.1 times its normal amount.
+- If you click and drag while over the scrubber, the value of the trait is
+  modified based on the direction you move the mouse. Right and/or up
+  increases the value, left and/or down decreases the value. Holding the
+  Shift key down while scrubbing causes the value to change by 10 times its
+  normal amount. Holding the Control key down while scrubbing changes the
+  value by 0.1 times its normal amount.
 
-  - Scrubbing is not limited to the area of the scrubber control. You can drag
-    as far as you want in any direction, subject to the maximum limits imposed
-    by the trait or ScrubberEditor definition.
+- Scrubbing is not limited to the area of the scrubber control. You can drag
+  as far as you want in any direction, subject to the maximum limits imposed
+  by the trait or ScrubberEditor definition.
 
 The ScrubberEditor also supports several different style and functional
 variations:
 
-  - The visual default is to display only the special scrubber pointer to
-    indicate to the user that 'scrubber' functionality is available.
+- The visual default is to display only the special scrubber pointer to
+  indicate to the user that 'scrubber' functionality is available.
 
-  - By specifying a 'hover_color' value, you can also have the editor change
-    color when the mouse pointer is over it.
+- By specifying a 'hover_color' value, you can also have the editor change
+  color when the mouse pointer is over it.
 
-  - By specifying an 'active_color' value, you can have the editor change color
-    while the user is scrubbing.
+- By specifying an 'active_color' value, you can have the editor change color
+  while the user is scrubbing.
 
-  - By specifying a 'border_color' value, you can display a solid border around
-    the editor to mark it as something other than an ordinary text field.
+- By specifying a 'border_color' value, you can display a solid border around
+  the editor to mark it as something other than an ordinary text field.
 
-  - By specifying an 'increment' value, you can tell the editor what the normal
-    increment value for the scrubber should be. Otherwise, the editor will
-    calculate the increment value itself. Explicitly specifying an increment
-    can be very useful in cases where the underlying trait has an unbounded
-    value, which makes it difficult for the editor to determine what a
-    reasonable increment value might be.
+- By specifying an 'increment' value, you can tell the editor what the normal
+  increment value for the scrubber should be. Otherwise, the editor will
+  calculate the increment value itself. Explicitly specifying an increment
+  can be very useful in cases where the underlying trait has an unbounded
+  value, which makes it difficult for the editor to determine what a
+  reasonable increment value might be.
 
-  - The editor will also correctly handle traits with dynamic ranges (i.e.
-    ranges whose high and low limits are defined by other traits). Besides
-    correctly handling the range limits, the editor will also adjust the
-    default tooltip to display the current range of the scrubber.
+- The editor will also correctly handle traits with dynamic ranges (i.e.
+  ranges whose high and low limits are defined by other traits). Besides
+  correctly handling the range limits, the editor will also adjust the
+  default tooltip to display the current range of the scrubber.
 
 In this example, several of the variations described above are shown:
 
-  - A simple integer range with default visual cues.
+- A simple integer range with default visual cues.
 
-  - A float range with both 'hover_color' and 'active_color' values specified.
+- A float range with both 'hover_color' and 'active_color' values specified.
 
-  - An unbounded range with a 'border_color' value specified.
+- An unbounded range with a 'border_color' value specified.
 
-  - A dynamic range. This consists of three scrubbers: one
-    to control the low end of the range, one to control the high end, and one
-    that uses the high and low values to determine its range.
+- A dynamic range. This consists of three scrubbers: one
+  to control the low end of the range, one to control the high end, and one
+  that uses the high and low values to determine its range.
 
 For comparison purposes, the example also shows the same traits displayed using
 their default editors.

--- a/traitsui/examples/demo/Advanced/Statusbar_demo.py
+++ b/traitsui/examples/demo/Advanced/Statusbar_demo.py
@@ -11,8 +11,8 @@ the object attribute that will contain the statusbar information.
 
 In this example, there are two statusbar fields:
 
- - The current length of the text input data (variable width)
- - The current time (fixed width, updated once per second).
+- The current length of the text input data (variable width)
+- The current time (fixed width, updated once per second).
 
 Note the use of a timer thread to update the status bar once per second.
 

--- a/traitsui/examples/demo/Advanced/Table_editor_with_live_search_and_cell_editor.py
+++ b/traitsui/examples/demo/Advanced/Table_editor_with_live_search_and_cell_editor.py
@@ -13,11 +13,11 @@ across the top line of the view.
 You specify the root directory to search for files in using the 'Path' field.
 You can either:
 
-  - Type in a directory name.
-  - Click the '...' button and select a directory from the drop-down tree view
-    that is displayed.
-  - Click on the directory name drop-down to display a history list of the 10
-    most recently visited directories, and select a directory from the list.
+- Type in a directory name.
+- Click the '...' button and select a directory from the drop-down tree view
+  that is displayed.
+- Click on the directory name drop-down to display a history list of the 10
+  most recently visited directories, and select a directory from the list.
 
 You can specify whether sub-directories should be included or not by toggling
 the 'Recursive' checkbox on or off.
@@ -39,17 +39,17 @@ You can specify whether the search is case sensitive or not by toggling the
 The results of the search are displayed in a table below the input fields.
 The table contains four columns:
 
-  - #: The number of lines matching the search string in the file.
-  - Matches: A list of all lines containing search string matches in the file.
-    Normally, only the first match is displayed, but you can click on this
-    field to display the entire list of matches (the table row will expand and a
-    CodeEditor will be displayed showing the complete list of matching source
-    code file lines). You can click on or cursor to lines in the code editor to
-    display the corresponding source code line in context in the code editor
-    that appears at the bottom of the view.
-  - Name: Displays the base name of the source file with no path information.
-  - Path: Displays the portion of the source file path not included in the
-    the root directory being used for the search.
+- #: The number of lines matching the search string in the file.
+- Matches: A list of all lines containing search string matches in the file.
+  Normally, only the first match is displayed, but you can click on this
+  field to display the entire list of matches (the table row will expand and a
+  CodeEditor will be displayed showing the complete list of matching source
+  code file lines). You can click on or cursor to lines in the code editor to
+  display the corresponding source code line in context in the code editor
+  that appears at the bottom of the view.
+- Name: Displays the base name of the source file with no path information.
+- Path: Displays the portion of the source file path not included in the
+  the root directory being used for the search.
 
 Selecting a line in the table editor will display the contents of the
 corresponding source file in the Code Editor displayed at the bottom of the
@@ -65,13 +65,12 @@ You can also exit the 'Matches' code editor by pressing the Escape key.
 
 Finally:
 
-  - You can click and drag the little circle to the right of the currently
-    selected file to drag and drop the file. This can be useful, for example, to
-    drag and drop the file into your favorite text editor.
-
-  - Similarly, you can also drag the contents of the 'Name' column into your
-    favorite text editor to edit the file corresponding to that line in the
-    table.
+- You can click and drag the little circle to the right of the currently
+  selected file to drag and drop the file. This can be useful, for example, to
+  drag and drop the file into your favorite text editor.
+- Similarly, you can also drag the contents of the 'Name' column into your
+  favorite text editor to edit the file corresponding to that line in the
+  table.
 """
 
 #-- Imports --------------------------------------------------------------

--- a/traitsui/examples/demo/Advanced/Tabular_editor_demo.py
+++ b/traitsui/examples/demo/Advanced/Tabular_editor_demo.py
@@ -16,43 +16,43 @@ relative to the table editor. See the Traits UI User Manual for details.
 
 This example defines three classes:
 
- - *Person*: A single person.
- - *MarriedPerson*: A married person (subclass of Person).
- - *Report*: Defines a report based on a list of single and married people.
+- *Person*: A single person.
+- *MarriedPerson*: A married person (subclass of Person).
+- *Report*: Defines a report based on a list of single and married people.
 
 It creates a tabular display of 10,000 single and married people showing the
 following information:
 
- - Name of the person.
- - Age of the person.
- - The person's address.
- - The name of the person's spouse (if any).
+- Name of the person.
+- Age of the person.
+- The person's address.
+- The name of the person's spouse (if any).
 
 In addition:
 
- - It uses a Courier 10 point font for each line in the table.
- - It displays age column right, instead of left, justified.
- - If the person is a minor (age < 18) and married, it displays a red flag
-   image in the age column.
- - If the person is married, it makes the background color for that row a light
-   blue.
+- It uses a Courier 10 point font for each line in the table.
+- It displays age column right, instead of left, justified.
+- If the person is a minor (age < 18) and married, it displays a red flag
+  image in the age column.
+- If the person is married, it makes the background color for that row a light
+  blue.
 
- - If this demo is running under QT, it displays each person's surname
-   in a row label.
+- If this demo is running under QT, it displays each person's surname
+in a row label.
 
 This example demonstrates:
 
- - How to set up a *TabularEditor*.
- - The display speed of the *TabularEditor*.
- - How to create a *TabularAdapter* that meets each of the specified display
-   requirements.
+- How to set up a *TabularEditor*.
+- The display speed of the *TabularEditor*.
+- How to create a *TabularAdapter* that meets each of the specified display
+requirements.
 
 Additional notes:
 
- - You can change the current selection using the up and down arrow keys.
- - If the demo is running under WX, you can move a selected row up and down in
-   the table using the left and right arrow keys.
- - If the demo is running under QT, you can move rows by clicking and dragging.
+- You can change the current selection using the up and down arrow keys.
+- If the demo is running under WX, you can move a selected row up and down in
+  the table using the left and right arrow keys.
+- If the demo is running under QT, you can move rows by clicking and dragging.
 
 Hopefully, this simple example conveys some of the power and flexibility that
 the :py:class:`TabularAdapter` class provides you. But, just in case it

--- a/traitsui/examples/demo/Applications/Python_source_browser.py
+++ b/traitsui/examples/demo/Applications/Python_source_browser.py
@@ -6,17 +6,17 @@ This demo shows a combination of the **DirectoryEditor**, the
 **TabularEditor** and the **CodeEditor** used to create a simple Python
 source browser:
 
- - Use the **DirectoryEditor** on the left to navigate to and select
-   directories containing Python source files.
- - Use the **TabularEditor** on the top-right to view information about and
-   to select Python source files in the currently selected directory.
- - View the currently selected Python source file's contents in the
-   **CodeEditor** in the bottom-right.
+- Use the **DirectoryEditor** on the left to navigate to and select
+  directories containing Python source files.
+- Use the **TabularEditor** on the top-right to view information about and
+  to select Python source files in the currently selected directory.
+- View the currently selected Python source file's contents in the
+  **CodeEditor** in the bottom-right.
 
 As an extra *feature*, the **TabularEditor** also displays a:
 
- - Red ball if the file size > 64KB.
- - Blue ball if the file size > 16KB.
+- Red ball if the file size > 64KB.
+- Blue ball if the file size > 16KB.
 """
 
 from time \

--- a/traitsui/examples/demo/Dynamic_Forms/dynamic_range_editor.py
+++ b/traitsui/examples/demo/Dynamic_Forms/dynamic_range_editor.py
@@ -13,9 +13,9 @@ limits would often be calculated from other user input or model data.
 
 The demo is divided into three tabs:
 
- * A dynamic range using a simple slider.
- * A dynamic range using a large-range slider.
- * A dynamic range using a spinner.
+* A dynamic range using a simple slider.
+* A dynamic range using a large-range slider.
+* A dynamic range using a spinner.
 
 In each section of the demo, the top-most 'value' trait can have its range
 end points changed dynamically by modifying the 'low' and 'high' sliders

--- a/traitsui/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
@@ -6,16 +6,16 @@ items from a list of known strings.
 
 This example demonstrates the checklist editor's two most useful styles:
 
-  * 'custom' displays all the strings in columns next to checkboxes.
-  * 'readonly' displays only the selected strings, as a Python list of strings.
+* 'custom' displays all the strings in columns next to checkboxes.
+* 'readonly' displays only the selected strings, as a Python list of strings.
 
 We do *not* demonstrate two styles which are not as useful for this editor:
 
-  * 'text' is like 'readonly' except editable. It will accept a list of strings
-    or numbers or even expressions. This is useful for quick, non-production
-    data entry, but it ignores the editor's list of valid 'values'.
-  * 'simple' (the default) only lets you select one item at a time, from a
-    drop-down widget.
+* 'text' is like 'readonly' except editable. It will accept a list of strings
+  or numbers or even expressions. This is useful for quick, non-production
+  data entry, but it ignores the editor's list of valid 'values'.
+* 'simple' (the default) only lets you select one item at a time, from a
+  drop-down widget.
 """
 
 from traits.api import HasTraits, List

--- a/traitsui/examples/demo/Standard_Editors/EnumEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/EnumEditor_demo.py
@@ -10,14 +10,14 @@ tuples.
 
 An Enum can be displayed / edited in one of five styles:
 
-  * 'simple' displays a drop-down list of allowed values
-  * 'custom' by default, displays one or more columns of radio buttons (only
-    one of which is selected at a time).
-  * 'custom' in 'list' mode (see source code below), displays a list of all the
-    allowed values at once.
-  * 'readonly' displays the current value as non-editable text.
-  * 'text' displays the current value as text. You can also edit this text,
-    but your text must be in the list of allowed values.
+* 'simple' displays a drop-down list of allowed values
+* 'custom' by default, displays one or more columns of radio buttons (only
+  one of which is selected at a time).
+* 'custom' in 'list' mode (see source code below), displays a list of all the
+  allowed values at once.
+* 'readonly' displays the current value as non-editable text.
+* 'text' displays the current value as text. You can also edit this text,
+  but your text must be in the list of allowed values.
 
 """
 

--- a/traitsui/examples/demo/Standard_Editors/File_Dialog/File_Open.py
+++ b/traitsui/examples/demo/Standard_Editors/File_Dialog/File_Open.py
@@ -15,49 +15,49 @@ the standard OS file dialog is also available?
 And the answer is that you can use either, but the advantages of using the
 TraitsUI file dialog are:
 
- - It supports history. That is, each time the user selects a file for opening,
-   the file is added to a persistent history list, similar to many applications
-   *Open recent...* function, but built directly into the file dialog.
-   The amount of history remembered can be specified by the developer, with the
-   default being the last 10 files opened.
+- It supports history. That is, each time the user selects a file for opening,
+  the file is added to a persistent history list, similar to many applications
+  *Open recent...* function, but built directly into the file dialog.
+  The amount of history remembered can be specified by the developer, with the
+  default being the last 10 files opened.
 
- - It is resizable. Some standard OS file dialogs are not resizable, which can
-   be very annoying to the user trying to select a file through a tiny
-   peephole view of the file system. In addition, if the user resizes the
-   dialog, the new size and position will be persisted, so that the file dialog
-   will appear in the same location the next time the user wants to open a
-   file.
+- It is resizable. Some standard OS file dialogs are not resizable, which can
+  be very annoying to the user trying to select a file through a tiny
+  peephole view of the file system. In addition, if the user resizes the
+  dialog, the new size and position will be persisted, so that the file dialog
+  will appear in the same location the next time the user wants to open a
+  file.
 
- - There is a very nice synergy between the file system view and the history
-   list. Quite often users shuttle between several *favorite* locations in
-   the file system when opening files. The TraitsUI file dialog automatically
-   discovers these favorite locations just by the user opening files. When a
-   user opens the file dialog, they can select a previously opened file from
-   the history list, which then automatically causes the file system view to
-   expand the selected file's containing folder, thus allowing them to select a
-   different file in the same location. Since the history list is updated each
-   time a user selects a file, It tends to automatically discover a *working
-   set* of favorite directories just through simple use, without the user
-   having to explicitly designate them as such.
+- There is a very nice synergy between the file system view and the history
+  list. Quite often users shuttle between several *favorite* locations in
+  the file system when opening files. The TraitsUI file dialog automatically
+  discovers these favorite locations just by the user opening files. When a
+  user opens the file dialog, they can select a previously opened file from
+  the history list, which then automatically causes the file system view to
+  expand the selected file's containing folder, thus allowing them to select a
+  different file in the same location. Since the history list is updated each
+  time a user selects a file, It tends to automatically discover a *working
+  set* of favorite directories just through simple use, without the user
+  having to explicitly designate them as such.
 
- - It's customizable. The TraitsUI file dialog accepts extension objects which
-   can be used to display additional file information or even modify the
-   selection behavior of the dialog. Several extensions are provided with
-   TraitsUI (and are demonstrated in some of the other examples), and you are
-   free to write your own by implementing a very simple interface.
+- It's customizable. The TraitsUI file dialog accepts extension objects which
+  can be used to display additional file information or even modify the
+  selection behavior of the dialog. Several extensions are provided with
+  TraitsUI (and are demonstrated in some of the other examples), and you are
+  free to write your own by implementing a very simple interface.
 
- - The history and user settings are customizable per application. Just by
-   setting a unique id in the file dialog request, you can specify that the
-   history and window size and position information are specific to your
-   application. If you have file dialog extensions added, the user can
-   reorder, resize and reconfigure the overall file dialog layout, including
-   your extensions, and have their custom settings restored each time they use
-   the file dialog. If you do not specify a unique id, then the history and
-   user settings default to the system-wide settings for the file dialog. It's
-   your choice.
+- The history and user settings are customizable per application. Just by
+  setting a unique id in the file dialog request, you can specify that the
+  history and window size and position information are specific to your
+  application. If you have file dialog extensions added, the user can
+  reorder, resize and reconfigure the overall file dialog layout, including
+  your extensions, and have their custom settings restored each time they use
+  the file dialog. If you do not specify a unique id, then the history and
+  user settings default to the system-wide settings for the file dialog. It's
+  your choice.
 
- - It's easy to use. That's what this particular example is all about. So take
-   a look at the source code for this example to see how easy it is...
+- It's easy to use. That's what this particular example is all about. So take
+  a look at the source code for this example to see how easy it is...
 """
 # Issue related to the demo warning: enthought/traitsui#953
 

--- a/traitsui/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
+++ b/traitsui/examples/demo/Standard_Editors/File_Dialog/File_Open_with_FileInfo_Extension.py
@@ -10,10 +10,10 @@ This demonstrates using the TraitsUI file dialog with a file dialog extension,
 in this case, the **FileInfo** extension, which displays information about
 the currently selected file, such as:
 
- - File size.
- - Date and time last accessed.
- - Date and time last modified.
- - Date and time last created.
+- File size.
+- Date and time last accessed.
+- Date and time last modified.
+- Date and time last created.
 
 For more information about why you would want to use the TraitsUI file dialog
 over the standard OS file dialog, select the **File Open** demo. For a

--- a/traitsui/examples/demo/Standard_Editors/TextEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/TextEditor_demo.py
@@ -6,12 +6,10 @@ The TextEditor displays a Str, Password, or Int trait for the user to edit.
 The demo shows all styles of the editor for each of the traits, however certain
 styles are more useful than others:
 
-  - When editing a Str, consider styles 'simple' (one-line), 'custom'
-    (multi-line), or 'readonly' (multi-line).
-
-  - When editing a Password, style 'simple' is recommended (shows asterisks).
-
-  - When editing an Int, consider styles 'simple' and 'readonly'.
+- When editing a Str, consider styles 'simple' (one-line), 'custom'
+  (multi-line), or 'readonly' (multi-line).
+- When editing a Password, style 'simple' is recommended (shows asterisks).
+- When editing an Int, consider styles 'simple' and 'readonly'.
 
 """
 

--- a/traitsui/examples/demo/Standard_Editors/TitleEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/TitleEditor_demo.py
@@ -10,14 +10,14 @@ the view.
 
 This demonstration shows three variations of using a TitleEditor:
 
- * In the first example, the TitleEditor values are supplied by an Enum trait.
-   Simply select a new value for the title from the drop-down list to cause the
-   title to change.
- * In the second example, the TitleEditor values are supplied by a Str trait.
-   Simply type a new value into the title field to cause the title to change.
- * In the third example, the TitleEditor values are supplied by a Property
-   whose value is derived from a calculation on a Float trait. Type a number
-   into the value field to cause the title to changed.
+* In the first example, the TitleEditor values are supplied by an Enum trait.
+  Simply select a new value for the title from the drop-down list to cause the
+  title to change.
+* In the second example, the TitleEditor values are supplied by a Str trait.
+  Simply type a new value into the title field to cause the title to change.
+* In the third example, the TitleEditor values are supplied by a Property
+  whose value is derived from a calculation on a Float trait. Type a number
+  into the value field to cause the title to changed.
 """
 
 from traits.api import HasTraits, Enum, Str, Float, Property, cached_property

--- a/traitsui/examples/demo/Standard_Editors/TreeEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/TreeEditor_demo.py
@@ -6,13 +6,10 @@ structure.
 
 In this case, the tree has the following hierarchy:
 
-  - Partner
-
-    - Company
-
-      - Department
-
-        - Employee
+- Partner
+ - Company
+  - Department
+   - Employee
 
 The TreeEditor generates a hierarchical tree control, consisting of nodes. It
 is useful for cases where objects contain lists of other objects.


### PR DESCRIPTION
Some of the lists had indentation which made the description look awkward. This commit simply dedents the lists.