### PR TITLE
UI Tester updates - Instance editor implementation

### DIFF
--- a/traitsui/testing/tester/qt4/default_registry.py
+++ b/traitsui/testing/tester/qt4/default_registry.py
@@ -14,6 +14,7 @@ from traitsui.testing.tester.qt4 import common_ui_targets
 from traitsui.testing.tester.qt4.implementation import (
     button_editor,
     check_list_editor,
+    instance_editor,
     list_editor,
     range_editor,
     text_editor,
@@ -47,5 +48,8 @@ def get_default_registry():
 
     # RangeEditor
     range_editor.register(registry)
+
+    # InstanceEditor
+    instance_editor.register(registry)
 
     return registry

--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -16,12 +16,24 @@ from traitsui.qt4.instance_editor import (
 
 
 def _get_netsed_ui_simple(target):
+    """ Obtains a nested UI within a Simple Instance Editor.
+
+    Parameters
+    ----------
+    target : instance of SimpleEditor
+    """
     if target._dialog_ui is None:
         target._button.click()
     return target._dialog_ui
 
 
 def _get_netsed_ui_custom(target):
+    """ Obtains a nested UI within a Custom Instance Editor.
+
+    Parameters
+    ----------
+    target : instance of CustomEditor
+    """
     return target._ui
 
 

--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -1,0 +1,39 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.qt4.instance_editor import (
+    CustomEditor,
+    SimpleEditor
+)
+
+def _get_netsed_ui_simple(target):
+    if target._dialog_ui is None:
+        target._button.click()
+    return target._dialog_ui
+
+
+def _get_netsed_ui_custom(target):
+    return target._ui
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    register_nested_ui_solvers(registry, SimpleEditor, _get_netsed_ui_simple)
+    register_nested_ui_solvers(registry, CustomEditor, _get_netsed_ui_custom)

--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -25,8 +25,6 @@ def _get_nested_ui_simple(target):
     ----------
     target : instance of SimpleEditor
     """
-    if target._dialog_ui is None:
-        target._button.click()
     return target._dialog_ui
 
 

--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -8,12 +8,12 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.tester import command, locator
 from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
 from traitsui.qt4.instance_editor import (
     CustomEditor,
     SimpleEditor
 )
+
 
 def _get_netsed_ui_simple(target):
     if target._dialog_ui is None:

--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -8,6 +8,9 @@
 #
 #  Thanks for using Enthought open source!
 #
+
+from traitsui.testing.tester import command
+from traitsui.testing.tester.qt4.helpers import mouse_click_qwidget
 from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
 from traitsui.qt4.instance_editor import (
     CustomEditor,
@@ -47,5 +50,12 @@ def register(registry):
     registry : TargetRegistry
         The registry being registered to.
     """
+    registry.register_handler(
+        target_class=SimpleEditor,
+        interaction_class=command.MouseClick,
+        handler=lambda wrapper, _: (
+            mouse_click_qwidget(wrapper.target._button, delay=wrapper.delay)
+        )
+    )
     register_nested_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
     register_nested_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)

--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -15,7 +15,7 @@ from traitsui.qt4.instance_editor import (
 )
 
 
-def _get_netsed_ui_simple(target):
+def _get_nested_ui_simple(target):
     """ Obtains a nested UI within a Simple Instance Editor.
 
     Parameters
@@ -27,7 +27,7 @@ def _get_netsed_ui_simple(target):
     return target._dialog_ui
 
 
-def _get_netsed_ui_custom(target):
+def _get_nested_ui_custom(target):
     """ Obtains a nested UI within a Custom Instance Editor.
 
     Parameters
@@ -47,5 +47,5 @@ def register(registry):
     registry : TargetRegistry
         The registry being registered to.
     """
-    register_nested_ui_solvers(registry, SimpleEditor, _get_netsed_ui_simple)
-    register_nested_ui_solvers(registry, CustomEditor, _get_netsed_ui_custom)
+    register_nested_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
+    register_nested_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)

--- a/traitsui/testing/tester/wx/default_registry.py
+++ b/traitsui/testing/tester/wx/default_registry.py
@@ -14,6 +14,7 @@ from traitsui.testing.tester.wx import common_ui_targets
 from traitsui.testing.tester.wx.implementation import (
     button_editor,
     check_list_editor,
+    instance_editor,
     list_editor,
     range_editor,
     text_editor,
@@ -47,5 +48,8 @@ def get_default_registry():
 
     # RangeEditor
     range_editor.register(registry)
+
+    # InstanceEditor
+    instance_editor.register(registry)
 
     return registry

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -1,0 +1,38 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.qt4.instance_editor import (
+    CustomEditor,
+    SimpleEditor
+)
+
+
+def _get_netsed_ui_simple(target):
+    return target.edit_instance(None)
+
+
+def _get_netsed_ui_custom(target):
+    return target._ui
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    register_nested_ui_solvers(registry, SimpleEditor, _get_netsed_ui_simple)
+    register_nested_ui_solvers(registry, CustomEditor, _get_netsed_ui_custom)

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -15,7 +15,7 @@ from traitsui.wx.instance_editor import (
 )
 
 
-def _get_netsed_ui_simple(target):
+def _get_nested_ui_simple(target):
     """ Obtains a nested UI within a Simple Instance Editor.
 
     Parameters
@@ -25,7 +25,7 @@ def _get_netsed_ui_simple(target):
     return target.edit_instance(None)
 
 
-def _get_netsed_ui_custom(target):
+def _get_nested_ui_custom(target):
     """ Obtains a nested UI within a Custom Instance Editor.
 
     Parameters
@@ -45,5 +45,5 @@ def register(registry):
     registry : TargetRegistry
         The registry being registered to.
     """
-    register_nested_ui_solvers(registry, SimpleEditor, _get_netsed_ui_simple)
-    register_nested_ui_solvers(registry, CustomEditor, _get_netsed_ui_custom)
+    register_nested_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
+    register_nested_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -8,7 +8,10 @@
 #
 #  Thanks for using Enthought open source!
 #
+
+from traitsui.testing.tester import command
 from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.testing.tester.wx.helpers import mouse_click_button
 from traitsui.wx.instance_editor import (
     CustomEditor,
     SimpleEditor
@@ -22,7 +25,7 @@ def _get_nested_ui_simple(target):
     ----------
     target : instance of SimpleEditor
     """
-    return target.edit_instance(None)
+    return target._dialog_ui
 
 
 def _get_nested_ui_custom(target):
@@ -45,5 +48,12 @@ def register(registry):
     registry : TargetRegistry
         The registry being registered to.
     """
+    registry.register_handler(
+        target_class=SimpleEditor,
+        interaction_class=command.MouseClick,
+        handler=lambda wrapper, _: mouse_click_button(
+            wrapper.target._button, delay=wrapper.delay,
+        )
+    )
     register_nested_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
     register_nested_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -8,7 +8,6 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.tester import command, locator
 from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
 from traitsui.wx.instance_editor import (
     CustomEditor,

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -10,7 +10,7 @@
 #
 from traitsui.testing.tester import command, locator
 from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
-from traitsui.qt4.instance_editor import (
+from traitsui.wx.instance_editor import (
     CustomEditor,
     SimpleEditor
 )

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -16,10 +16,22 @@ from traitsui.wx.instance_editor import (
 
 
 def _get_netsed_ui_simple(target):
+    """ Obtains a nested UI within a Simple Instance Editor.
+
+    Parameters
+    ----------
+    target : instance of SimpleEditor
+    """
     return target.edit_instance(None)
 
 
 def _get_netsed_ui_custom(target):
+    """ Obtains a nested UI within a Custom Instance Editor.
+
+    Parameters
+    ----------
+    target : instance of CustomEditor
+    """
     return target._ui
 
 

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,16 +1,14 @@
 import unittest
 
 from traits.api import HasTraits, Instance, Str
-from traitsui.api import InstanceEditor
 from traitsui.item import Item
 from traitsui.view import View
 from traitsui.tests._tools import (
-    press_ok_button,
     requires_toolkit,
     ToolkitName,
 )
 
-from traitsui.testing.tester import command, locator, query
+from traitsui.testing.tester import command, query
 from traitsui.testing.tester.ui_tester import UITester
 
 

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -34,15 +34,10 @@ class TestInstanceEditor(unittest.TestCase):
         with tester.create_ui(obj) as ui:
             instance = tester.find_by_name(ui, "inst")
             editor = instance.locate(locator.NestedUI())
+            # the below code requires ui_base implementation to work
+            #ok_button = editor.find_by_id("OK")
+            #ok_button.perform(command.MouseClick())
             press_ok_button(editor.target)
-        """with reraise_exceptions(), create_ui(obj) as ui:
-            editor = ui.get_editors("inst")[0]
-
-            # make the dialog appear
-            editor._button.click()
-
-            # close the ui dialog
-            press_ok_button(editor._dialog_ui)"""
 
     @requires_toolkit([ToolkitName.qt])
     def test_simple_editor_parent_closed(self):

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 
 from traits.api import HasTraits, Instance, Str
 from traitsui.item import Item
@@ -22,28 +23,60 @@ class EditedInstance(HasTraits):
 
 class NonmodalInstanceEditor(HasTraits):
     inst = Instance(EditedInstance, ())
-    traits_view = View(Item("inst", style="simple"), buttons=["OK"])
 
 
+def get_view(style):
+    return View(Item("inst", style=style), buttons=["OK"])
+
+
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestInstanceEditor(unittest.TestCase):
 
-    @requires_toolkit([ToolkitName.qt])
-    def test_simple_editor(self):
+
+    def check_editor_update_value(self, style):
         obj = NonmodalInstanceEditor()
-        tester=UITester()
-        with tester.create_ui(obj) as ui:
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=get_view(style))) as ui:
             instance = tester.find_by_name(ui, "inst")
             editor = instance.locate(locator.NestedUI())
+            value_txt = editor.find_by_name("value")
+            value_txt.perform(command.KeySequence("abc"))
             # the below code requires ui_base implementation to work
             #ok_button = editor.find_by_id("OK")
             #ok_button.perform(command.MouseClick())
-            press_ok_button(editor.target)
+            if style == 'simple':
+                press_ok_button(editor.target)
+            self.assertEqual(obj.inst.value, "abc")
+    
+    def test_simple_editor(self):
+        return self.check_editor_update_value('simple')
 
-    @requires_toolkit([ToolkitName.qt])
+    def test_custom_editor(self):
+        return self.check_editor_update_value('custom')
+
+    def check_resynch_editor(self, style):
+        edited_inst = EditedInstance(value='hello')
+        obj = NonmodalInstanceEditor(inst=edited_inst)
+        tester= UITester()
+        with tester.create_ui(obj, dict(view=get_view(style))) as ui: 
+            instance = tester.find_by_name(ui, "inst")
+            editor = instance.locate(locator.NestedUI())
+            value_txt = editor.find_by_name("value")
+            displayed = value_txt.inspect(query.DisplayedText())
+            self.assertEqual(displayed, "hello")
+            edited_inst.value = "bye"
+            displayed = value_txt.inspect(query.DisplayedText())
+            self.assertEqual(displayed, "bye")
+
+    def test_custom_editor_resynch_editor(self):
+        return self.check_resynch_editor('custom')
+
+    def test_simple_editor_resynch_editor(self):
+        return self.check_resynch_editor('simple')
+
     def test_simple_editor_parent_closed(self):
         obj = NonmodalInstanceEditor()
-        with reraise_exceptions(), create_ui(obj) as ui:
-            editor = ui.get_editors("inst")[0]
-
-            # make the dialog appear
-            editor._button.click()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=get_view('simple'))) as ui:
+            instance = tester.find_by_name(ui, "inst")
+            instance.locate(locator.NestedUI())

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,14 +1,11 @@
 import unittest
-import time
 
 from traits.api import HasTraits, Instance, Str
 from traitsui.item import Item
 from traitsui.view import View
 from traitsui.tests._tools import (
-    create_ui,
     press_ok_button,
     requires_toolkit,
-    reraise_exceptions,
     ToolkitName,
 )
 
@@ -32,7 +29,6 @@ def get_view(style):
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestInstanceEditor(unittest.TestCase):
 
-
     def check_editor_update_value(self, style):
         obj = NonmodalInstanceEditor()
         tester = UITester()
@@ -41,13 +37,13 @@ class TestInstanceEditor(unittest.TestCase):
             editor = instance.locate(locator.NestedUI())
             value_txt = editor.find_by_name("value")
             value_txt.perform(command.KeySequence("abc"))
-            # the below code requires ui_base implementation to work
-            #ok_button = editor.find_by_id("OK")
-            #ok_button.perform(command.MouseClick())
             if style == 'simple':
+                # the below code requires ui_base implementation to work
+                # ok_button = editor.find_by_id("OK")
+                # ok_button.perform(command.MouseClick())
                 press_ok_button(editor.target)
             self.assertEqual(obj.inst.value, "abc")
-    
+
     def test_simple_editor(self):
         return self.check_editor_update_value('simple')
 
@@ -57,8 +53,8 @@ class TestInstanceEditor(unittest.TestCase):
     def check_resynch_editor(self, style):
         edited_inst = EditedInstance(value='hello')
         obj = NonmodalInstanceEditor(inst=edited_inst)
-        tester= UITester()
-        with tester.create_ui(obj, dict(view=get_view(style))) as ui: 
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=get_view(style))) as ui:
             instance = tester.find_by_name(ui, "inst")
             editor = instance.locate(locator.NestedUI())
             value_txt = editor.find_by_name("value")

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,6 +1,7 @@
 import unittest
 
 from traits.api import HasTraits, Instance, Str
+from traitsui.api import InstanceEditor
 from traitsui.item import Item
 from traitsui.view import View
 from traitsui.tests._tools import (
@@ -29,50 +30,54 @@ def get_view(style):
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestInstanceEditor(unittest.TestCase):
 
-    def check_editor_update_value(self, style):
+    def test_simple_editor(self):
         obj = NonmodalInstanceEditor()
         tester = UITester()
-        with tester.create_ui(obj, dict(view=get_view(style))) as ui:
+        with tester.create_ui(obj, dict(view=get_view("simple"))) as ui:
             instance = tester.find_by_name(ui, "inst")
-            editor = instance.locate(locator.NestedUI())
-            value_txt = editor.find_by_name("value")
+            instance.perform(command.MouseClick())
+            value_txt = instance.find_by_name("value")
             value_txt.perform(command.KeySequence("abc"))
-            if style == 'simple':
-                # the below code requires ui_base implementation to work
-                # ok_button = editor.find_by_id("OK")
-                # ok_button.perform(command.MouseClick())
-                press_ok_button(editor.target)
             self.assertEqual(obj.inst.value, "abc")
 
-    def test_simple_editor(self):
-        return self.check_editor_update_value('simple')
-
     def test_custom_editor(self):
-        return self.check_editor_update_value('custom')
+        obj = NonmodalInstanceEditor()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=get_view("custom"))) as ui:
+            value_txt = tester.find_by_name(ui, "inst").find_by_name("value")
+            value_txt.perform(command.KeySequence("abc"))
+            self.assertEqual(obj.inst.value, "abc")
 
-    def check_resynch_editor(self, style):
+    def test_custom_editor_resynch_editor(self):
         edited_inst = EditedInstance(value='hello')
         obj = NonmodalInstanceEditor(inst=edited_inst)
         tester = UITester()
-        with tester.create_ui(obj, dict(view=get_view(style))) as ui:
-            instance = tester.find_by_name(ui, "inst")
-            editor = instance.locate(locator.NestedUI())
-            value_txt = editor.find_by_name("value")
+        with tester.create_ui(obj, dict(view=get_view("custom"))) as ui:
+            value_txt = tester.find_by_name(ui, "inst").find_by_name("value")
             displayed = value_txt.inspect(query.DisplayedText())
             self.assertEqual(displayed, "hello")
             edited_inst.value = "bye"
             displayed = value_txt.inspect(query.DisplayedText())
             self.assertEqual(displayed, "bye")
 
-    def test_custom_editor_resynch_editor(self):
-        return self.check_resynch_editor('custom')
-
     def test_simple_editor_resynch_editor(self):
-        return self.check_resynch_editor('simple')
+        edited_inst = EditedInstance(value='hello')
+        obj = NonmodalInstanceEditor(inst=edited_inst)
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=get_view("simple"))) as ui:
+            instance = tester.find_by_name(ui, "inst")
+            instance.perform(command.MouseClick())
+
+            value_txt = instance.find_by_name("value")
+            displayed = value_txt.inspect(query.DisplayedText())
+            self.assertEqual(displayed, "hello")
+            edited_inst.value = "bye"
+            displayed = value_txt.inspect(query.DisplayedText())
+            self.assertEqual(displayed, "bye")
 
     def test_simple_editor_parent_closed(self):
         obj = NonmodalInstanceEditor()
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view('simple'))) as ui:
             instance = tester.find_by_name(ui, "inst")
-            instance.locate(locator.NestedUI())
+            instance.perform(command.MouseClick())

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -11,6 +11,9 @@ from traitsui.tests._tools import (
     ToolkitName,
 )
 
+from traitsui.testing.tester import command, locator, query
+from traitsui.testing.tester.ui_tester import UITester
+
 
 class EditedInstance(HasTraits):
     value = Str()
@@ -27,14 +30,19 @@ class TestInstanceEditor(unittest.TestCase):
     @requires_toolkit([ToolkitName.qt])
     def test_simple_editor(self):
         obj = NonmodalInstanceEditor()
-        with reraise_exceptions(), create_ui(obj) as ui:
+        tester=UITester()
+        with tester.create_ui(obj) as ui:
+            instance = tester.find_by_name(ui, "inst")
+            editor = instance.locate(locator.NestedUI())
+            press_ok_button(editor.target)
+        """with reraise_exceptions(), create_ui(obj) as ui:
             editor = ui.get_editors("inst")[0]
 
             # make the dialog appear
             editor._button.click()
 
             # close the ui dialog
-            press_ok_button(editor._dialog_ui)
+            press_ok_button(editor._dialog_ui)"""
 
     @requires_toolkit([ToolkitName.qt])
     def test_simple_editor_parent_closed(self):

--- a/traitsui/wx/instance_editor.py
+++ b/traitsui/wx/instance_editor.py
@@ -527,6 +527,7 @@ class SimpleEditor(CustomEditor):
             # have its own:
             if ui.history is None:
                 ui.history = self.ui.history
+        return ui
 
     def resynch_editor(self):
         """ Resynchronizes the contents of the editor when the object trait

--- a/traitsui/wx/instance_editor.py
+++ b/traitsui/wx/instance_editor.py
@@ -23,7 +23,7 @@ toolkit.
 import wx
 
 from pyface.wx.drag_and_drop import PythonDropTarget
-from traits.api import HasTraits, Property
+from traits.api import HasTraits, Instance, Property
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
 # compatibility. The class has been moved to the
@@ -488,6 +488,9 @@ class SimpleEditor(CustomEditor):
     orientation = wx.HORIZONTAL
     extra = 2
 
+    #: The ui instance for the currently open editor dialog
+    _dialog_ui = Instance("traitsui.ui.UI")
+
     def create_editor(self, parent, sizer):
         """ Creates the editor control (a button).
         """
@@ -501,6 +504,10 @@ class SimpleEditor(CustomEditor):
         button = self._button
         if button is not None:
             button.Bind(wx.EVT_BUTTON, None, id=button.GetId())
+
+        if self._dialog_ui is not None:
+            self._dialog_ui.dispose()
+            self._dialog_ui = None
 
         super(SimpleEditor, self).dispose()
 
@@ -527,7 +534,7 @@ class SimpleEditor(CustomEditor):
             # have its own:
             if ui.history is None:
                 ui.history = self.ui.history
-        return ui
+        self._dialog_ui = ui
 
     def resynch_editor(self):
         """ Resynchronizes the contents of the editor when the object trait


### PR DESCRIPTION
fixes #1206 
Adds a simple implementation for Instance editor, and modifies tests to now use UI Tester.  Also adds an additional test to see that the displayed editor updates if a trait changes externally to the editor.  

Note: the code for the wx instance editor had to be changed very slightly in order to gain access to the ui of interest.  This idea was take from kit's draft branch #1150 