### PR TITLE
TST: Update a test on Radio enum editor to use UITester

### DIFF
--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -316,18 +316,13 @@ class TestSimpleEnumEditor(unittest.TestCase):
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestRadioEnumEditor(unittest.TestCase):
 
-    @contextlib.contextmanager
-    def setup_gui(self, model, view):
-        with create_ui(model, dict(view=view)) as ui:
-            process_cascade_events()
-            editor = ui.get_editors("value")[0]
-            yield editor
-
     def test_radio_enum_editor_update(self):
         enum_edit = EnumModel()
         tester = UITester()
 
         with tester.create_ui(enum_edit, dict(view=get_view("custom"))) as ui:
+            # sanity check
+            self.assertEqual(enum_edit.value, "one")
             radio_editor = tester.find_by_name(ui, "value")
             self.assertEqual(
                 radio_editor.inspect(query.SelectedText()),
@@ -335,6 +330,7 @@ class TestRadioEnumEditor(unittest.TestCase):
             )
 
             enum_edit.value = "two"
+
             self.assertEqual(
                 radio_editor.inspect(query.SelectedText()),
                 "Two",
@@ -356,20 +352,6 @@ class TestRadioEnumEditor(unittest.TestCase):
                     item = radio_editor.locate(locator.Index(3))
                     item.perform(command.MouseClick())
                     self.assertEqual(enum_edit.value, "four")
-
-    def test_radio_enum_displayed_selected_text(self):
-        enum_edit = EnumModel()
-        tester = UITester()
-        with tester.create_ui(enum_edit, dict(view=get_radio_view())) as ui:
-            # sanity check
-            self.assertEqual(enum_edit.value, "one")
-            radio_editor = tester.find_by_name(ui, "value")
-            displayed = radio_editor.inspect(query.SelectedText())
-            # Radio Editor capitalizes
-            self.assertEqual(displayed, "One")
-            radio_editor.locate(locator.Index(3)).perform(command.MouseClick())
-            displayed = radio_editor.inspect(query.SelectedText())
-            self.assertEqual(displayed, "Four")
 
     # it appears that on windows the behavior is different - it forces
     # enum_edit.value to be 'one'

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -6,7 +6,6 @@ from traits.api import Enum, HasTraits, Int, List
 from traitsui.api import EnumEditor, UItem, View
 from traitsui.tests._tools import (
     create_ui,
-    get_all_button_status,
     is_qt,
     is_wx,
     process_cascade_events,
@@ -324,24 +323,21 @@ class TestRadioEnumEditor(unittest.TestCase):
             editor = ui.get_editors("value")[0]
             yield editor
 
-    def test_radio_enum_editor_button_update(self):
+    def test_radio_enum_editor_update(self):
         enum_edit = EnumModel()
+        tester = UITester()
 
-        with reraise_exceptions(), \
-                self.setup_gui(enum_edit, get_view("custom")) as editor:
-
-            # The layout is: one, three, four \n two
+        with tester.create_ui(enum_edit, dict(view=get_view("custom"))) as ui:
+            radio_editor = tester.find_by_name(ui, "value")
             self.assertEqual(
-                get_all_button_status(editor.control),
-                [True, False, False, False]
+                radio_editor.inspect(query.SelectedText()),
+                "One",
             )
 
             enum_edit.value = "two"
-            process_cascade_events()
-
             self.assertEqual(
-                get_all_button_status(editor.control),
-                [False, False, False, True]
+                radio_editor.inspect(query.SelectedText()),
+                "Two",
             )
 
     def test_radio_enum_editor_pick(self):


### PR DESCRIPTION
One of the existing tests (`test_radio_enum_editor_button_update`) for the radio enum editor checks the UI states are updated when the trait state is updated.
The test was added prior to the introduction of UITester.

The implementation of the test does this by getting all the states of the radio buttons, but since radio buttons are "auto-exclusive" for one-of-many selections, the implementation for querying for the selected item achieves the same goal.

This PR:
- Update the test to use UITester features. This demonstrates one of the two patterns of UI testing: Updating the trait results in UI state change.
- Remove `test_radio_enum_displayed_selected_text` because its purpose is for exercising the logic of `SelectedText`. The test updated here now uses `SelectedText` so `test_radio_enum_displayed_selected_text` is redundant.

Note: The other, unchanged `test_radio_enum_editor_pick` demonstrates the second pattern of UI testing - Updating the UI state via user interaction updates the trait.
Note: The auto-exclusive behaviour is not coded in traitsui, it is a feature provided by Qt and Wx Radio button widgets. But if in doubt, we can always update the tester implementation to do some sanity check there - but we will be testing Qt / Wx rather than testing traitsui.