### PR TITLE
Fix for menu actions with on_perform being performed twice

### DIFF
--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -259,6 +259,7 @@ class Editor(UIEditor):
 
         if action.on_perform is not None:
             action.on_perform(selection)
+            return
 
         action.perform(selection)
 

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -3,8 +3,7 @@ from unittest.mock import Mock
 
 from traits.api import HasTraits, Instance, Int, List, Str, Tuple
 
-from traitsui.api import EvalTableFilter, Item, ObjectColumn, TableEditor, View
-from traitsui.menu import Action, Menu
+from traitsui.api import Action, EvalTableFilter, Item, ObjectColumn, TableEditor, View
 from traitsui.tests._tools import (
     create_ui,
     is_qt,

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -1,8 +1,10 @@
 import unittest
+from unittest.mock import Mock
 
 from traits.api import HasTraits, Instance, Int, List, Str, Tuple
 
 from traitsui.api import EvalTableFilter, Item, ObjectColumn, TableEditor, View
+from traitsui.menu import Action, Menu
 from traitsui.tests._tools import (
     create_ui,
     is_qt,
@@ -564,3 +566,21 @@ class TestTableEditor(unittest.TestCase):
         with reraise_exceptions(), \
                 create_ui(object_list, dict(view=progress_view)) as ui:
             process_cascade_events()
+
+    @requires_toolkit([ToolkitName.qt])
+    def test_on_perform_action(self):
+        # A test for issue #741, where actions with an on_perform function set
+        # would get called twice
+        object_list = ObjectList(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        mock_function = Mock()
+        action = Action(on_perform=mock_function)
+
+        with reraise_exceptions(), \
+                create_ui(object_list, dict(view=simple_view)) as ui:
+            editor = ui.get_editors("values")[0]
+            process_cascade_events()
+            editor.set_menu_context(None, None, None)
+            editor.perform(action)
+        mock_function.assert_called_once()


### PR DESCRIPTION
This should fix #741, though I'm not entirely sure where to add tests to confirm it! Having it work in one canopy data app where this came up probably isn't sufficient..
 
The problem seemed to be that `Action`s with an `on_perform` attribute hit :
https://github.com/enthought/traitsui/blob/884414547b634ce30421df29e817bb6beaa1036c/traitsui/qt4/editor.py#L260-L261
and called the function set as `on_perform`, but then afterwards hit:
https://github.com/enthought/traitsui/blob/884414547b634ce30421df29e817bb6beaa1036c/traitsui/qt4/editor.py#L263
which basically does the same thing again, only in the `Action` class this time.
https://github.com/enthought/pyface/blob/4b91627c8a8ab2680f62e85af261d1da54675558/pyface/action/action.py#L123-L132

Just returning after the first one would mean `on_perform` would take precedence over a overridden `perform` method if an `Action` had both of these. If creating `Action`s with both these properties was an expected usage, this PR won't be enough!