### PR TITLE
Clarify entry point definition requirement for etsdemo

### DIFF
--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -63,7 +63,7 @@ data files. For example::
         }
 
 Then in ``setup.py``, add an entry point under the ``etsdemo_data`` group to
-reference the newly created function . For example::
+reference the newly created function. For example::
 
     from setuptools import setup
 

--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -75,6 +75,9 @@ function. For example::
         ...
     )
 
+Note that the entry point group must match `"etsdemo_data"`, but the
+entry point name (`"demo"` in the above example) can be any value.
+
 Launch with specific data sources
 ---------------------------------
 

--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -75,7 +75,7 @@ reference the newly created function. For example::
         ...
     )
 
-Note that the entry point name (`"my_demo"` in the above example) can be any
+Note that the entry point name (``"my_demo"`` in the above example) can be any
 value.
 
 Launch with specific data sources

--- a/ets-demo/README.rst
+++ b/ets-demo/README.rst
@@ -62,8 +62,8 @@ data files. For example::
             "root": pkg_resources.resource_filename("my_project", "data"),
         }
 
-Then add an entry point in ``setup.py`` that points to the newly created
-function. For example::
+Then in ``setup.py``, add an entry point under the ``etsdemo_data`` group to
+reference the newly created function . For example::
 
     from setuptools import setup
 
@@ -71,12 +71,12 @@ function. For example::
         name="my_project",
         ...
         entry_points={
-            "etsdemo_data": ["demo = my_project.info:info"],
+            "etsdemo_data": ["my_demo = my_project.info:info"],
         ...
     )
 
-Note that the entry point group must match `"etsdemo_data"`, but the
-entry point name (`"demo"` in the above example) can be any value.
+Note that the entry point name (`"my_demo"` in the above example) can be any
+value.
 
 Launch with specific data sources
 ---------------------------------


### PR DESCRIPTION
This PR clarifies the API documentation for contributing entry points to etsdemo: The entry point group is required to match, but the entry point name isn't.