### PR TITLE
adding a workaround that prevents a possible segfault in Settable_cached_property.py

### DIFF
--- a/traitsui/examples/demo/Advanced/Settable_cached_property.py
+++ b/traitsui/examples/demo/Advanced/Settable_cached_property.py
@@ -84,7 +84,7 @@ class SettableCachedProperty(HasTraits):
         Item('c'),
         '_',
         Item('d',
-             editor=RangeEditor(low=1, high=400, mode='slider')),
+             editor=RangeEditor(low=1, high=400, mode='slider'), style='readonly'),
         Item('d'),
         width=0.3
     )


### PR DESCRIPTION
fixes #1069 

This changes the view of the d attribute to not show the slider.  However, the d attribute is intended to be read only and a user can still follow the instructions given in the doctoring to see the text field turn red.  

This may not be the desired solution though, because we are explicitly making it a readonly view, but we want to show that because it is a cached trait with no setter method, it can not be modified.  I just did not know of another way to remove the text box on the right side, which gave the opportunity for a segfault.

It is possible the original behavior isn't even really a big problem and that this change is unnecessary in which case I will just scrap this PR
