### PR TITLE
Fix backspacing wx textbox when there is selected text

### DIFF
--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -124,8 +124,11 @@ def key_click_text_ctrl(control, interaction, delay):
         control.ProcessEvent(event)
     elif interaction.key == "Backspace":
         wx.MilliSleep(delay)
-        pos = control.GetInsertionPoint()
-        control.Remove(max(0, pos - 1), pos)
+        if control.GetStringSelection():
+            control.Remove(*control.GetSelection())
+        else:
+            pos = control.GetInsertionPoint()
+            control.Remove(max(0, pos - 1), pos)
     else:
         check_key_compat(interaction.key)
         wx.MilliSleep(delay)

--- a/traitsui/testing/tester/wx/tests/test_helpers.py
+++ b/traitsui/testing/tester/wx/tests/test_helpers.py
@@ -120,11 +120,40 @@ class TestInteractions(unittest.TestCase):
 
     def test_key_click(self):
         textbox = wx.TextCtrl(self.frame)
+        handler = mock.Mock()
+        textbox.Bind(wx.EVT_TEXT, handler)
 
         helpers.key_click_text_ctrl(textbox, command.KeyClick("A"), 0)
+
         self.assertEqual(textbox.Value, "A")
+        self.assertEqual(handler.call_count, 1)
+
+    def test_key_click_backspace(self):
+        textbox = wx.TextCtrl(self.frame)
+        textbox.SetValue("A")
+        handler = mock.Mock()
+        textbox.Bind(wx.EVT_TEXT, handler)
+
         helpers.key_click_text_ctrl(textbox, command.KeyClick("Backspace"), 0)
+
         self.assertEqual(textbox.Value, "")
+        self.assertEqual(handler.call_count, 1)
+
+    def test_key_click_backspace_with_selection(self):
+        textbox = wx.TextCtrl(self.frame)
+        textbox.SetFocus()
+        textbox.SetValue("ABCDE")
+        textbox.SetSelection(0, 4)
+        # sanity check
+        self.assertEqual(textbox.GetStringSelection(), "ABCD")
+
+        handler = mock.Mock()
+        textbox.Bind(wx.EVT_TEXT, handler)
+
+        helpers.key_click_text_ctrl(textbox, command.KeyClick("Backspace"), 0)
+
+        self.assertEqual(textbox.Value, "E")
+        self.assertEqual(handler.call_count, 1)
 
     def test_key_click_disabled(self):
         textbox = wx.TextCtrl(self.frame)

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -163,13 +163,12 @@ class TestTextEditor(unittest.TestCase, UnittestTools):
         self.check_editor_init_and_dispose(style="custom", auto_set=False)
 
     def test_simple_auto_set_update_text(self):
-        foo = Foo(name="a")
+        foo = Foo()
         view = get_view(style="simple", auto_set=True)
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
-            with self.assertTraitChanges(foo, "name", count=4):
+            with self.assertTraitChanges(foo, "name", count=3):
                 name_field = tester.find_by_name(ui, "name")
-                name_field.perform(command.KeyClick("Backspace"))
                 name_field.perform(command.KeySequence("NEW"))
                 # with auto-set the displayed name should match the name trait
             display_name = name_field.inspect(query.DisplayedText())

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -163,12 +163,13 @@ class TestTextEditor(unittest.TestCase, UnittestTools):
         self.check_editor_init_and_dispose(style="custom", auto_set=False)
 
     def test_simple_auto_set_update_text(self):
-        foo = Foo()
+        foo = Foo(name="a")
         view = get_view(style="simple", auto_set=True)
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
-            with self.assertTraitChanges(foo, "name", count=3):
+            with self.assertTraitChanges(foo, "name", count=4):
                 name_field = tester.find_by_name(ui, "name")
+                name_field.perform(command.KeyClick("Backspace"))
                 name_field.perform(command.KeySequence("NEW"))
                 # with auto-set the displayed name should match the name trait
             display_name = name_field.inspect(query.DisplayedText())


### PR DESCRIPTION
This PR fixes the implementation of `KeyClick("Backspace")` on wx.TextCtrl when there is already some selected text.

For reference, we could not get [`wx.TextCtrl.EmulateKeyPress`](https://wxpython.org/Phoenix/docs/html/wx.TextCtrl.html#wx.TextCtrl.EmulateKeyPress) to emulate backspace on Windows, hence we had to emulate it ourselves. See https://github.com/enthought/traitsui/pull/1184 and this [discussion on wxPython forum](https://discuss.wxpython.org/t/wx-textctrl-and-emulatekeypress/28300).