### PR TITLE
Remove cycle reference to control in its sizeHint

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -214,7 +214,7 @@ class _Panel(BasePanel):
         # Ensure the control has a size hint reflecting the View specification.
         # Yes, this is a hack, but it's too late to repair this convoluted
         # control building process, so we do what we have to...
-        self.control.sizeHint = _size_hint_wrapper(self.control.sizeHint, ui)
+        self.control.sizeHint = _size_hint_wrapper(ui)
 
     def _add_toolbar(self, parent):
         """ Adds a toolbar to the `parent` (QtWindow)
@@ -329,12 +329,12 @@ def _fill_panel(panel, content, ui, item_handler=None):
     panel.setCurrentIndex(active)
 
 
-def _size_hint_wrapper(f, ui):
+def _size_hint_wrapper(ui):
     """Wrap an existing sizeHint method with sizes from a UI object.
     """
 
     def sizeHint():
-        size = f()
+        size = QtCore.QSize(-1, -1)
         if ui.view.width > 0:
             size.setWidth(ui.view.width)
         if ui.view.height > 0:

--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+from pyface.api import GUI
 from traits.api import Bool, HasTraits, Instance, List, Str
 from traitsui.api import (
     Item,
@@ -123,6 +124,29 @@ class BogusTreeNodeObjectView(HasTraits):
 
 
 class TestTreeView(unittest.TestCase):
+
+    def test_tree_editor_with_nested_ui(self):
+        tree_editor = TreeEditor(
+            nodes=[
+                TreeNode(
+                    node_for=[Bogus],
+                    auto_open=True,
+                    children="bogus_list",
+                    label="bogus",
+                    view=View(Item("name")),
+                ),
+            ],
+            hide_root=True,
+        )
+        bogus_list = [Bogus()]
+        object_view = BogusTreeView(bogus=Bogus(bogus_list=bogus_list))
+        view = View(Item("bogus", id="tree", editor=tree_editor))
+        with reraise_exceptions(), \
+                create_ui(object_view, dict(view=view)) as ui:
+            editor = ui.info.tree
+            editor.selected = bogus_list[0]
+            GUI.process_events()
+
     def _test_tree_editor_releases_listeners(
         self, hide_root, nodes=None, trait="bogus_list", expected_listeners=1
     ):

--- a/traitsui/tests/editors/test_tree_editor.py
+++ b/traitsui/tests/editors/test_tree_editor.py
@@ -125,6 +125,9 @@ class BogusTreeNodeObjectView(HasTraits):
 
 class TestTreeView(unittest.TestCase):
 
+    # test for wx is failing for other reasons.
+    # It might pass once we receive fix for enthought/pyface#558
+    @requires_toolkit([ToolkitName.qt])
     def test_tree_editor_with_nested_ui(self):
         tree_editor = TreeEditor(
             nodes=[


### PR DESCRIPTION
Closes #1166

The patch to the control's own sizeHint method inevitably creates a cycle reference.
The purpose of keeping the original sizeHint instance method was to set a default sizeHint... which actually results in more weird layout than without.

This was the layout for the `TreeEditor_demo.py` before the change:
![Screenshot 2020-08-28 at 12 01 54](https://user-images.githubusercontent.com/3673984/91554263-b4d35800-e926-11ea-9a6f-f7f976e2185a.png)

This is after the change:
![Screenshot 2020-08-28 at 12 01 37](https://user-images.githubusercontent.com/3673984/91554282-bb61cf80-e926-11ea-98d7-400d2921699f.png)

The cycle reference seems to be what was causing #1166. While #1168 fixed it by applying a guard, this PR fixed it too independently.
The first commit adds a test that reproduces the error on master _before_ #1168 was merged. The second commit fixes the issue.

I scanned through the demo examples and I could not see any adversed effect caused by this change.