### PR TITLE
Update appveyor config to also build on macos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,8 @@ matrix:
     - env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
     - env: RUNTIME=3.6 TOOLKITS="pyqt5" TRAITS_REQUIRES="^=6.0"
-    - os: osx
-      env: RUNTIME=3.6 TOOLKITS="null pyqt pyqt5 pyside2"
-    - os: osx
-      env: RUNTIME=3.6 TOOLKITS="wx"
   allow_failures:
     - env: RUNTIME=3.6 TOOLKITS="wx"
-    - os: osx
-      env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true
 
 cache:
@@ -47,7 +41,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,8 @@ branches:
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
-  - sh: ls -la
+  - sh: pwd
+  - sh: ls -la "${HOME}"
   - sh: mkdir -p "${HOME}/download"
   - sh: export PATH="${PATH}:/usr/local/bin"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 build: false
 shallow_clone: false
 skip_branch_with_pr: true
+image:
+  - MacOS
+  - Visual Studio 2019
+
 environment:
 
   global:
@@ -22,27 +26,14 @@ environment:
     #   image: Visual Studio 2019
     - RUNTIME: '3.6'
       TOOLKITS: "null"
-      os: macOS
-      image: macos
-    - RUNTIME: '3.6'
-      TOOLKITS: "null"
-      os: win64
-      image: Visual Studio 2019
 
 matrix:
   #fast_finish: true
-  allow_failures:
-    - RUNTIME: '3.6'
-      TOOLKITS: "wx"
 
 branches:
   only:
     - master
     - maint/6.1
-
-cache:
-  - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
-  - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt
 
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
   matrix:
     - RUNTIME: '3.6'
       TOOLKITS: "null"
-      image: Visual Studio 2019
+      os: Visual Studio 2019
     # - RUNTIME: '3.6'
     #   TOOLKITS: "pyqt"
     #   image: Visual Studio 2019
@@ -24,8 +24,8 @@ environment:
     #   TOOLKITS: "wx"
     #   image: Visual Studio 2019
     - RUNTIME: '3.6'
-      TOOLKITS: "null pyqt pyqt5 pyside2"
-      image: macos
+      TOOLKITS: "null"
+      os: macos
 
 matrix:
   #fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ init:
   - sh: ls -la "${HOME}"
   - sh: mkdir -p "${HOME}/download"
   - sh: export PATH="${PATH}:/usr/local/bin"
+  - sh: sysctl -n machdep.cpu.brand_string
 
 install:
   - cmd: install-edm-windows.cmd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,10 +52,10 @@ install:
   - cmd: install-edm-windows.cmd
   - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - sh: edm run -- python etstool.py install --runtime="${RUNTIME}" --toolkit="${toolkit}"
+  - sh: edm run -- python etstool.py install --runtime="${RUNTIME}" --toolkit="${TOOLKIT}"
   - cmd: edm run -- python etstool.py install --runtime=%RUNTIME% --toolkit=%toolkit%
 test_script:
-  - sh: edm run -- python etstool.py test --runtime="${RUNTIME}" --toolkit="${toolkit}"
+  - sh: edm run -- python etstool.py test --runtime="${RUNTIME}" --toolkit="${TOOLKIT}"
   - cmd: edm run -- python etstool.py test --runtime=%RUNTIME% --toolkit=%toolkit%
 on_success:
   - edm run -- coverage combine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,11 +50,9 @@ install:
   - cmd: install-edm-windows.cmd
   - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - cmd: appveyor-run.cmd install %runtime% %toolkits%
-  - sh: for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
+  - python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit}
 test_script:
-  - sh: for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
-  - cmd: appveyor-run.cmd test %runtime% %toolkits%
+  - python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit}
 on_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,11 +52,11 @@ install:
   - cmd: install-edm-windows.cmd
   - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - ps: edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit}
   - sh: edm run -- python etstool.py install --runtime="${RUNTIME}" --toolkit="${toolkit}"
+  - cmd: edm run -- python etstool.py install --runtime=%RUNTIME% --toolkit=%toolkit%
 test_script:
   - sh: edm run -- python etstool.py test --runtime="${RUNTIME}" --toolkit="${toolkit}"
-  - ps: edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit}
+  - cmd: edm run -- python etstool.py test --runtime=%RUNTIME% --toolkit=%toolkit%
 on_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,10 +39,9 @@ branches:
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
-  - sh: pwd
-  - sh: ls -la "${HOME}"
-  - sh: mkdir -p "${HOME}/download"
   - sh: export PATH="${PATH}:/usr/local/bin"
+  - sh: export XDG_CACHE_HOME="${HOME}/cache"
+  - sh: mkdir -p "${HOME}/cache/download"
   - sh: sysctl -n machdep.cpu.brand_string
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,13 +24,11 @@ environment:
     - RUNTIME: '3.6'
       TOOLKIT: "null"
 
-#matrix:
-# fast_finish: true
 matrix:
   fast_finish: true
   allow_failures:
     - RUNTIME: '3.6'
-      TOOLKITS: "wx"
+      TOOLKIT: "wx"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,18 +13,14 @@ environment:
     APPVEYOR_YML_DISABLE_PS_LINUX: true
 
   matrix:
-    # - RUNTIME: '3.6'
-    #   TOOLKITS: "pyqt"
-    #   image: Visual Studio 2019
-    # - RUNTIME: '3.6'
-    #   TOOLKITS: "pyqt5"
-    #   image: Visual Studio 2019
-    # - RUNTIME: '3.6'
-    #   TOOLKITS: "pyside2"
-    #   image: Visual Studio 2019
-    # - RUNTIME: '3.6'
-    #   TOOLKITS: "wx"
-    #   image: Visual Studio 2019
+    - RUNTIME: '3.6'
+      TOOLKITS: "pyqt"
+    - RUNTIME: '3.6'
+      TOOLKITS: "pyqt5"
+    - RUNTIME: '3.6'
+      TOOLKITS: "pyside2"
+    - RUNTIME: '3.6'
+      TOOLKITS: "wx"
     - RUNTIME: '3.6'
       TOOLKIT: "null"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ environment:
     INSTALL_EDM_VERSION: "3.0.1"
 
   matrix:
-    - RUNTIME: '3.6'
-      TOOLKITS: "null"
-      os: Visual Studio 2019
     # - RUNTIME: '3.6'
     #   TOOLKITS: "pyqt"
     #   image: Visual Studio 2019
@@ -25,7 +22,12 @@ environment:
     #   image: Visual Studio 2019
     - RUNTIME: '3.6'
       TOOLKITS: "null"
-      os: macos
+      os: macOS
+      image: macos
+    - RUNTIME: '3.6'
+      TOOLKITS: "null"
+      os: win64
+      image: Visual Studio 2019
 
 matrix:
   #fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 build: false
-image: Visual Studio 2019
 shallow_clone: false
 skip_branch_with_pr: true
 environment:
@@ -11,17 +10,25 @@ environment:
   matrix:
     - RUNTIME: '3.6'
       TOOLKITS: "null"
+      image: Visual Studio 2019
+    # - RUNTIME: '3.6'
+    #   TOOLKITS: "pyqt"
+    #   image: Visual Studio 2019
+    # - RUNTIME: '3.6'
+    #   TOOLKITS: "pyqt5"
+    #   image: Visual Studio 2019
+    # - RUNTIME: '3.6'
+    #   TOOLKITS: "pyside2"
+    #   image: Visual Studio 2019
+    # - RUNTIME: '3.6'
+    #   TOOLKITS: "wx"
+    #   image: Visual Studio 2019
     - RUNTIME: '3.6'
-      TOOLKITS: "pyqt"
-    - RUNTIME: '3.6'
-      TOOLKITS: "pyqt5"
-    - RUNTIME: '3.6'
-      TOOLKITS: "pyside2"
-    - RUNTIME: '3.6'
-      TOOLKITS: "wx"
+      TOOLKITS: "null pyqt pyqt5 pyside2"
+      image: macos
 
 matrix:
-  fast_finish: true
+  #fast_finish: true
   allow_failures:
     - RUNTIME: '3.6'
       TOOLKITS: "wx"
@@ -38,13 +45,17 @@ cache:
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
+  - sh: export PATH="${PATH}:/usr/local/bin"
 
 install:
-  - install-edm-windows.cmd
+  - cmd: install-edm-windows.cmd
+  - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - appveyor-run.cmd install %runtime% %toolkits%
+  - cmd: appveyor-run.cmd install %runtime% %toolkits%
+  - sh: for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
 test_script:
-  - appveyor-run.cmd test %runtime% %toolkits%
+  - sh: for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
+  - cmd: appveyor-run.cmd test %runtime% %toolkits%
 on_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
   global:
     PYTHONUNBUFFERED: "1"
     INSTALL_EDM_VERSION: "3.0.1"
+    APPVEYOR_YML_DISABLE_PS_LINUX: true
 
   matrix:
     # - RUNTIME: '3.6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,8 @@ init:
   # and we cannot create files there.
   - sh: export PATH="${PATH}:/usr/local/bin"
   - sh: export XDG_CACHE_HOME="${HOME}/cache"
+  - sh: export LC_ALL=en_US.UTF-8
+  - sh: export LANG=en_US.UTF-8
   - sh: mkdir -p "${HOME}/cache/download"
   - sh: sysctl -n machdep.cpu.brand_string
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,9 +50,9 @@ install:
   - cmd: install-edm-windows.cmd
   - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit}
+  - edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit}
 test_script:
-  - python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit}
+  - edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit}
 on_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,9 +52,11 @@ install:
   - cmd: install-edm-windows.cmd
   - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - edm run -- python etstool.py install --runtime="${RUNTIME} --toolkit=${toolkit}"
+  - ps: edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit}
+  - sh: edm run -- python etstool.py install --runtime="${RUNTIME}" --toolkit="${toolkit}"
 test_script:
-  - edm run -- python etstool.py test --runtime="${RUNTIME}" --toolkit="${toolkit}"
+  - sh: edm run -- python etstool.py test --runtime="${RUNTIME}" --toolkit="${toolkit}"
+  - ps: edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit}
 on_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,7 @@ branches:
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
+  - sh: mkdir -p "${HOME}/.cache/download"
   - sh: export PATH="${PATH}:/usr/local/bin"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,9 +52,9 @@ install:
   - cmd: install-edm-windows.cmd
   - sh: ./install-edm-osx.sh
   - edm install -y wheel click coverage
-  - edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit}
+  - edm run -- python etstool.py install --runtime="${RUNTIME} --toolkit=${toolkit}"
 test_script:
-  - edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit}
+  - edm run -- python etstool.py test --runtime="${RUNTIME}" --toolkit="${toolkit}"
 on_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,13 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "pyqt"
+      TOOLKIT: "pyqt"
     - RUNTIME: '3.6'
-      TOOLKITS: "pyqt5"
+      TOOLKIT: "pyqt5"
     - RUNTIME: '3.6'
-      TOOLKITS: "pyside2"
+      TOOLKIT: "pyside2"
     - RUNTIME: '3.6'
-      TOOLKITS: "wx"
+      TOOLKIT: "wx"
     - RUNTIME: '3.6'
       TOOLKIT: "null"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,11 @@ branches:
     - master
     - maint/6.1
 
+cache:
+  - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt
+  - C:\Users\appveyor\AppData\Local\pip\Cache -> appveyor-clean-cache.txt
+  - '${HOME}/cache -> appveyor-clean-cache.txt'
+
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,8 @@ environment:
     - RUNTIME: '3.6'
       TOOLKITS: "null"
 
-matrix:
-  #fast_finish: true
+#matrix:
+# fast_finish: true
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,8 @@ branches:
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
-  - sh: chown -R appveyor:appveyor .cache
-  - sh: mkdir -p "${HOME}/.cache/download"
+  - sh: ls -la
+  - sh: mkdir -p "${HOME}/download"
   - sh: export PATH="${PATH}:/usr/local/bin"
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,11 @@ environment:
 
 #matrix:
 # fast_finish: true
+matrix:
+  fast_finish: true
+  allow_failures:
+    - RUNTIME: '3.6'
+      TOOLKITS: "wx"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,8 @@ branches:
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
+  # note that on osx the .cache folder is owned by root
+  # and we cannot create files there.
   - sh: export PATH="${PATH}:/usr/local/bin"
   - sh: export XDG_CACHE_HOME="${HOME}/cache"
   - sh: mkdir -p "${HOME}/cache/download"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ environment:
     #   TOOLKITS: "wx"
     #   image: Visual Studio 2019
     - RUNTIME: '3.6'
-      TOOLKITS: "null"
+      TOOLKIT: "null"
 
 #matrix:
 # fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,7 @@ branches:
 init:
   - ps: $Env:path = "C:/Enthought/edm;" + $Env:path
   - ps: md C:/Users/appveyor/.cache -Force
+  - sh: chown -R appveyor:appveyor .cache
   - sh: mkdir -p "${HOME}/.cache/download"
   - sh: export PATH="${PATH}:/usr/local/bin"
 

--- a/etstool.py
+++ b/etstool.py
@@ -124,10 +124,7 @@ test_dependencies = {
     "h5py",
     "numpy",
     "pandas",
-    # This version is pinned due to the latest build causing failures on the
-    # travis CI see issue #1156. Note: pytables is not a runtime dependency of
-    # traitsui, it is only a test dependency for one of the integration tests
-    "pytables==3.5.1-4",
+    "pytables",
 }
 
 extra_dependencies = {

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -5,7 +5,7 @@ set -e
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
     local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
-    local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
+    local EDM_INSTALLER_PATH="${HOME}/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
         curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -5,7 +5,7 @@ set -e
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
     local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
-    local EDM_INSTALLER_PATH="${HOME}/download/${EDM_PACKAGE}"
+    local EDM_INSTALLER_PATH="${HOME}/cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
         curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/osx_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"


### PR DESCRIPTION
fixes #1156 

Travis-CI osx VMs use a 2013 CPU which does not support AVX2. This PR updates the ci builds to run the osx build on appveyor whose MacOS VMs use more recent CPUs