### PR TITLE
fix UITester wx - explicitly handle a KeyClick('Backspace') and update key_click_text_ctrl

### DIFF
--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -13,7 +13,6 @@ import wx
 
 from traitsui.testing.tester.compat import check_key_compat
 from traitsui.testing.tester.exceptions import Disabled
-from traitsui.wx.key_event_to_name import key_map as _KEY_MAP
 
 
 def mouse_click_button(control, delay):

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -122,7 +122,9 @@ def key_click_text_ctrl(control, interaction, delay):
         pos = control.GetInsertionPoint()
         control.Remove(max(0, pos - 1), pos)
     else:
-        key_click(control, interaction.key, delay)
+        check_key_compat(interaction.key)
+        wx.MilliSleep(delay)
+        control.WriteText(interaction.key)
 
 
 def key_sequence_text_ctrl(control, interaction, delay):

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -115,7 +115,10 @@ def key_click_text_ctrl(control, interaction, delay):
     if not control.IsEditable():
         raise Disabled("{!r} is disabled.".format(control))
     if not control.HasFocus():
+        # setFocus resets the InsertionPoint to be 0. We want to preserve it
+        temp = control.GetInsertionPoint()
         control.SetFocus()
+        control.SetInsertionPoint(temp)
     # EmulateKeyPress in key_click seems to not be handling "Enter"
     # correctly.
     if interaction.key == "Enter":

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -117,6 +117,10 @@ def key_click_text_ctrl(control, interaction, delay):
         wx.MilliSleep(delay)
         event = wx.CommandEvent(wx.EVT_TEXT_ENTER.typeId, control.GetId())
         control.ProcessEvent(event)
+    elif interaction.key == "Backspace":
+        wx.MilliSleep(delay)
+        pos = control.GetInsertionPoint()
+        control.Remove(max(0, pos - 1), pos)
     else:
         key_click(control, interaction.key, delay)
 

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -30,6 +30,11 @@ def key_click(widget, key, delay=0):
         Note: modifiers (e.g. Shift, Alt, etc. are not currently supported)
     delay : int
         Time delay (in ms) in which the key click will be performed.
+
+    Notes
+    -----
+    This function is currently unused due to issue on Windows
+    see traitsui issues #1182 and #1183
     """
 
     mapping = {name: event for event, name in _KEY_MAP.items()}

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -16,48 +16,6 @@ from traitsui.testing.tester.exceptions import Disabled
 from traitsui.wx.key_event_to_name import key_map as _KEY_MAP
 
 
-def key_click(widget, key, delay=0):
-    """ Performs a key click of the given key on the given widget after
-    a delay.
-
-    Parameters
-    ----------
-    widget : wx.TextCtrl
-        The wx Object to be key cliecked to.
-    key : str
-        Standardized (pyface) name for a keyboard event.
-        e.g. "Enter", "Tab", "Space", "0", "1", "A", ...
-        Note: modifiers (e.g. Shift, Alt, etc. are not currently supported)
-    delay : int
-        Time delay (in ms) in which the key click will be performed.
-
-    Notes
-    -----
-    This function is currently unused due to issue on Windows
-    see traitsui issues #1182 and #1183
-    """
-
-    mapping = {name: event for event, name in _KEY_MAP.items()}
-    if key not in mapping:
-        try:
-            KEY = ord(key)
-        except [TypeError, ValueError]:
-            raise ValueError(
-                "Unknown key {!r}. Expected one of these: {!r}, or a unicode character".format(  # noqa
-                    key, sorted(mapping)
-                ))
-        else:
-            wx.MilliSleep(delay)
-            key_event = wx.KeyEvent(wx.wxEVT_CHAR)
-            key_event.SetUnicodeKey(KEY)
-            widget.EmulateKeyPress(key_event)
-    else:
-        wx.MilliSleep(delay)
-        key_event = wx.KeyEvent(wx.wxEVT_CHAR)
-        key_event.SetKeyCode(mapping[key])
-        widget.EmulateKeyPress(key_event)
-
-
 def mouse_click_button(control, delay):
     """ Performs a mouce click on a wx button.
 
@@ -115,12 +73,8 @@ def key_click_text_ctrl(control, interaction, delay):
     if not control.IsEditable():
         raise Disabled("{!r} is disabled.".format(control))
     if not control.HasFocus():
-        # setFocus resets the InsertionPoint to be 0. We want to preserve it
-        temp = control.GetInsertionPoint()
         control.SetFocus()
-        control.SetInsertionPoint(temp)
-    # EmulateKeyPress in key_click seems to not be handling "Enter"
-    # correctly.
+        control.SetInsertionPointEnd()
     if interaction.key == "Enter":
         wx.MilliSleep(delay)
         event = wx.CommandEvent(wx.EVT_TEXT_ENTER.typeId, control.GetId())

--- a/traitsui/testing/tester/wx/implementation/range_editor.py
+++ b/traitsui/testing/tester/wx/implementation/range_editor.py
@@ -33,7 +33,9 @@ def resolve_location_slider(wrapper, location):
         The location we are looking to resolve.
     """
     if location == locator.WidgetType.textbox:
-        return LocatedTextbox(textbox=wrapper.target.control.text)
+        textbox = wrapper.target.control.text
+        textbox.SetInsertionPoint(textbox.GetLastPosition()+1)
+        return LocatedTextbox(textbox=textbox)
     if location in [locator.WidgetType.slider]:
         raise NotImplementedError(
             f"Logic for interacting with the {location}"
@@ -60,7 +62,12 @@ def resolve_location_range_text(wrapper, location):
     """
 
     if location == locator.WidgetType.textbox:
-        return LocatedTextbox(textbox=wrapper.target.control)
+        textbox = wrapper.target.control
+        # wx defaults to having insertion point start at 0
+        # for consistent behavior accross toolkits, we set this default to
+        # be the right most point of the textbox
+        textbox.SetInsertionPoint(textbox.GetLastPosition()+1)
+        return LocatedTextbox(textbox=textbox)
     raise ValueError(
         f"Unable to resolve {location} on {wrapper.target}."
         " Currently supported: {locator.WidgetType.textbox}"

--- a/traitsui/testing/tester/wx/implementation/range_editor.py
+++ b/traitsui/testing/tester/wx/implementation/range_editor.py
@@ -34,10 +34,6 @@ def resolve_location_slider(wrapper, location):
     """
     if location == locator.WidgetType.textbox:
         textbox = wrapper.target.control.text
-        # wx defaults to having insertion point start at 0
-        # for consistent behavior accross toolkits, we set this default to
-        # be the right most point of the textbox
-        textbox.SetInsertionPoint(textbox.GetLastPosition()+1)
         return LocatedTextbox(textbox=textbox)
     if location in [locator.WidgetType.slider]:
         raise NotImplementedError(
@@ -66,10 +62,6 @@ def resolve_location_range_text(wrapper, location):
 
     if location == locator.WidgetType.textbox:
         textbox = wrapper.target.control
-        # wx defaults to having insertion point start at 0
-        # for consistent behavior accross toolkits, we set this default to
-        # be the right most point of the textbox
-        textbox.SetInsertionPoint(textbox.GetLastPosition()+1)
         return LocatedTextbox(textbox=textbox)
     raise ValueError(
         f"Unable to resolve {location} on {wrapper.target}."

--- a/traitsui/testing/tester/wx/implementation/range_editor.py
+++ b/traitsui/testing/tester/wx/implementation/range_editor.py
@@ -34,6 +34,9 @@ def resolve_location_slider(wrapper, location):
     """
     if location == locator.WidgetType.textbox:
         textbox = wrapper.target.control.text
+        # wx defaults to having insertion point start at 0
+        # for consistent behavior accross toolkits, we set this default to
+        # be the right most point of the textbox
         textbox.SetInsertionPoint(textbox.GetLastPosition()+1)
         return LocatedTextbox(textbox=textbox)
     if location in [locator.WidgetType.slider]:

--- a/traitsui/testing/tester/wx/implementation/range_editor.py
+++ b/traitsui/testing/tester/wx/implementation/range_editor.py
@@ -33,8 +33,7 @@ def resolve_location_slider(wrapper, location):
         The location we are looking to resolve.
     """
     if location == locator.WidgetType.textbox:
-        textbox = wrapper.target.control.text
-        return LocatedTextbox(textbox=textbox)
+        return LocatedTextbox(textbox=wrapper.target.control.text)
     if location in [locator.WidgetType.slider]:
         raise NotImplementedError(
             f"Logic for interacting with the {location}"
@@ -61,8 +60,7 @@ def resolve_location_range_text(wrapper, location):
     """
 
     if location == locator.WidgetType.textbox:
-        textbox = wrapper.target.control
-        return LocatedTextbox(textbox=textbox)
+        return LocatedTextbox(textbox=wrapper.target.control)
     raise ValueError(
         f"Unable to resolve {location} on {wrapper.target}."
         " Currently supported: {locator.WidgetType.textbox}"

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -79,7 +79,12 @@ class TestRangeEditor(unittest.TestCase):
     def test_log_range_slider_editor_set_with_text(self):
         return self.check_set_with_text(mode='logslider')
 
+    @requires_toolkit([ToolkitName.qt])
     def test_range_text_editor_set_with_text(self):
+        return self.check_set_with_text(mode='text')
+    
+    @requires_toolkit([ToolkitName.wx])
+    def test_range_text_editor_set_with_text_wx(self):
         # this test is seperate to avoid an invalid state after deleting
         # contents of textbox
         model = RangeModel()

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -58,7 +58,7 @@ class TestRangeEditor(unittest.TestCase):
                 editor=RangeEditor(low=1, high=12, mode=mode)
             )
         )
-        tester = UITester()
+        tester = UITester(delay=500)
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
             text = number_field.locate(locator.WidgetType.textbox)

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -1,3 +1,4 @@
+import platform
 import unittest
 
 from traits.api import HasTraits, Int
@@ -5,10 +6,12 @@ from traitsui.api import Item, RangeEditor, UItem, View
 from traitsui.testing.tester import command, locator, query
 from traitsui.testing.tester.ui_tester import UITester
 from traitsui.tests._tools import (
+    is_wx,
     requires_toolkit,
     ToolkitName,
 )
 
+is_windows = platform.system() == "Windows"
 
 class RangeModel(HasTraits):
 
@@ -64,6 +67,11 @@ class TestRangeEditor(unittest.TestCase):
             self.assertEqual(model.value, 1)
             number_field = tester.find_by_name(ui, "value")
             text = number_field.locate(locator.WidgetType.textbox)
+            if is_windows and is_wx() and mode=='text':
+                # For RangeTextEditor on wx and windows, the textbox
+                # automatically gets focus and the full content is selected.
+                # Insertion point is moved to keep the test consistent   
+                text.target.textbox.SetInsertionPointEnd()
             text.perform(command.KeyClick("0"))
             text.perform(command.KeyClick("Enter"))
             displayed = text.inspect(query.DisplayedText())

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -58,7 +58,7 @@ class TestRangeEditor(unittest.TestCase):
                 editor=RangeEditor(low=1, high=12, mode=mode)
             )
         )
-        tester = UITester(delay=500)
+        tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
             text = number_field.locate(locator.WidgetType.textbox)

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -80,6 +80,8 @@ class TestRangeEditor(unittest.TestCase):
         return self.check_set_with_text(mode='logslider')
 
     def test_range_text_editor_set_with_text(self):
+        # this test is seperate to avoid an invalid state after deleting
+        # contents of textbox
         model = RangeModel()
         view = View(
             Item(

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -13,6 +13,7 @@ from traitsui.tests._tools import (
 
 is_windows = platform.system() == "Windows"
 
+
 class RangeModel(HasTraits):
 
     value = Int(1)
@@ -67,10 +68,10 @@ class TestRangeEditor(unittest.TestCase):
             self.assertEqual(model.value, 1)
             number_field = tester.find_by_name(ui, "value")
             text = number_field.locate(locator.WidgetType.textbox)
-            if is_windows and is_wx() and mode=='text':
+            if is_windows and is_wx() and mode == 'text':
                 # For RangeTextEditor on wx and windows, the textbox
                 # automatically gets focus and the full content is selected.
-                # Insertion point is moved to keep the test consistent   
+                # Insertion point is moved to keep the test consistent
                 text.target.textbox.SetInsertionPointEnd()
             text.perform(command.KeyClick("0"))
             text.perform(command.KeyClick("Enter"))
@@ -121,8 +122,7 @@ class TestRangeEditor(unittest.TestCase):
         return self.check_set_with_text_after_empty(mode='logslider')
 
     # on wx the text style editor gives an error whenever the textbox
-    # is empty, even if enter has not been pressed. 
+    # is empty, even if enter has not been pressed.
     @requires_toolkit([ToolkitName.qt])
     def test_range_text_editor_set_with_text_after_empty(self):
         return self.check_set_with_text_after_empty(mode='text')
-

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -80,4 +80,25 @@ class TestRangeEditor(unittest.TestCase):
         return self.check_set_with_text(mode='logslider')
 
     def test_range_text_editor_set_with_text(self):
-        return self.check_set_with_text(mode='text')
+        model = RangeModel()
+        view = View(
+            Item(
+                "value",
+                editor=RangeEditor(low=1, high=12, mode='text')
+            )
+        )
+        tester = UITester()
+        with tester.create_ui(model, dict(view=view)) as ui:
+            number_field = tester.find_by_name(ui, "value")
+            text = number_field.locate(locator.WidgetType.textbox)
+            text.perform(command.KeyClick("1"))
+            text.perform(command.KeyClick("Enter"))
+            displayed = text.inspect(query.DisplayedText())
+            self.assertEqual(model.value, 11)
+            self.assertEqual(displayed, str(model.value))
+            text.perform(command.KeyClick("Backspace"))
+            text.perform(command.KeyClick("0"))
+            text.perform(command.KeyClick("Enter"))
+            displayed = text.inspect(query.DisplayedText())
+            self.assertEqual(model.value, 10)
+            self.assertEqual(displayed, str(model.value))


### PR DESCRIPTION
fixes #1183 
fixes #1182 
fixes #1177 
This PR explicitly handles the case when a KeyClick command is issued with "Backspace" as the key.  It also makes the same change that was added in PR #1181 for `key_sequence_text_ctrl` to `key_click_text_ctrl`
Finally, it makes the default behavior for entering a textbox to have the insertion point be the rightmost rather than the leftmost point of text.  (this keeps consistent behavior with qt)