### PR TITLE
Check that the UI has a valid View before modifying size in _size_hint_wrapper

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -335,10 +335,11 @@ def _size_hint_wrapper(f, ui):
 
     def sizeHint():
         size = f()
-        if ui.view.width > 0:
-            size.setWidth(ui.view.width)
-        if ui.view.height > 0:
-            size.setHeight(ui.view.height)
+        if ui.view is not None:
+            if ui.view.width > 0:
+                size.setWidth(ui.view.width)
+            if ui.view.height > 0:
+                size.setHeight(ui.view.height)
         return size
 
     return sizeHint


### PR DESCRIPTION
It is possible that a `UI` instance has its `View` set to `None` during the lifetime of a widget or layout that is using the `_size_hint_wrapper` (which is itself a hack).  In some circumstances this causes a segfault at UI dispose time.  This PR puts a guard in place to prevent exceptions in this code.

No tests at the moment, because this is an implementation detail of a hack in a private implementation detail, and I'm not sure I want to be formalizing this piece of code that much, but if review thinks it's needed, I will add.