### PR TITLE
Mention additional dependencies in examples

### DIFF
--- a/traitsui/examples/demo/Advanced/Adapted_tree_editor_demo.py
+++ b/traitsui/examples/demo/Advanced/Adapted_tree_editor_demo.py
@@ -5,8 +5,8 @@
 Demonstrates an alternative method of defining a **TreeEditor** by creating
 **ITreeNodeAdapter** subclasses.
 
-To run this demonstration successfully, you must have the **AppTools** egg
-installed.
+To run this demonstration successfully, you must have **AppTools**
+(``apptools``) installed.
 
 Using **ITreeNodeAdapters** can be useful in cases where the kind of content
 of the tree is not always known ahead of time. For example, you might be

--- a/traitsui/examples/demo/Advanced/HDF5_tree_demo.py
+++ b/traitsui/examples/demo/Advanced/HDF5_tree_demo.py
@@ -6,6 +6,12 @@ In the demo, the path to the selected item is printed whenever the selection
 changes. An example HDF5 file is provided here, but you could easily change
 the path given at the bottom of this file to a path to your own HDF5 file.
 
+To run this demonstration successfully, you must have the following packages
+installed:
+
+- **PyTables** (``tables``)
+- **HDF5 for Python** (``h5py``)
+
 Note that PyTables can't read HDF5 files created with h5py,
 but h5py can read HDF5 files created with PyTables. See HDF5_tree_demo2 for
 an example using h5py.

--- a/traitsui/examples/demo/Advanced/HDF5_tree_demo2.py
+++ b/traitsui/examples/demo/Advanced/HDF5_tree_demo2.py
@@ -5,6 +5,12 @@ In the demo, the path to the selected item is printed whenever the selection
 changes. An example HDF5 file is provided here, but you could easily change
 the path given at the bottom of this file to a path to your own HDF5 file.
 
+To run this demonstration successfully, you must have the following packages
+installed:
+
+- **PyTables** (``tables``)
+- **HDF5 for Python** (``h5py``)
+
 Note that PyTables can't read HDF5 files created with h5py,
 but h5py can read HDF5 files created with PyTables. See HDF5_tree_demo for
 an example using PyTables.

--- a/traitsui/examples/demo/Extras/Tree_editor_with_TreeNodeRenderer.py
+++ b/traitsui/examples/demo/Extras/Tree_editor_with_TreeNodeRenderer.py
@@ -12,6 +12,9 @@
 """
 This demo illustrates use of TreeNodeRenderers for displaying more complex
 contents inside the cells of a TreeEditor.
+
+To run this demonstration successfully, you must have **NumPy**
+(``numpy``) installed.
 """
 
 from random import choice, uniform

--- a/traitsui/examples/demo/Standard_Editors/DataFrameEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/DataFrameEditor_demo.py
@@ -11,6 +11,8 @@
   missing.
 
 -------------------------------------------------------------------------------
+
+To run this demonstration successfully, you must have **pandas** installed.
 """
 # Issue related to the demo warning: enthought/traitsui#944
 


### PR DESCRIPTION
Closes #1125

This PR highlights some additional dependencies in the examples.

Note that for examples that are primarily for editing NumPy array (e.g. `NumPy_array_view_editor_demo.py`), I did not add the mention of "this example requires NumPy" because this feels dumb :) 
