### PR TITLE
Skip test module for DataFrameEditor if numpy is absent

### DIFF
--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -7,9 +7,13 @@
 #  is also available online at http://www.enthought.com/licenses/BSD.txt
 
 import unittest
-import numpy as np
-from numpy.testing import assert_array_equal
 
+try:
+    import numpy as np
+except ImportError:
+    raise unittest.SkipTest("Can't import NumPy: skipping")
+else:
+    from numpy.testing import assert_array_equal
 
 try:
     from pandas import DataFrame


### PR DESCRIPTION
Currently the test module for DataFrameEditor will fail with ImportError if one runs `python -m unittest discover -t . traitsui` with an environment installed from PyPI, Qt5 and without NumPy.

NumPy is an optional dependency, e.g. the `ArrayEditor` is skipped in `traitsui.api` if importing it should fail due to absence of numpy.

This PR skips the test module if NumPy cannot be imported, in the same way that the module is skipped if pandas is not available.
