### PR TITLE
Pin pytables to 3.5.1-4 for integration tests

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -124,6 +124,9 @@ test_dependencies = {
     "h5py",
     "numpy",
     "pandas",
+    # This version is pinned due to the latest build causing failures on the
+    # travis CI see issue #1156. Note: pytables is not a runtime dependency of
+    # traitsui, it is only a test dependency for one of the integration tests
     "pytables==3.5.1-4",
 }
 
@@ -261,7 +264,7 @@ def test(runtime, toolkit, environment):
         # coverage run prevents local images to be loaded for demo examples
         # which are not defined in Python packages. Run with python directly
         # instead.
-        "edm run -e {environment} -- python -X faulthandler -W default -m unittest discover -v {integrationtests}",
+        "edm run -e {environment} -- python -W default -m unittest discover -v {integrationtests}",
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong traitsui


### PR DESCRIPTION
This PR contains a number of experimental commits to reproduce and diagnose the recent build error seen on #1152.

Eventually we avoid the error by avoiding the pytables 3.5.1-5 egg released recently and pin the 3.5.1-4 egg.
