### PR TITLE
[WIP] Fix AttributeError accessing removed objects during UI.dispose

### DIFF
--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -302,11 +302,6 @@ class TestExample(unittest.TestCase):
                     # before running the next one.
                     process_cascade_events()
 
-                    # XXX temporary change to see how Appveyor + OSX + Qt4
-                    # reacts
-                    for _ in range(10):
-                        process_cascade_events()
-
         # Report skipped files
         for file_path, reason in skipped_files:
             with self.subTest(file_path=file_path):

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -229,8 +229,10 @@ def replaced_configure_traits(
     )
     with reraise_exceptions():
         process_cascade_events()
-        ui.dispose()
-        process_cascade_events()
+        try:
+            ui.dispose()
+        finally:
+            process_cascade_events()
 
 
 @contextlib.contextmanager

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -302,6 +302,11 @@ class TestExample(unittest.TestCase):
                     # before running the next one.
                     process_cascade_events()
 
+                    # XXX temporary change to see how Appveyor + OSX + Qt4
+                    # reacts
+                    for _ in range(10):
+                        process_cascade_events()
+
         # Report skipped files
         for file_path, reason in skipped_files:
             with self.subTest(file_path=file_path):

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -229,13 +229,6 @@ def replaced_configure_traits(
     )
     with reraise_exceptions():
         process_cascade_events()
-
-        # Temporary fix for enthought/traitsui#907
-        if is_qt():
-            ui.control.hide()
-        if is_wx():
-            ui.control.Hide()
-
         ui.dispose()
         process_cascade_events()
 

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -929,7 +929,8 @@ class _TableView(QtGui.QTableView):
             if self._user_widths is None:
                 self._user_widths = [None] * len(self._editor.adapter.columns)
             self._user_widths[index] = new
-            if not self._editor.factory.auto_resize:
+            if (self._editor.factory is not None
+                    and not self._editor.factory.auto_resize):
                 self.resizeColumnsToContents()
 
     @contextmanager

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -929,8 +929,7 @@ class _TableView(QtGui.QTableView):
             if self._user_widths is None:
                 self._user_widths = [None] * len(self._editor.adapter.columns)
             self._user_widths[index] = new
-            if (self._editor.factory is not None
-                    and not self._editor.factory.auto_resize):
+            if not self._editor.factory.auto_resize:
                 self.resizeColumnsToContents()
 
     @contextmanager

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -378,9 +378,15 @@ class GUIToolkit(Toolkit):
     def hide_control(self, control):
         """ Hide a GUI toolkit control."""
         control.hide()
+
+    def hide_children(self, control):
+        """ Recursively hide all of the children controls of a specified GUI
+        toolkit control.
+        """
         for w in control.children():
             if isinstance(w, QtGui.QWidget):
                 self.hide_control(w)
+                self.hide_children(w)
 
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -378,6 +378,9 @@ class GUIToolkit(Toolkit):
     def hide_control(self, control):
         """ Hide a GUI toolkit control."""
         control.hide()
+        for w in control.children():
+            if isinstance(w, QtGui.QWidget):
+                self.hide_control(w)
 
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -375,6 +375,10 @@ class GUIToolkit(Toolkit):
         """
         event.ignore()
 
+    def hide_control(self, control):
+        """ Hide a GUI toolkit control."""
+        control.hide()
+
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.
         """
@@ -384,7 +388,7 @@ class GUIToolkit(Toolkit):
 
         # This may be called from within the finished() signal handler so we
         # need to do the delete after the handler has returned.
-        control.hide()
+        self.hide_control(control)
         control.deleteLater()
 
         # PyQt v4.3.1 and earlier deleteLater() didn't transfer ownership to

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -417,8 +417,10 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             editor, = ui.get_editors("people")
             editor.adapter.columns = [("Name", "name")]
             # Avoid calling process_cascade_events here.
-            ui.dispose()
-            process_cascade_events()
+            try:
+                ui.dispose()
+            finally:
+                process_cascade_events()
 
     @contextlib.contextmanager
     def report_and_editor(self, view):

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -399,14 +399,26 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             editor.adapter.columns = [("Name", "name")]
             process_cascade_events()
 
-    def test_view_column_resized_attribute_error_workaround(self):
-        # This tests the workaround which checks if `factory` is None before
-        # using it while resizing the columns.
-        # The resize event is processed after UI.dispose is called.
-        # Maybe related to enthought/traits#431
-        with reraise_exceptions(), \
-                self.report_and_editor(get_view()) as (_, editor):
+    def test_view_column_resized_not_called_on_disposed(self):
+        # A workaround / guard was added to check if `factory` is None
+        # in _TableView.columnResized. (see enthought/traitsui##897)
+        # This was caused by the factory attribute being removed as part of
+        # UI.dispose when there are resize events left unprocessed.
+        report = Report(
+            people=[
+                Person(name="Theresa", age=60),
+                Person(name="Arlene", age=46),
+                Person(name="Karen", age=40),
+            ]
+        )
+        view = get_view()
+        with reraise_exceptions():
+            ui = report.edit_traits(view=view)
+            editor, = ui.get_editors("people")
             editor.adapter.columns = [("Name", "name")]
+            # Avoid calling process_cascade_events here.
+            ui.dispose()
+            process_cascade_events()
 
     @contextlib.contextmanager
     def report_and_editor(self, view):

--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -399,29 +399,6 @@ class TestTabularEditor(UnittestTools, unittest.TestCase):
             editor.adapter.columns = [("Name", "name")]
             process_cascade_events()
 
-    def test_view_column_resized_not_called_on_disposed(self):
-        # A workaround / guard was added to check if `factory` is None
-        # in _TableView.columnResized. (see enthought/traitsui##897)
-        # This was caused by the factory attribute being removed as part of
-        # UI.dispose when there are resize events left unprocessed.
-        report = Report(
-            people=[
-                Person(name="Theresa", age=60),
-                Person(name="Arlene", age=46),
-                Person(name="Karen", age=40),
-            ]
-        )
-        view = get_view()
-        with reraise_exceptions():
-            ui = report.edit_traits(view=view)
-            editor, = ui.get_editors("people")
-            editor.adapter.columns = [("Name", "name")]
-            # Avoid calling process_cascade_events here.
-            try:
-                ui.dispose()
-            finally:
-                process_cascade_events()
-
     @contextlib.contextmanager
     def report_and_editor(self, view):
         """

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -275,10 +275,11 @@ if is_qt():
     class EditorWithCustomWidget(ToolkitSpecificEditor):
 
         def init(self, parent):
-            # To reproduce an assertion from sizeHint, it is necessary to have
-            # two widgets, where one of them is created with a nested UI.
-            # When the nested UI is disposed, the original AttributeError is
-            # caused by the neighboring widgets trying to resize / repaint /
+            # This example reproduces a failure scenario where sizeHint tries
+            # to access a factory attribute that has been reset to None.
+            # We have two widgets, where one of them is created with a nested
+            # UI. When the nested UI is disposed, the original AttributeError
+            # is caused by the neighboring widgets trying to resize / repaint /
             # ... adjust to fit the layout. These do not happen if the widgets
             # are made to be hidden first before dispose is called.
             self.control = QtGui.QSplitter(QtCore.Qt.Horizontal)

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -370,10 +370,6 @@ class TestUIDispose(unittest.TestCase):
                     "number",
                     editor=BasicEditorFactory(klass=EditorWithCustomWidget),
                 ),
-                Item(
-                    "number",
-                    editor=BasicEditorFactory(klass=EditorWithCustomWidget),
-                ),
             ),
         )
         with reraise_exceptions():

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -310,7 +310,6 @@ if is_wx():
     import wx
     from traitsui.wx.helper import TraitsUIPanel
 
-
     class EditorWithCustomWidget(ToolkitSpecificEditor):  # noqa: F811
 
         def init(self, parent):

--- a/traitsui/toolkit.py
+++ b/traitsui/toolkit.py
@@ -321,6 +321,14 @@ class Toolkit(Toolkit):
             not_implemented_message.format(ETSConfig.toolkit)
         )
 
+    def hide_children(self, control):
+        """ Recursively hide all of the children controls of a specified GUI
+        toolkit control.
+        """
+        raise NotImplementedError(
+            not_implemented_message.format(ETSConfig.toolkit)
+        )
+
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.
         """

--- a/traitsui/toolkit.py
+++ b/traitsui/toolkit.py
@@ -315,6 +315,12 @@ class Toolkit(Toolkit):
             not_implemented_message.format(ETSConfig.toolkit)
         )
 
+    def hide_control(self, control):
+        """ Hide a GUI toolkit control."""
+        raise NotImplementedError(
+            not_implemented_message.format(ETSConfig.toolkit)
+        )
+
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.
         """

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -22,6 +22,7 @@
 import shelve
 import os
 
+from pyface.api import GUI
 from pyface.ui_traits import Image
 from traits.api import (
     Any,

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -277,6 +277,7 @@ class UI(HasPrivateTraits):
         # Hide the view control to prevent events (e.g. resize) from being
         # emitted when we are tearing things down.
         toolkit().hide_control(self.control)
+        toolkit().hide_children(self.control)
 
         # Reset the contents of the user interface
         self.reset(destroy=False)

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -22,7 +22,6 @@
 import shelve
 import os
 
-from pyface.api import GUI
 from pyface.ui_traits import Image
 from traits.api import (
     Any,

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -273,6 +273,9 @@ class UI(HasPrivateTraits):
     def finish(self):
         """ Finishes disposing of a user interface.
         """
+        # Hide the view control to prevent resizing events from being emitted
+        # when we are tearing things down.
+        toolkit().hide_control(self.control)
 
         # Reset the contents of the user interface
         self.reset(destroy=False)

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -273,8 +273,8 @@ class UI(HasPrivateTraits):
     def finish(self):
         """ Finishes disposing of a user interface.
         """
-        # Hide the view control to prevent resizing events from being emitted
-        # when we are tearing things down.
+        # Hide the view control to prevent events (e.g. resize) from being
+        # emitted when we are tearing things down.
         toolkit().hide_control(self.control)
 
         # Reset the contents of the user interface

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -273,8 +273,9 @@ class UI(HasPrivateTraits):
     def finish(self):
         """ Finishes disposing of a user interface.
         """
-        # Hide the view control to prevent events (e.g. resize) from being
-        # emitted when we are tearing things down.
+        # Hide the view control to minimize additional events being posted
+        # while neighboring controls are removed as the UI enters an invalid
+        # state.
         toolkit().hide_control(self.control)
         toolkit().hide_children(self.control)
 

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -426,6 +426,10 @@ class GUIToolkit(Toolkit):
         """
         event.Skip()
 
+    def hide_control(self, control):
+        """ Hide a GUI toolkit control."""
+        control.Hide()
+
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.
         """

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -429,8 +429,14 @@ class GUIToolkit(Toolkit):
     def hide_control(self, control):
         """ Hide a GUI toolkit control."""
         control.Hide()
+
+    def hide_children(self, control):
+        """ Recursively hide the children controls of a specified GUI toolkit
+        control.
+        """
         for child in control.GetChildren():
             self.hide_control(child)
+            self.hide_children(child)
 
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -429,6 +429,8 @@ class GUIToolkit(Toolkit):
     def hide_control(self, control):
         """ Hide a GUI toolkit control."""
         control.Hide()
+        for child in control.GetChildren():
+            self.hide_control(child)
 
     def destroy_control(self, control):
         """ Destroys a specified GUI toolkit control.


### PR DESCRIPTION
Closes #1145
Closes #907
Replaces the workaround in the second item of #897
Also resolve the second item in #1073 (note that #1161 also fixes it)

Understanding the issue
---
In the `UI.dispose` code path, it first asks the editors to clean up themselves. This involves resetting some of the attributes (e.g. `control`, `factory`) to `None`. I do not know why they need to be unset, presumably to avoid holding references to GUI toolkit objects, but this is the root cause of the AttributeError. I assume we are keeping this attribute removal. The goal is therefore to figure out why these attributes are still being accessed after they are removed.

After all the editors have reset its attribute, the UI then asks the GUI to delete widgets. In Qt, that request is asynchronous via the use of `deleteLater`. However, the attributes on the editors are unset synchronously.

A number of scenarios can cause the AttributeError to occur.

For example, an application typically has many nested widgets. While the application is running and when a nested widget is disposed, the neighbouring widgets need to respond by adjusting their sizes, possibly involving repainting themselves. An example of a widget being disposed of would be an item being removed from a list while a custom ListEditor is used. 

In the context of an entire UI disposal, all the nested widgets are recursively disposed of. Consequently a nested widget will have an event for resizing / repainting prior to its delete instruction being delivered. Note that a UI is not necessary the main window, it could also be nested (e.g. custom ListEditor and TreeEditor both have nested UI objects). This can happen while the GUI is still being active in a production setting.

This scenario is relevant for both Qt and Wx: In Qt, Qt often drives these resizing / repainting events automatically. In Wx, we typically have event handlers for monitoring losing focus on a widget (Qt typically provides this sort of low-level handling already, e.g. `QLineEdit.editingFinished` signal). 

This issue not only affects tests, but also production environment, as we have seen in #1073 and we have evidence of it from external reports (see discussion in #897).

Trying to unset the attributes asynchronously by queuing that action in the event loop resolves the issue in some situations (see https://github.com/enthought/traitsui/pull/910), but it does not resolve the issue entirely because it still relies on event ordering. I verified this not being able to fix a test I added in this PR, neither could it fix the second item in #1073.

Fix
---
The fix is to hide the GUI toolkit control recursively early in `UI.dispose`. This disables the widgets, preventing the cascade of repaint / resizing events when the UI is being disposed of and is entering an inconsistent state.

This fix is not dissimilar in principle compared to a previous attempt fixing the same AttributeError: #46
However, the fix was effectively reverted in https://github.com/enthought/traitsui/pull/283

The fix here is different in the sense that instead of asking for the nested controls to be _destroyed_, we are hiding them, i.e. disabling them. Hiding is a safe and idempotent operation - we can call it many times without an issue, whereas destroy isn't.

Hiding the control early is consistent with what happens when a user closes a GUI window. If we inspect the events being sent while we close a GUI window, we can see a HideEvent being emitted.

Note that initially I thought hiding a parent Qt widget would hide all of its children: That is not true. Removing the `hide_children` line in `UI` in this PR will cause the test I added to fail. It is necessary to hide children widgets explicitly and recursively.

This PR
---
- Adds tests that independently reproduce the AttributeError.
- Reverted the workaround in TabularEditor. I updated the test that would reproduce the AttributeError without the workaround, and then verified that the fix in `UI.dispose` fixes the issue.

I think this makes a lot of `if self.control is not None` or `if self.factory is not None` guards unnecessary.