### PR TITLE
UI Tester - use _BaseSourceWithLocation for Checklist and List editor implementations

### DIFF
--- a/traitsui/testing/tester/qt4/helpers.py
+++ b/traitsui/testing/tester/qt4/helpers.py
@@ -124,6 +124,8 @@ def mouse_click_tab_index(tab_widget, index, delay):
     delay : int
         Time delay (in ms) in which click will be performed.
     """
+    if not 0 <= index < tab_widget.count():
+        raise IndexError(index)
     tabbar = tab_widget.tabBar()
     rect = tabbar.tabRect(index)
     QTest.mouseClick(

--- a/traitsui/testing/tester/qt4/implementation/check_list_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/check_list_editor.py
@@ -11,6 +11,7 @@
 
 from traitsui.qt4.check_list_editor import CustomEditor
 from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.editors.layout import column_major_to_row_major
 from traitsui.testing.tester.qt4 import helpers
 
 
@@ -69,10 +70,35 @@ class _IndexedCustomCheckListEditor:
             interaction_class=command.MouseClick,
             handler=lambda wrapper, _: helpers.mouse_click_qlayout(
                 layout=wrapper.target.target.control.layout(),
-                index=wrapper.target.index,
+                index=convert_index(
+                    wrapper.target.target.control.layout(),
+                    wrapper.target.index
+                ),
                 delay=wrapper.delay,
             )
         )
+
+
+def convert_index(layout, index):
+    """ Helper function to convert an index for a QGridLayout so that the
+    index counts over the grid in the correct direction.
+    The grid is always populated in row major order, but it is done so in
+    such a way that the entries appear in column major order.
+    Qlayouts are indexed in the order they are populated, so to access
+    the correct element we may need to convert a column-major based index
+    into a row-major one.
+
+    Parameters
+    ----------
+    layout : QGridLayout
+        The layout of interest
+    index : int
+        the index of interest
+    """
+    n = layout.count()
+    num_cols = layout.columnCount()
+    num_rows = layout.rowCount()
+    return column_major_to_row_major(index, n, num_rows, num_cols)
 
 
 def register(registry):

--- a/traitsui/testing/tester/qt4/implementation/check_list_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/check_list_editor.py
@@ -11,72 +11,24 @@
 
 from traitsui.qt4.check_list_editor import CustomEditor
 from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.common_ui_targets import _BaseSourceWithLocation
 from traitsui.testing.tester.editors.layout import column_major_to_row_major
 from traitsui.testing.tester.qt4 import helpers
 
 
-class _IndexedCustomCheckListEditor:
+class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
     """ Wrapper for CheckListEditor + locator.Index """
-
-    def __init__(self, target, index):
-        """
-        Parameters
-        ----------
-        target : CustomCheckListEditor
-            The Custom Check List Editor
-        index : int
-            The index of interest.
-        """
-        self.target = target
-        self.index = index
-
-    @classmethod
-    def from_location_index(cls, wrapper, location):
-        """ Creates an instance of _IndexedCustomCheckListEditor from a
-        wrapper wrapping a Custom CheckListEditor, and a locator.Index
-        object.
-
-        Parameters
-        ----------
-        wrapper : UIWrapper
-            wrapper wrapping a Custom CheckListEditor
-        location : Instance of locator.Index
-        """
-        # Conform to the call signature specified in the register
-        return cls(
-            target=wrapper.target,
-            index=location.index,
-        )
-
-    @classmethod
-    def register(cls, registry):
-        """ Class method to register interactions on an
-        _IndexedCustomCheckListEditor for the given registry.
-
-        If there are any conflicts, an error will occur.
-
-        Parameters
-        ----------
-        registry : TargetRegistry
-            The registry being registered to.
-        """
-        registry.register_solver(
-            target_class=CustomEditor,
-            locator_class=locator.Index,
-            solver=cls.from_location_index,
-        )
-        registry.register_handler(
-            target_class=cls,
-            interaction_class=command.MouseClick,
-            handler=lambda wrapper, _: helpers.mouse_click_qlayout(
-                layout=wrapper.target.target.control.layout(),
-                index=convert_index(
-                    wrapper.target.target.control.layout(),
-                    wrapper.target.index
-                ),
-                delay=wrapper.delay,
-            )
-        )
+    source_class = CustomEditor
+    locator_class = locator.Index
+    handlers = [
+        (command.MouseClick, (lambda wrapper, _: helpers.mouse_click_qlayout(
+            layout=wrapper.target.source.control.layout(),
+            index=convert_index(
+                layout=wrapper.target.source.control.layout(),
+                index=wrapper.target.location.index,
+            ),
+            delay=wrapper.delay))),
+    ]
 
 
 def convert_index(layout, index):

--- a/traitsui/testing/tester/wx/implementation/check_list_editor.py
+++ b/traitsui/testing/tester/wx/implementation/check_list_editor.py
@@ -8,9 +8,11 @@
 #
 #  Thanks for using Enthought open source!
 #
+import wx
 
 from traitsui.wx.check_list_editor import CustomEditor
 from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.editors.layout import column_major_to_row_major
 from traitsui.testing.tester.wx import helpers
 
 
@@ -70,9 +72,39 @@ class _IndexedCustomCheckListEditor:
             handler=lambda wrapper, _:
                 (helpers.mouse_click_checkbox_child_in_panel(
                     control=wrapper.target.target.control,
-                    index=wrapper.target.index,
+                    index=convert_index(
+                        wrapper.target.target,
+                        wrapper.target.index,
+                    ),
                     delay=wrapper.delay))
         )
+
+
+def convert_index(source, index):
+    """ Helper function to convert an index for a GridSizer so that the
+    index counts over the grid in the correct direction.
+    The grid is always populated in row major order, however, the elements
+    are assigned to each entry in the grid so that when displayed they appear
+    in column major order.
+    Sizers are indexed in the order they are populated, so to access
+    the correct element we may need to convert a column-major based index
+    into a row-major one.
+
+    Parameters
+    ----------
+    control : CustomEditor
+        The Custom CheckList Editor of interest. Its control is the wx.Panel
+        containing child objects organized with a wx.GridSizer
+    index : int
+        the index of interest
+    """
+    sizer = source.control.GetSizer()
+    if isinstance(sizer, wx.BoxSizer):
+        return index
+    n = len(source.names)
+    num_cols = sizer.GetCols()
+    num_rows = sizer.GetEffectiveRowsCount()
+    return column_major_to_row_major(index, n, num_rows, num_cols)
 
 
 def register(registry):

--- a/traitsui/testing/tester/wx/implementation/check_list_editor.py
+++ b/traitsui/testing/tester/wx/implementation/check_list_editor.py
@@ -12,72 +12,26 @@ import wx
 
 from traitsui.wx.check_list_editor import CustomEditor
 from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.common_ui_targets import _BaseSourceWithLocation
 from traitsui.testing.tester.editors.layout import column_major_to_row_major
 from traitsui.testing.tester.wx import helpers
 
 
-class _IndexedCustomCheckListEditor:
-    """ Wrapper for CheckListEditor + locator.Index """
-
-    def __init__(self, target, index):
-        """
-        Parameters
-        ----------
-        target : CustomCheckListEditor
-            The Custom Check List Editor
-        index : int
-            The index of interest.
-        """
-        self.target = target
-        self.index = index
-
-    @classmethod
-    def from_location_index(cls, wrapper, location):
-        """ Creates an instance of _IndexedCustomCheckListEditor from a
-        wrapper wrapping a Custom CheckListEditor, and a locator.Index
-        object.
-
-        Parameters
-        ----------
-        wrapper : UIWrapper
-            wrapper wrapping a Custom CheckListEditor
-        location : Instance of locator.Index
-        """
-        # Conform to the call signature specified in the register
-        return cls(
-            target=wrapper.target,
-            index=location.index,
-        )
-
-    @classmethod
-    def register(cls, registry):
-        """ Class method to register interactions on an
-        _IndexedCustomCheckListEditor for the given registry.
-
-        If there are any conflicts, an error will occur.
-
-        Parameters
-        ----------
-        registry : TargetRegistry
-            The registry being registered to.
-        """
-        registry.register_solver(
-            target_class=CustomEditor,
-            locator_class=locator.Index,
-            solver=cls.from_location_index,
-        )
-        registry.register_handler(
-            target_class=cls,
-            interaction_class=command.MouseClick,
-            handler=lambda wrapper, _:
-                (helpers.mouse_click_checkbox_child_in_panel(
-                    control=wrapper.target.target.control,
-                    index=convert_index(
-                        wrapper.target.target,
-                        wrapper.target.index,
-                    ),
-                    delay=wrapper.delay))
-        )
+class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
+    """ Wrapper for CheckListEditor + locator.Index
+    """
+    source_class = CustomEditor
+    locator_class = locator.Index
+    handlers = [
+        (command.MouseClick,
+            (lambda wrapper, _: helpers.mouse_click_checkbox_child_in_panel(
+                control=wrapper.target.source.control,
+                index=convert_index(
+                    source=wrapper.target.source,
+                    index=wrapper.target.location.index
+                ),
+                delay=wrapper.delay))),
+    ]
 
 
 def convert_index(source, index):

--- a/traitsui/testing/tester/wx/implementation/list_editor.py
+++ b/traitsui/testing/tester/wx/implementation/list_editor.py
@@ -9,6 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.common_ui_targets import _BaseSourceWithLocation
 from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
 from traitsui.testing.tester.wx import helpers
 from traitsui.wx.list_editor import (
@@ -17,40 +18,18 @@ from traitsui.wx.list_editor import (
 )
 
 
-class _IndexedNotebookEditor:
+class _IndexedNotebookEditor(_BaseSourceWithLocation):
     """ Wrapper for a ListEditor (Notebook) with an index.
     """
-
-    def __init__(self, target, index):
-        """
-        Parameters
-        ----------
-        target : NotebookEditor
-            The Notebook List Editor
-        index : int
-            The index of interest.
-        """
-        self.target = target
-        self.index = index
-
-    @classmethod
-    def from_location(cls, wrapper, location):
-        """ Helper method to create an instance of _IndexedNotebookEditor
-        but checking if the index is valid before doing so.
-
-        Parameters
-        ----------
-        wrapper : UIWrapper
-            the UIWrapper wrapping the Notebook List Editor
-        location : locator.Index
-            the locator.Index object containing the index
-        """
-        # Raise IndexError early
-        wrapper.target._uis[location.index]
-        return cls(
-            target=wrapper.target,
-            index=location.index,
-        )
+    source_class = NotebookEditor
+    locator_class = locator.Index
+    handlers = [
+        (command.MouseClick, (lambda wrapper, _:
+            helpers.mouse_click_notebook_tab_index(
+                control=wrapper.target.source.control,
+                index=wrapper.target.location.index,
+                delay=wrapper.delay))),
+    ]
 
     @classmethod
     def register(cls, registry):
@@ -64,49 +43,25 @@ class _IndexedNotebookEditor:
         registry : TargetRegistry
             The registry being registered to.
         """
-        registry.register_solver(
-            target_class=NotebookEditor,
-            locator_class=locator.Index,
-            solver=cls.from_location,
-        )
-
+        super().register(registry)
         register_nested_ui_solvers(
             registry=registry,
             target_class=cls,
             nested_ui_getter=lambda target: target._get_nested_ui()
         )
 
-        registry.register_handler(
-            target_class=cls,
-            interaction_class=command.MouseClick,
-            handler=lambda wrapper, _: helpers.mouse_click_notebook_tab_index(
-                control=wrapper.target.target.control,
-                index=wrapper.target.index,
-                delay=wrapper.delay),
-        )
-
     def _get_nested_ui(self):
         """ Method to get the nested ui corresponding to the List element at
         the given index.
         """
-        return self.target._uis[self.index][0].dockable.ui
+        return self.source._uis[self.location.index][0].dockable.ui
 
 
-class _IndexedCustomEditor:
+class _IndexedCustomEditor(_BaseSourceWithLocation):
     """ Wrapper for a ListEditor (custom) with an index.
     """
-
-    def __init__(self, target, index):
-        """
-        Parameters
-        ----------
-        target : CustomEditor
-            The Custom List Editor
-        index : int
-            The index of interest.
-        """
-        self.target = target
-        self.index = index
+    source_class = CustomEditor
+    locator_class = locator.Index
 
     @classmethod
     def register(cls, registry):
@@ -120,12 +75,7 @@ class _IndexedCustomEditor:
         registry : TargetRegistry
             The registry being registered to.
         """
-        registry.register_solver(
-            target_class=CustomEditor,
-            locator_class=locator.Index,
-            solver=lambda wrapper, location:
-                cls(target=wrapper.target, index=location.index)
-        )
+        super().register(registry)
         register_nested_ui_solvers(
             registry=registry,
             target_class=cls,
@@ -141,8 +91,8 @@ class _IndexedCustomEditor:
         # item itself.  Thus, index is actually an index over the odd elements
         # of the list of children corresponding to items in the list we would
         # want to interact with
-        new_index = 2*self.index + 1
-        WindowList = self.target.control.GetChildren()
+        new_index = 2*self.location.index + 1
+        WindowList = self.source.control.GetChildren()
         item = WindowList[new_index]
         return item._editor._ui
 

--- a/traitsui/tests/editors/test_check_list_editor.py
+++ b/traitsui/tests/editors/test_check_list_editor.py
@@ -479,7 +479,7 @@ class TestCustomCheckListEditor(unittest.TestCase):
             self.assertEqual(str_edit.value, "three,one")
 
     def test_custom_check_list_editor_grid_layout(self):
-        for cols in range(1,8):
+        for cols in range(1, 8):
             list_edit = ListModel()
             tester = UITester()
             view = get_view_custom_cols(cols=cols)

--- a/traitsui/tests/editors/test_check_list_editor.py
+++ b/traitsui/tests/editors/test_check_list_editor.py
@@ -481,7 +481,7 @@ class TestCustomCheckListEditor(unittest.TestCase):
     def test_custom_check_list_editor_grid_layout(self):
         for cols in range(1,8):
             list_edit = ListModel()
-            tester = UITester(delay=1000)
+            tester = UITester()
             view = get_view_custom_cols(cols=cols)
             with tester.create_ui(list_edit, dict(view=view)) as ui:
                 self.assertEqual(list_edit.value, [])

--- a/traitsui/tests/editors/test_check_list_editor.py
+++ b/traitsui/tests/editors/test_check_list_editor.py
@@ -35,6 +35,20 @@ def get_view(style):
     )
 
 
+def get_view_custom_cols(cols):
+    return View(
+        UItem(
+            "value",
+            editor=CheckListEditor(
+                values=["one", "two", "three", "four", "five", "six", "seven"],
+                cols=cols,
+            ),
+            style="custom",
+        ),
+        resizable=True
+    )
+
+
 def get_mapped_view(style):
     return View(
         UItem(
@@ -463,6 +477,20 @@ class TestCustomCheckListEditor(unittest.TestCase):
             item_1.perform(command.MouseClick())
 
             self.assertEqual(str_edit.value, "three,one")
+
+    def test_custom_check_list_editor_grid_layout(self):
+        for cols in range(1,8):
+            list_edit = ListModel()
+            tester = UITester(delay=1000)
+            view = get_view_custom_cols(cols=cols)
+            with tester.create_ui(list_edit, dict(view=view)) as ui:
+                self.assertEqual(list_edit.value, [])
+                check_list = tester.find_by_name(ui, "value")
+                item = check_list.locate(locator.Index(6))
+                item.perform(command.MouseClick())
+                self.assertEqual(list_edit.value, ["seven"])
+                item.perform(command.MouseClick())
+                self.assertEqual(list_edit.value, [])
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])


### PR DESCRIPTION
fixes #1197 
I believe that `register_editable_textbox_handlers` is actually already currently used where it should be.  Thus, this PR simply changes the checklist and List editor implementations to utilize the new `_BaseSourceWithLocation` base class added in #1191 

Note this was originally sitting on top of PR #1215 (hence the couple extra commits in the commit history).  That is now merged though, so the files changed are correct.