### PR TITLE
Maint: Reorganize optional dependencies in etstool.py and setup.py

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -98,16 +98,10 @@ DEFAULT_TOOLKIT = 'null'
 # The requirement is to be interpreted by EDM
 TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
 
+# Required runtime dependencies. Should match install_requires in setup.py
 dependencies = {
-    "numpy",
     "traits" + TRAITS_VERSION_REQUIRES,
-    "pandas",
-    "pygments",
-    "pip",
-    "nose",
-    "coverage",
-    "configobj",
-    "docutils",
+    # pyface is installed from source via ci-src-requirements.txt
 }
 
 # NOTE : pyface is always installed from source
@@ -115,29 +109,51 @@ source_dependencies = {
     "traits": "git+http://github.com/enthought/traits.git#egg=traits",
 }
 
-# Additional toolkit-independent dependencies for demo testing
-# This should correspond to the "examples" dependencies in extras_requires but
-# the following names are used by EDM.
-test_dependencies = {
-    "apptools",
-    "chaco",
-    "h5py",
-    "numpy",
-    "pandas",
-    "pytables",
-}
-
+# The following should match extras_require in setup.py but with package
+# names compatible with EDM
 extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
-    'pyside2': set(),
-    'pyqt': {'pyqt<4.12'},  # FIXME: build 1 of 4.12.1 appears to be bad
-    'pyqt5': {'pyqt5'},
+    'pyside2': {
+        'pygments',
+    },
+    'pyqt': {
+        'pyqt<4.12',  # FIXME: build 1 of 4.12.1 appears to be bad
+        'pygments',
+    },
+    'pyqt5': {
+        'pyqt5',
+        'pygments',
+    },
     # XXX once wxPython 4 is available in EDM, we will want it here
-    'wx': set(),
-    'null': set()
+    'wx': {
+        'numpy',
+    },
+    'null': set(),
+    # Toolkit-independent dependencies for demo testing.
+    # This should correspond to "examples" option in extras_require
+    'examples': {
+        'apptools',
+        'chaco',
+        'h5py',
+        'numpy',
+        'pandas',
+        'pytables',
+    },
+    # Optional dependencies for some editors
+    'editors': {
+        'numpy',
+        'pandas',
+    },
+    # Test dependencies also applied to installation from PYPI
+    'test': {
+        'packaging',
+    }
 }
 
-runtime_dependencies = {}
+# Dependencies for CI jobs using this file.
+ci_dependencies = {
+    "coverage",
+}
 
 doc_dependencies = {
     "sphinx",
@@ -177,11 +193,13 @@ def install(runtime, toolkit, environment, editable, source):
 
     """
     parameters = get_parameters(runtime, toolkit, environment)
-    packages = ' '.join(
+    packages = (
         dependencies
         | extra_dependencies.get(toolkit, set())
-        | runtime_dependencies.get(runtime, set())
-        | test_dependencies
+        | extra_dependencies["test"]
+        | extra_dependencies["examples"]
+        | extra_dependencies["editors"]
+        | ci_dependencies
     )
 
     install_traitsui = "edm run -e {environment} -- pip install "
@@ -196,7 +214,7 @@ def install(runtime, toolkit, environment, editable, source):
         commands = ["edm environments create {environment} --force --version={runtime}"]
 
     commands.extend([
-        "edm install -y -e {environment} " + packages,
+        "edm install -y -e {environment} " + " ".join(packages),
         "edm run -e {environment} -- pip install --force-reinstall -r ci-src-requirements.txt --no-dependencies",
         "edm run -e {environment} -- python setup.py clean --all",
         install_traitsui,

--- a/etstool.py
+++ b/etstool.py
@@ -130,7 +130,6 @@ extra_dependencies = {
     },
     'null': set(),
     # Toolkit-independent dependencies for demo testing.
-    # This should correspond to "examples" option in extras_require
     'examples': {
         'apptools',
         'chaco',

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -40,7 +40,17 @@ __extras_require__ = {
         "pandas",
         "tables",
     ],
-    "test": ["packaging"],
+    "editors": [
+        # Optional dependencies for certain editors which may not be needed by
+        # projects. If they are absent, ``traitsui.api``` should still be
+        # importable and the relevant tests should be skipped.
+        "numpy",   # For ArrayEditor and DataFrameEditor
+        "pandas",  # For DataFrameEditor
+    ],
+    "test": [
+        # Dependencies for running test suites.
+        "packaging",
+    ],
 }
 
 


### PR DESCRIPTION
When I was trying to add flake8 to CI, I notice that the existing organization of dependencies in `etstool.py` will force me to add flake8 to the `dependencies` set. This led me to realize that the dependencies set has mixed runtime dependencies and CI dependencies.

This PR:
- Reorganize the dependencies in `etstool.py` to clarify what dependencies are used for what, with a goal of matching those used by `setup.py`
- Add an optional set of dependencies called `"editors"` to be used by `setup.py` to specify the dependencies on optional features:
      - `pandas` is required by DataFrameEditor. (Note that `DataFrameEditor` is not exposed in `api`)
      - `numpy` is required by ArrayEditor and DataFrameEditor. `traitsui.api` explicitly allows `numpy` to be absent. If numpy absent, `traitsui.api` won't include DataFrameEditor

I was tempted to go the extra mile to add a CI job to run with the minimal set of dependencies, but then I decided against it.  This PR should have no behavioural change to how CI is run.