### PR TITLE
adding a blank api for UITester

### DIFF
--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -1,0 +1,10 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#


### PR DESCRIPTION
As mentioned in the discussion https://github.com/enthought/traitsui/issues/1149#issuecomment-677477757 this adds an empty `traitsui.testing.api` module.  
This file will need to be appropriately populated to complete the second bullet on issue #1173 