### PR TITLE
Implement dispose for wx simple TextEditor (base class)

### DIFF
--- a/traitsui/testing/tester/qt4/default_registry.py
+++ b/traitsui/testing/tester/qt4/default_registry.py
@@ -15,6 +15,7 @@ from traitsui.testing.tester.qt4.implementation import (
     button_editor,
     check_list_editor,
     enum_editor,
+    font_editor,
     instance_editor,
     list_editor,
     range_editor,
@@ -44,6 +45,9 @@ def get_default_registry():
 
     # EnumEditor
     enum_editor.register(registry)
+
+    # FontEditor
+    font_editor.register(registry)
 
     # TextEditor
     text_editor.register(registry)

--- a/traitsui/testing/tester/qt4/implementation/font_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/font_editor.py
@@ -1,0 +1,31 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+from traitsui.testing.tester.qt4.registry_helper import (
+    register_editable_textbox_handlers,
+)
+from traitsui.qt4.font_editor import TextFontEditor
+
+
+def register(registry):
+    """ Register interactions pertaining to (Qt) FontEditor for the given
+    registry.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    register_editable_textbox_handlers(
+        registry=registry,
+        target_class=TextFontEditor,
+        widget_getter=lambda wrapper: wrapper.target.control,
+    )

--- a/traitsui/testing/tester/wx/default_registry.py
+++ b/traitsui/testing/tester/wx/default_registry.py
@@ -15,6 +15,7 @@ from traitsui.testing.tester.wx.implementation import (
     button_editor,
     check_list_editor,
     enum_editor,
+    font_editor,
     instance_editor,
     list_editor,
     range_editor,
@@ -44,6 +45,9 @@ def get_default_registry():
 
     # EnumEditor
     enum_editor.register(registry)
+
+    # FontEditor
+    font_editor.register(registry)
 
     # TextEditor
     text_editor.register(registry)

--- a/traitsui/testing/tester/wx/implementation/font_editor.py
+++ b/traitsui/testing/tester/wx/implementation/font_editor.py
@@ -1,0 +1,31 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+from traitsui.testing.tester.wx.registry_helper import (
+    register_editable_textbox_handlers,
+)
+from traitsui.wx.font_editor import TextFontEditor
+
+
+def register(registry):
+    """ Register interactions pertaining to (wx) FontEditor for the given
+    registry.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    register_editable_textbox_handlers(
+        registry=registry,
+        target_class=TextFontEditor,
+        widget_getter=lambda wrapper: wrapper.target.control,
+    )

--- a/traitsui/tests/editors/test_font_editor.py
+++ b/traitsui/tests/editors/test_font_editor.py
@@ -15,29 +15,15 @@ import unittest
 from traits.api import HasTraits
 from traitsui.api import Font, Item, View
 from traitsui.tests._tools import (
-    is_wx,
     requires_toolkit,
     ToolkitName,
 )
 from traitsui.testing.tester import command
 from traitsui.testing.tester.ui_tester import UITester
-from traitsui.testing.tester.registry import TargetRegistry
 
 
 class ObjectWithFont(HasTraits):
     font_trait = Font()
-
-
-# A local registry of interaction handlers for testing purposes.
-LOCAL_TARGET_REGISTRY = TargetRegistry()
-
-if is_wx():
-    from traitsui.wx.font_editor import TextEditor
-    LOCAL_TARGET_REGISTRY.register_handler(
-        target_class=TextEditor,
-        interaction_class=command.MouseClick,
-        handler=lambda wrapper, _: wrapper.target.control.SetFocus()
-    )
 
 
 @requires_toolkit([ToolkitName.wx])
@@ -47,7 +33,7 @@ class TestFontEditor(unittest.TestCase):
         # Setting focus on the widget and then disposing the widget
         # should not cause errors.
         view = View(Item("font_trait", style="text"))
-        tester = UITester([LOCAL_TARGET_REGISTRY])
+        tester = UITester()
         with tester.create_ui(ObjectWithFont(), dict(view=view)) as ui:
             wrapper = tester.find_by_name(ui, "font_trait")
             wrapper.perform(command.MouseClick())

--- a/traitsui/tests/editors/test_font_editor.py
+++ b/traitsui/tests/editors/test_font_editor.py
@@ -1,0 +1,53 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+""" Test FontEditor
+"""
+import unittest
+
+from traits.api import HasTraits
+from traitsui.api import Font, Item, View
+from traitsui.tests._tools import (
+    is_wx,
+    requires_toolkit,
+    ToolkitName,
+)
+from traitsui.testing.tester import command
+from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.tester.registry import TargetRegistry
+
+
+class ObjectWithFont(HasTraits):
+    font_trait = Font()
+
+
+# A local registry of interaction handlers for testing purposes.
+LOCAL_TARGET_REGISTRY = TargetRegistry()
+
+if is_wx():
+    from traitsui.wx.font_editor import TextEditor
+    LOCAL_TARGET_REGISTRY.register_handler(
+        target_class=TextEditor,
+        interaction_class=command.MouseClick,
+        handler=lambda wrapper, _: wrapper.target.control.SetFocus()
+    )
+
+
+@requires_toolkit([ToolkitName.wx])
+class TestFontEditor(unittest.TestCase):
+
+    def test_create_and_dispose_text_style(self):
+        # Setting focus on the widget and then disposing the widget
+        # should not cause errors.
+        view = View(Item("font_trait", style="text"))
+        tester = UITester([LOCAL_TARGET_REGISTRY])
+        with tester.create_ui(ObjectWithFont(), dict(view=view)) as ui:
+            wrapper = tester.find_by_name(ui, "font_trait")
+            wrapper.perform(command.MouseClick())

--- a/traitsui/tests/editors/test_font_editor.py
+++ b/traitsui/tests/editors/test_font_editor.py
@@ -26,7 +26,7 @@ class ObjectWithFont(HasTraits):
     font_trait = Font()
 
 
-@requires_toolkit([ToolkitName.wx])
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestFontEditor(unittest.TestCase):
 
     def test_create_and_dispose_text_style(self):

--- a/traitsui/wx/editor_factory.py
+++ b/traitsui/wx/editor_factory.py
@@ -116,6 +116,16 @@ class TextEditor(Editor):
         parent.Bind(wx.EVT_TEXT_ENTER, self.update_object, id=self.control.GetId())
         self.set_tooltip()
 
+    def dispose(self):
+        parent = self.control.GetParent()
+        parent.Unbind(
+            wx.EVT_TEXT_ENTER,
+            handler=self.update_object,
+            id=self.control.GetId(),
+        )
+        self.control.Unbind(wx.EVT_KILL_FOCUS, handler=self.update_object)
+        super().dispose()
+
     def update_object(self, event):
         """ Handles the user changing the contents of the edit control.
         """

--- a/traitsui/wx/editor_factory.py
+++ b/traitsui/wx/editor_factory.py
@@ -117,13 +117,14 @@ class TextEditor(Editor):
         self.set_tooltip()
 
     def dispose(self):
-        parent = self.control.GetParent()
-        parent.Unbind(
-            wx.EVT_TEXT_ENTER,
-            handler=self.update_object,
-            id=self.control.GetId(),
-        )
-        self.control.Unbind(wx.EVT_KILL_FOCUS, handler=self.update_object)
+        if self.control is not None:   # just in-case
+            parent = self.control.GetParent()
+            parent.Unbind(
+                wx.EVT_TEXT_ENTER,
+                handler=self.update_object,
+                id=self.control.GetId(),
+            )
+            self.control.Unbind(wx.EVT_KILL_FOCUS, handler=self.update_object)
         super().dispose()
 
     def update_object(self, event):

--- a/traitsui/wx/editor_factory.py
+++ b/traitsui/wx/editor_factory.py
@@ -117,6 +117,8 @@ class TextEditor(Editor):
         self.set_tooltip()
 
     def dispose(self):
+        """ Disposes of the contents of an editor.
+        """
         if self.control is not None:   # just in-case
             parent = self.control.GetParent()
             parent.Unbind(


### PR DESCRIPTION
Closes #942 
Also resolve the second item in https://github.com/enthought/traitsui/issues/1073
Also part of #752 

The cause of the issue is as explained in #942.  This base class is used by both the text style FontEditor and the text style CompoundEditor.

I came across this while I was trying to _resolve_ #1145.
(The solution I am going to propose for #1145 also "resolves the error" in the context when the UI wrapping this editor has its `dispose` method called. But I believe removing the handler hooks with Unbind is still the right thing to do.)

As a drive-by improvement to the test coverage, implementations are added for testing the Qt implementation of the same editor.
