### PR TITLE
Clean super usage in etsdemo

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -453,7 +453,7 @@ class DemoFile(DemoFileBase):
     locals = Dict(Str, Any)
 
     def init(self):
-        super(DemoFile, self).init()
+        super().init()
         description, source = parse_source(self.path)
         self.description = publish_html_str(description, self.css_filename)
         self.source = source
@@ -508,7 +508,7 @@ class DemoFile(DemoFileBase):
 class DemoContentFile(DemoFileBase):
 
     def init(self):
-        super(DemoContentFile, self).init()
+        super().init()
         file_str = _read_file(self.path)
         self.description = publish_html_str(file_str, self.css_filename)
 
@@ -516,7 +516,7 @@ class DemoContentFile(DemoFileBase):
 class DemoImageFile(DemoFileBase):
 
     def init(self):
-        super(DemoImageFile, self).init()
+        super().init()
         rst_content = ".. image:: {}".format(self.name)
         self.description = publish_html_str(rst_content, self.css_filename)
 


### PR DESCRIPTION
This PR updates `super` usage in the `etsdemo` package but not in `traitsui` because `etsdemo` is small and new. This was done using manual search and replace.