### PR TITLE
Normalize KeySequence support for testing textboxes

### DIFF
--- a/traitsui/testing/tester/compat.py
+++ b/traitsui/testing/tester/compat.py
@@ -1,0 +1,36 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+""" This module contains functions used by toolkit specific implementation for
+normalizing differences among toolkits (Qt and Wx).
+"""
+
+
+def check_key_compat(key):
+    """ Check if the given key is a unicode character within the range of
+    values currently supported for emulating key sequences on both Qt and Wx
+    textboxes.
+
+    Parameters
+    ----------
+    key : str
+        A unicode character
+
+    Raises
+    ------
+    ValueError
+        If the unicode character is not within the supported range of values.
+    """
+    # Support for more characters can be added when there are needs.
+    if ord(key) < 32 or ord(key) >= 127:
+        raise ValueError(
+            f"Key {key!r} is currently not supported. "
+            f"Supported characters between code point 32 - 126."
+        )

--- a/traitsui/testing/tester/qt4/common_ui_targets.py
+++ b/traitsui/testing/tester/qt4/common_ui_targets.py
@@ -46,7 +46,7 @@ class LocatedTextbox:
         """
         handlers = [
             (command.KeySequence,
-                (lambda wrapper, interaction: helpers.key_sequence_qwidget(
+                (lambda wrapper, interaction: helpers.key_sequence_textbox(
                     wrapper.target.textbox, interaction, wrapper.delay))),
             (command.KeyClick,
                 (lambda wrapper, interaction: helpers.key_click_qwidget(

--- a/traitsui/testing/tester/qt4/helpers.py
+++ b/traitsui/testing/tester/qt4/helpers.py
@@ -12,6 +12,7 @@
 from pyface.qt import QtCore, QtGui
 from pyface.qt.QtTest import QTest
 
+from traitsui.testing.tester.compat import check_key_compat
 from traitsui.testing.tester.exceptions import Disabled
 from traitsui.qt4.key_event_to_name import key_map as _KEY_MAP
 
@@ -108,6 +109,30 @@ def key_sequence_qwidget(control, interaction, delay):
     if not control.isEnabled():
         raise Disabled("{!r} is disabled.".format(control))
     QTest.keyClicks(control, interaction.sequence, delay=delay)
+
+
+def key_sequence_textbox(control, interaction, delay):
+    """ Performs simulated typing of a sequence of keys on a widget that is
+    a textbox. The keys are restricted to values also supported for testing
+    wx.TextCtrl.
+
+    Parameters
+    ----------
+    control : QWidget
+        The Qt widget intended to hold text for editing.
+        e.g. QLineEdit and QTextEdit
+    interaction : instance of command.KeySequence
+        The interaction object holding the sequence of key inputs
+        to be simulated being typed
+    delay : int
+        Time delay (in ms) in which each key click in the sequence will be
+        performed.
+    """
+    for key in interaction.sequence:
+        check_key_compat(key)
+    if not control.hasFocus():
+        key_click(widget=control, key="End", delay=0)
+    key_sequence_qwidget(control=control, interaction=interaction, delay=delay)
 
 
 def key_click_qwidget(control, interaction, delay):

--- a/traitsui/testing/tester/qt4/implementation/text_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/text_editor.py
@@ -27,7 +27,7 @@ def register(registry):
 
     handlers = [
         (command.KeySequence,
-            (lambda wrapper, interaction: helpers.key_sequence_qwidget(
+            (lambda wrapper, interaction: helpers.key_sequence_textbox(
                 wrapper.target.control, interaction, wrapper.delay))),
         (command.KeyClick,
             (lambda wrapper, interaction: helpers.key_click_qwidget(

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -11,6 +11,7 @@
 
 import wx
 
+from traitsui.testing.tester.compat import check_key_compat
 from traitsui.testing.tester.exceptions import Disabled
 from traitsui.wx.key_event_to_name import key_map as _KEY_MAP
 
@@ -135,9 +136,15 @@ def key_sequence_text_ctrl(control, interaction, delay):
         Time delay (in ms) in which each key click in the sequence will be
         performed.
     """
+    # fail early
+    for char in interaction.sequence:
+        check_key_compat(char)
+
     if not control.IsEditable():
         raise Disabled("{!r} is disabled.".format(control))
     if not control.HasFocus():
         control.SetFocus()
+        control.SetInsertionPointEnd()
     for char in interaction.sequence:
-        key_click(control, char, delay)
+        wx.MilliSleep(delay)
+        control.WriteText(char)

--- a/traitsui/testing/tester/wx/tests/test_helpers.py
+++ b/traitsui/testing/tester/wx/tests/test_helpers.py
@@ -123,6 +123,8 @@ class TestInteractions(unittest.TestCase):
 
         helpers.key_click_text_ctrl(textbox, command.KeyClick("A"), 0)
         self.assertEqual(textbox.Value, "A")
+        helpers.key_click_text_ctrl(textbox, command.KeyClick("Backspace"), 0)
+        self.assertEqual(textbox.Value, "")
 
     def test_key_click_disabled(self):
         textbox = wx.TextCtrl(self.frame)

--- a/traitsui/testing/tester/wx/tests/test_helpers.py
+++ b/traitsui/testing/tester/wx/tests/test_helpers.py
@@ -64,11 +64,50 @@ class TestInteractions(unittest.TestCase):
         self.assertEqual(handler.call_count, 0)
 
     def test_key_sequence(self):
+        # The insertion point is moved to the end
         textbox = wx.TextCtrl(self.frame)
+        textbox.SetValue("123")
+        handler = mock.Mock()
+        textbox.Bind(wx.EVT_TEXT, handler)
 
         helpers.key_sequence_text_ctrl(textbox, command.KeySequence("abc"), 0)
 
-        self.assertEqual(textbox.Value, "abc")
+        self.assertEqual(textbox.GetValue(), "123abc")
+        self.assertEqual(handler.call_count, 3)
+
+    def test_key_sequence_with_unicode(self):
+        handler = mock.Mock()
+        textbox = wx.TextCtrl(self.frame)
+        textbox.Bind(wx.EVT_TEXT, handler)
+        # This range is supported by Qt
+        for code in range(32, 127):
+            with self.subTest(code=code, word=chr(code)):
+                textbox.Clear()
+                handler.reset_mock()
+
+                # when
+                helpers.key_sequence_text_ctrl(
+                    textbox,
+                    command.KeySequence(chr(code) * 3),
+                    delay=0,
+                )
+
+                # then
+                self.assertEqual(textbox.Value, chr(code) * 3)
+                self.assertEqual(handler.call_count, 3)
+
+    def test_key_sequence_with_backspace_unsupported(self):
+        textbox = wx.TextCtrl(self.frame)
+
+        with self.assertRaises(ValueError) as exception_context:
+            helpers.key_sequence_text_ctrl(
+                textbox, command.KeySequence("\b"), 0
+            )
+
+        self.assertIn(
+            "is currently not supported.",
+            str(exception_context.exception),
+        )
 
     def test_key_sequence_disabled(self):
         textbox = wx.TextCtrl(self.frame)
@@ -84,8 +123,6 @@ class TestInteractions(unittest.TestCase):
 
         helpers.key_click_text_ctrl(textbox, command.KeyClick("A"), 0)
         self.assertEqual(textbox.Value, "A")
-        helpers.key_click_text_ctrl(textbox, command.KeyClick("Backspace"), 0)
-        self.assertEqual(textbox.Value, "")
 
     def test_key_click_disabled(self):
         textbox = wx.TextCtrl(self.frame)


### PR DESCRIPTION
Currently the `KeySequence` accepts special keys such as "\b", "\t" for Qt. Under the hood, Qt converts these characters to Qt Key so the support is relatively painless. Similar support for wx.TextCtrl requires a bit more custom work. (See thread starting from https://github.com/enthought/traitsui/pull/1171#discussion_r481055086).

On the other hand, wx.TextCtrl supports some other unicode code points that QTest does not support out-of-the-box (e.g. `'\x1f'` == `chr(31)`).
For testing textboxes, it is probably not necessary to support all possible keys. It may be easier to start with a more limited support and expand it when there are new needs.

This PR
- Restrict supported characters in KeySequence only for the context of testing textbox. Tests all these characters.
      - KeySequence("\b") would not be supported for textboxes. KeyClick("Backspace") should be used instead.
- Somewhat orthogonal, happy to pull out to a separate PR with a separate issue: This PR also normalizes the behaviour for when the textbox already has text. For QLineEdit, we append. For QTextEdit, we insert at the beginning. For wx, we insert text at the beginning too. Here I took the opportunity to normalize these such that the insertion point is at the end of the text if the textbox does not already have focus.