### PR TITLE
Update travis CI + wx setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - pulseaudio
     - libpulse-mainloop-glib0
     # Wx dependencies
-    - libsdl1.2debian
+    - libsdl2-2.0-0
 
 env:
   global:

--- a/etstool.py
+++ b/etstool.py
@@ -215,7 +215,7 @@ def install(runtime, toolkit, environment, editable, source):
         else:
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython"
+                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"
             )
 
     click.echo("Creating environment '{environment}'".format(**parameters))


### PR DESCRIPTION
Travis CI + wx has not been able to build. This PR brings it recently changes on pyface.
~If that does not work I will need to do more debugging. Marking as a draft for now.~ Edited: That works.

For reference, the error looks like this:
```
======================================================================
ERROR: traitsui (unittest.loader._FailedTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/__init__.py", line 69, in load_tests
    from traitsui.tests._tools import filter_tests
  File "/home/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/traitsui/tests/_tools.py", line 24, in <module>
    from pyface.api import GUI
  File "/home/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/pyface/api.py", line 12, in <module>
    from .about_dialog import AboutDialog
  File "/home/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/pyface/about_dialog.py", line 15, in <module>
    from .toolkit import toolkit_object
  File "/home/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/pyface/toolkit.py", line 23, in <module>
    toolkit = toolkit_object = find_toolkit("pyface.toolkits")
  File "/home/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/pyface/base_toolkit.py", line 269, in find_toolkit
    return import_toolkit(ETSConfig.toolkit, entry_point)
  File "/home/travis/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/site-packages/pyface/base_toolkit.py", line 233, in import_toolkit
    raise RuntimeError(msg)
RuntimeError: No pyface.toolkits plugin could be loaded for wx
```

Setting logging level to debug should provide more info ~- I will do that if the first commit fails to fix this.~