### PR TITLE
Relax constrain on PySide2 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,18 @@ services:
 addons:
   apt:
     packages:
-    - libglu1-mesa-dev
+    # Qt dependencies
+    - libxkbcommon-x11-0
+    - libxcb-icccm4
+    - libxcb-image0
+    - libxcb-keysyms1
+    - libxcb-randr0
+    - libxcb-render-util0
+    - libxcb-xinerama0
+    - pulseaudio
+    - libpulse-mainloop-glib0
+    # Wx dependencies
+    - libsdl1.2debian
 
 env:
   global:
@@ -35,8 +46,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  # libdbus and libxkb for Pyside2, libsdl for wxpython
-  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libsdl1.2debian; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     packages:
     # Qt dependencies
+    - libglu1-mesa-dev
     - libxkbcommon-x11-0
     - libxcb-icccm4
     - libxcb-image0

--- a/etstool.py
+++ b/etstool.py
@@ -201,7 +201,7 @@ def install(runtime, toolkit, environment, editable, source):
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
     if toolkit == 'pyside2':
         commands.append(
-            "edm run -e {environment} -- pip install pyside2==5.11"
+            "edm run -e {environment} -- pip install pyside2"
         )
     elif toolkit == 'wx':
         if sys.platform != 'linux':


### PR DESCRIPTION
Looks like PySide2 version was pinned to workaround #509
This was a while ago. Now we have PySide2 5.15.0 from PyPI, let's see if it is good now.