### PR TITLE
logger.warn is deprecated, use logger.warning instead

### DIFF
--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -98,7 +98,7 @@ class SimpleEditor(EditorWithList):
                     del cur_value[i]
                     modified = True
                 except TypeError as e:
-                    logger.warn(
+                    logger.warning(
                         "Unable to remove non-current value [%s] from "
                         "values %s",
                         cur_value[i],

--- a/traitsui/wx/check_list_editor.py
+++ b/traitsui/wx/check_list_editor.py
@@ -103,7 +103,7 @@ class SimpleEditor(EditorWithList):
                     del cur_value[i]
                     modified = True
                 except TypeError as e:
-                    logger.warn(
+                    logger.warning(
                         "Unable to remove non-current value [%s] from "
                         "values %s",
                         cur_value[i],


### PR DESCRIPTION
Ref https://docs.python.org/3.6/library/logging.html#logging.Logger.warning