### PR TITLE
Refactor registering interaction handlers for editable textboxes

### DIFF
--- a/traitsui/testing/tester/qt4/common_ui_targets.py
+++ b/traitsui/testing/tester/qt4/common_ui_targets.py
@@ -44,22 +44,44 @@ class LocatedTextbox:
         registry : TargetRegistry
             The registry being registered to.
         """
-        handlers = [
-            (command.KeySequence,
-                (lambda wrapper, interaction: helpers.key_sequence_textbox(
-                    wrapper.target.textbox, interaction, wrapper.delay))),
-            (command.KeyClick,
-                (lambda wrapper, interaction: helpers.key_click_qwidget(
-                    wrapper.target.textbox, interaction, wrapper.delay))),
-            (command.MouseClick,
-                (lambda wrapper, _: helpers.mouse_click_qwidget(
-                    wrapper.target.textbox, wrapper.delay))),
-            (query.DisplayedText,
-                lambda wrapper, _: wrapper.target.textbox.displayText()),
-        ]
-        for interaction_class, handler in handlers:
-            registry.register_handler(
-                target_class=cls,
-                interaction_class=interaction_class,
-                handler=handler,
-            )
+        register_editable_textbox_handlers(
+            registry=registry,
+            target_class=cls,
+            widget_getter=lambda wrapper: wrapper.target.textbox,
+        )
+
+
+def register_editable_textbox_handlers(registry, target_class, widget_getter):
+    """ Register common interactions for an editable textbox (in Qt)
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    target_class : subclass of type
+        The type of target being wrapped in a UIWrapper on which the
+        interaction will be performed.
+    widget_getter : callable(wrapper: UIWrapper) -> QWidget
+        A callable to return a Qt widget for editing text, i.e. QLineEdit
+        or QTextEdit.
+    """
+    handlers = [
+        (command.KeySequence,
+            (lambda wrapper, interaction: helpers.key_sequence_textbox(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.KeyClick,
+            (lambda wrapper, interaction: helpers.key_click_qwidget(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.MouseClick,
+            (lambda wrapper, _: helpers.mouse_click_qwidget(
+                widget_getter(wrapper), wrapper.delay))),
+        (query.DisplayedText,
+            lambda wrapper, _: helpers.displayed_text_qobject(
+                widget_getter(wrapper))),
+    ]
+    for interaction_class, handler in handlers:
+        registry.register_handler(
+            target_class=target_class,
+            interaction_class=interaction_class,
+            handler=handler,
+        )

--- a/traitsui/testing/tester/qt4/common_ui_targets.py
+++ b/traitsui/testing/tester/qt4/common_ui_targets.py
@@ -17,8 +17,7 @@ target_class of choice to one of these as the locator_class. For an example,
 see the implementation of range_editor.
 """
 
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.qt4 import helpers
+from traitsui.testing.tester.qt4 import registry_helper
 
 
 class LocatedTextbox:
@@ -44,44 +43,8 @@ class LocatedTextbox:
         registry : TargetRegistry
             The registry being registered to.
         """
-        register_editable_textbox_handlers(
+        registry_helper.register_editable_textbox_handlers(
             registry=registry,
             target_class=cls,
             widget_getter=lambda wrapper: wrapper.target.textbox,
-        )
-
-
-def register_editable_textbox_handlers(registry, target_class, widget_getter):
-    """ Register common interactions for an editable textbox (in Qt)
-
-    Parameters
-    ----------
-    registry : TargetRegistry
-        The registry being registered to.
-    target_class : subclass of type
-        The type of target being wrapped in a UIWrapper on which the
-        interaction will be performed.
-    widget_getter : callable(wrapper: UIWrapper) -> QWidget
-        A callable to return a Qt widget for editing text, i.e. QLineEdit
-        or QTextEdit.
-    """
-    handlers = [
-        (command.KeySequence,
-            (lambda wrapper, interaction: helpers.key_sequence_textbox(
-                widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.KeyClick,
-            (lambda wrapper, interaction: helpers.key_click_qwidget(
-                widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.MouseClick,
-            (lambda wrapper, _: helpers.mouse_click_qwidget(
-                widget_getter(wrapper), wrapper.delay))),
-        (query.DisplayedText,
-            lambda wrapper, _: helpers.displayed_text_qobject(
-                widget_getter(wrapper))),
-    ]
-    for interaction_class, handler in handlers:
-        registry.register_handler(
-            target_class=target_class,
-            interaction_class=interaction_class,
-            handler=handler,
         )

--- a/traitsui/testing/tester/qt4/implementation/text_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/text_editor.py
@@ -11,6 +11,9 @@
 
 from traitsui.testing.tester import command, query
 from traitsui.testing.tester.qt4 import helpers
+from traitsui.testing.tester.qt4.common_ui_targets import (
+    register_editable_textbox_handlers,
+)
 from traitsui.qt4.text_editor import CustomEditor, ReadonlyEditor, SimpleEditor
 
 
@@ -25,26 +28,13 @@ def register(registry):
         The registry being registered to.
     """
 
-    handlers = [
-        (command.KeySequence,
-            (lambda wrapper, interaction: helpers.key_sequence_textbox(
-                wrapper.target.control, interaction, wrapper.delay))),
-        (command.KeyClick,
-            (lambda wrapper, interaction: helpers.key_click_qwidget(
-                wrapper.target.control, interaction, wrapper.delay))),
-        (command.MouseClick,
-            (lambda wrapper, _: helpers.mouse_click_qwidget(
-                wrapper.target.control, wrapper.delay))),
-    ]
     for target_class in [CustomEditor, SimpleEditor]:
-        for interaction_class, handler in handlers:
-            registry.register_handler(
-                target_class=target_class,
-                interaction_class=interaction_class,
-                handler=handler,
-            )
-
-    for target_class in [CustomEditor, ReadonlyEditor, SimpleEditor]:
+        register_editable_textbox_handlers(
+            registry=registry,
+            target_class=target_class,
+            widget_getter=lambda wrapper: wrapper.target.control,
+        )
+    for target_class in [ReadonlyEditor]:
         registry.register_handler(
             target_class=target_class,
             interaction_class=query.DisplayedText,

--- a/traitsui/testing/tester/qt4/implementation/text_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/text_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.tester import command, query
+from traitsui.testing.tester import query
 from traitsui.testing.tester.qt4 import helpers
 from traitsui.testing.tester.qt4.common_ui_targets import (
     register_editable_textbox_handlers,
@@ -34,10 +34,10 @@ def register(registry):
             target_class=target_class,
             widget_getter=lambda wrapper: wrapper.target.control,
         )
-    for target_class in [ReadonlyEditor]:
-        registry.register_handler(
-            target_class=target_class,
-            interaction_class=query.DisplayedText,
-            handler=lambda wrapper, _: helpers.displayed_text_qobject(
-                wrapper.target.control),
-        )
+
+    registry.register_handler(
+        target_class=ReadonlyEditor,
+        interaction_class=query.DisplayedText,
+        handler=lambda wrapper, _: helpers.displayed_text_qobject(
+            wrapper.target.control),
+    )

--- a/traitsui/testing/tester/qt4/implementation/text_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/text_editor.py
@@ -11,7 +11,7 @@
 
 from traitsui.testing.tester import query
 from traitsui.testing.tester.qt4 import helpers
-from traitsui.testing.tester.qt4.common_ui_targets import (
+from traitsui.testing.tester.qt4.registry_helper import (
     register_editable_textbox_handlers,
 )
 from traitsui.qt4.text_editor import CustomEditor, ReadonlyEditor, SimpleEditor

--- a/traitsui/testing/tester/qt4/registry_helper.py
+++ b/traitsui/testing/tester/qt4/registry_helper.py
@@ -1,0 +1,53 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+""" This module provides functions for registering interaction handlers
+and location solvers for common Qt GUI components.
+"""
+
+from traitsui.testing.tester import command, query
+from traitsui.testing.tester.qt4 import helpers
+
+
+def register_editable_textbox_handlers(registry, target_class, widget_getter):
+    """ Register common interactions for an editable textbox (in Qt)
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    target_class : subclass of type
+        The type of target being wrapped in a UIWrapper on which the
+        interaction will be performed.
+    widget_getter : callable(wrapper: UIWrapper) -> QWidget
+        A callable to return a Qt widget for editing text, i.e. QLineEdit
+        or QTextEdit.
+    """
+    handlers = [
+        (command.KeySequence,
+            (lambda wrapper, interaction: helpers.key_sequence_textbox(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.KeyClick,
+            (lambda wrapper, interaction: helpers.key_click_qwidget(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.MouseClick,
+            (lambda wrapper, _: helpers.mouse_click_qwidget(
+                widget_getter(wrapper), wrapper.delay))),
+        (query.DisplayedText,
+            lambda wrapper, _: helpers.displayed_text_qobject(
+                widget_getter(wrapper))),
+    ]
+    for interaction_class, handler in handlers:
+        registry.register_handler(
+            target_class=target_class,
+            interaction_class=interaction_class,
+            handler=handler,
+        )

--- a/traitsui/testing/tester/wx/common_ui_targets.py
+++ b/traitsui/testing/tester/wx/common_ui_targets.py
@@ -17,8 +17,7 @@ target_class of choice to one of these as the locator_class. For an example,
 see the implementation of range_editor.
 """
 
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.wx import helpers
+from traitsui.testing.tester.wx import registry_helper
 
 
 class LocatedTextbox:
@@ -44,42 +43,8 @@ class LocatedTextbox:
         registry : TargetRegistry
             The registry being registered to.
         """
-        register_editable_textbox_handlers(
+        registry_helper.register_editable_textbox_handlers(
             registry=registry,
             target_class=cls,
             widget_getter=lambda wrapper: wrapper.target.textbox,
-        )
-
-
-def register_editable_textbox_handlers(registry, target_class, widget_getter):
-    """ Register common interactions for an editable textbox (in Wx)
-
-    Parameters
-    ----------
-    registry : TargetRegistry
-        The registry being registered to.
-    target_class : subclass of type
-        The type of target being wrapped in a UIWrapper on which the
-        interaction will be performed.
-    widget_getter : callable(wrapper: UIWrapper) -> wx.TextCtrl
-        A callable to return a wx.TextCtrl
-    """
-    handlers = [
-        (command.KeySequence,
-            (lambda wrapper, interaction: helpers.key_sequence_text_ctrl(
-                widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.KeyClick,
-            (lambda wrapper, interaction: helpers.key_click_text_ctrl(
-                widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.MouseClick,
-            (lambda wrapper, _: helpers.mouse_click_object(
-                widget_getter(wrapper), wrapper.delay))),
-        (query.DisplayedText,
-            lambda wrapper, _: widget_getter(wrapper).GetValue()),
-    ]
-    for interaction_class, handler in handlers:
-        registry.register_handler(
-            target_class=target_class,
-            interaction_class=interaction_class,
-            handler=handler,
         )

--- a/traitsui/testing/tester/wx/common_ui_targets.py
+++ b/traitsui/testing/tester/wx/common_ui_targets.py
@@ -44,22 +44,42 @@ class LocatedTextbox:
         registry : TargetRegistry
             The registry being registered to.
         """
-        handlers = [
-            (command.KeySequence,
-                (lambda wrapper, interaction: helpers.key_sequence_text_ctrl(
-                    wrapper.target.textbox, interaction, wrapper.delay))),
-            (command.KeyClick,
-                (lambda wrapper, interaction: helpers.key_click_text_ctrl(
-                    wrapper.target.textbox, interaction, wrapper.delay))),
-            (command.MouseClick,
-                (lambda wrapper, _: helpers.mouse_click_object(
-                    wrapper.target.textbox, wrapper.delay))),
-            (query.DisplayedText,
-                lambda wrapper, _: wrapper.target.textbox.GetValue()),
-        ]
-        for interaction_class, handler in handlers:
-            registry.register_handler(
-                target_class=cls,
-                interaction_class=interaction_class,
-                handler=handler,
-            )
+        register_editable_textbox_handlers(
+            registry=registry,
+            target_class=cls,
+            widget_getter=lambda wrapper: wrapper.target.textbox,
+        )
+
+
+def register_editable_textbox_handlers(registry, target_class, widget_getter):
+    """ Register common interactions for an editable textbox (in Wx)
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    target_class : subclass of type
+        The type of target being wrapped in a UIWrapper on which the
+        interaction will be performed.
+    widget_getter : callable(wrapper: UIWrapper) -> wx.TextCtrl
+        A callable to return a wx.TextCtrl
+    """
+    handlers = [
+        (command.KeySequence,
+            (lambda wrapper, interaction: helpers.key_sequence_text_ctrl(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.KeyClick,
+            (lambda wrapper, interaction: helpers.key_click_text_ctrl(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.MouseClick,
+            (lambda wrapper, _: helpers.mouse_click_object(
+                widget_getter(wrapper), wrapper.delay))),
+        (query.DisplayedText,
+            lambda wrapper, _: widget_getter(wrapper).GetValue()),
+    ]
+    for interaction_class, handler in handlers:
+        registry.register_handler(
+            target_class=target_class,
+            interaction_class=interaction_class,
+            handler=handler,
+        )

--- a/traitsui/testing/tester/wx/implementation/text_editor.py
+++ b/traitsui/testing/tester/wx/implementation/text_editor.py
@@ -13,7 +13,7 @@ import wx
 
 from traitsui.wx.text_editor import CustomEditor, ReadonlyEditor, SimpleEditor
 from traitsui.testing.tester import query
-from traitsui.testing.tester.wx.common_ui_targets import (
+from traitsui.testing.tester.wx.registry_helper import (
     register_editable_textbox_handlers,
 )
 

--- a/traitsui/testing/tester/wx/implementation/text_editor.py
+++ b/traitsui/testing/tester/wx/implementation/text_editor.py
@@ -12,8 +12,10 @@
 import wx
 
 from traitsui.wx.text_editor import CustomEditor, ReadonlyEditor, SimpleEditor
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.wx import helpers
+from traitsui.testing.tester import query
+from traitsui.testing.tester.wx.common_ui_targets import (
+    register_editable_textbox_handlers,
+)
 
 
 def readonly_displayed_text_handler(wrapper, interaction):
@@ -54,31 +56,11 @@ def register(registry):
         The registry being registered to.
     """
 
-    handlers = [
-        (command.KeyClick,
-            (lambda wrapper, interaction: helpers.key_click_text_ctrl(
-                wrapper.target.control, interaction, wrapper.delay))),
-        (command.KeySequence,
-            (lambda wrapper, interaction: helpers.key_sequence_text_ctrl(
-                wrapper.target.control, interaction, wrapper.delay))),
-        (command.MouseClick,
-            (lambda wrapper, _: helpers.mouse_click_object(
-                wrapper.target.control, wrapper.delay))),
-    ]
-
     for target_class in [CustomEditor, SimpleEditor]:
-        for interaction_class, handler in handlers:
-            registry.register_handler(
-                target_class=target_class,
-                interaction_class=interaction_class,
-                handler=handler,
-            )
-
-    for target_class in [CustomEditor, SimpleEditor]:
-        registry.register_handler(
+        register_editable_textbox_handlers(
+            registry=registry,
             target_class=target_class,
-            interaction_class=query.DisplayedText,
-            handler=lambda wrapper, _: wrapper.target.control.GetValue(),
+            widget_getter=lambda wrapper: wrapper.target.control,
         )
 
     registry.register_handler(

--- a/traitsui/testing/tester/wx/registry_helper.py
+++ b/traitsui/testing/tester/wx/registry_helper.py
@@ -1,0 +1,51 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+""" This module provides functions for registering interaction handlers
+and location solvers for common Wx GUI components.
+"""
+
+from traitsui.testing.tester import command, query
+from traitsui.testing.tester.wx import helpers
+
+
+def register_editable_textbox_handlers(registry, target_class, widget_getter):
+    """ Register common interactions for an editable textbox (in Wx)
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    target_class : subclass of type
+        The type of target being wrapped in a UIWrapper on which the
+        interaction will be performed.
+    widget_getter : callable(wrapper: UIWrapper) -> wx.TextCtrl
+        A callable to return a wx.TextCtrl
+    """
+    handlers = [
+        (command.KeySequence,
+            (lambda wrapper, interaction: helpers.key_sequence_text_ctrl(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.KeyClick,
+            (lambda wrapper, interaction: helpers.key_click_text_ctrl(
+                widget_getter(wrapper), interaction, wrapper.delay))),
+        (command.MouseClick,
+            (lambda wrapper, _: helpers.mouse_click_object(
+                widget_getter(wrapper), wrapper.delay))),
+        (query.DisplayedText,
+            lambda wrapper, _: widget_getter(wrapper).GetValue()),
+    ]
+    for interaction_class, handler in handlers:
+        registry.register_handler(
+            target_class=target_class,
+            interaction_class=interaction_class,
+            handler=handler,
+        )

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -106,10 +106,10 @@ class TestRangeEditor(unittest.TestCase):
             # Delete all contents of textbox
             for _ in range(5):
                 text.perform(command.KeyClick("Backspace"))
-            text.perform(command.KeyClick("4"))
+            text.perform(command.KeySequence("11"))
             text.perform(command.KeyClick("Enter"))
             displayed = text.inspect(query.DisplayedText())
-            self.assertEqual(model.value, 4)
+            self.assertEqual(model.value, 11)
             self.assertEqual(displayed, str(model.value))
 
     def test_simple_slider_editor_set_with_text_after_empty(self):

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -163,13 +163,12 @@ class TestTextEditor(unittest.TestCase, UnittestTools):
         self.check_editor_init_and_dispose(style="custom", auto_set=False)
 
     def test_simple_auto_set_update_text(self):
-        foo = Foo(name="a")
+        foo = Foo()
         view = get_view(style="simple", auto_set=True)
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
-            with self.assertTraitChanges(foo, "name", count=4):
+            with self.assertTraitChanges(foo, "name", count=3):
                 name_field = tester.find_by_name(ui, "name")
-                name_field.perform(command.KeyClick("Backspace"))
                 name_field.perform(command.KeySequence("NEW"))
                 # with auto-set the displayed name should match the name trait
             display_name = name_field.inspect(query.DisplayedText())

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -163,12 +163,13 @@ class TestTextEditor(unittest.TestCase, UnittestTools):
         self.check_editor_init_and_dispose(style="custom", auto_set=False)
 
     def test_simple_auto_set_update_text(self):
-        foo = Foo()
+        foo = Foo(name="a")
         view = get_view(style="simple", auto_set=True)
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
-            with self.assertTraitChanges(foo, "name", count=3):
+            with self.assertTraitChanges(foo, "name", count=4):
                 name_field = tester.find_by_name(ui, "name")
+                name_field.perform(command.KeyClick("Backspace"))
                 name_field.perform(command.KeySequence("NEW"))
                 # with auto-set the displayed name should match the name trait
             display_name = name_field.inspect(query.DisplayedText())


### PR DESCRIPTION
This PR refactors how we add interaction handlers for editable textboxes.

There are small changes to the tests to exercise more interactions in order to ensure the refactoring has not broken things.

With this refactoring, I can add interactions for things like the text-style FontEditor relatively easily (see #1161).