### PR TITLE
Update extras_require to include requirements for examples

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -122,6 +122,7 @@ test_dependencies = {
     "apptools",
     "chaco",
     "h5py",
+    "pandas",
     "pytables",
 }
 

--- a/etstool.py
+++ b/etstool.py
@@ -116,6 +116,8 @@ source_dependencies = {
 }
 
 # Additional toolkit-independent dependencies for demo testing
+# This should correspond to the "examples" dependencies in extras_requires but
+# the following names are used by EDM.
 test_dependencies = {
     "apptools",
     "chaco",

--- a/etstool.py
+++ b/etstool.py
@@ -122,6 +122,7 @@ test_dependencies = {
     "apptools",
     "chaco",
     "h5py",
+    "numpy",
     "pandas",
     "pytables",
 }

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -37,6 +37,7 @@ __extras_require__ = {
         "chaco",   # for a very simple example, see enthought/traitsui#1139
         "h5py",
         "numpy",
+        "pandas",
         "tables",
     ],
     "test": ["packaging"],

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -27,7 +27,14 @@ __extras_require__ = {
     "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt5", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
-    "demo": ["configobj", "docutils"],
+    "examples": [
+        # Dependencies for examples
+        "apptools",
+        "chaco",   # for a very simple example, see enthought/traitsui#1139
+        "h5py",
+        "numpy",
+        "tables",
+    ],
     "test": ["packaging"],
 }
 

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -27,7 +27,10 @@ __extras_require__ = {
     "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt5", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
-    "demo": ["configobj", "docutils"],
+    "demo": [
+        # to be deprecated, see enthought/traitsui#950
+        "configobj", "docutils",
+    ],
     "examples": [
         # Dependencies for examples
         "apptools",

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -27,6 +27,7 @@ __extras_require__ = {
     "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt5", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
+    "demo": ["configobj", "docutils"],
     "examples": [
         # Dependencies for examples
         "apptools",


### PR DESCRIPTION
This provides for point 2 of #1125
 This PR updates the `extras_requires` to include dependencies for the demo examples.

We should mention this in the README, but then we should also mention installation options for PyQt5 etc... they aren't there at the moment, and I decided not to mix them in this PR.