### PR TITLE
Update docstrings for UITester and UIWrapper

### DIFF
--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -125,21 +125,27 @@ class UITester:
 
     See documentation on ``TargetRegistry`` for details.
 
-    Attributes
+    Parameters
     ----------
     registries : list of TargetRegistry, optional
-        Registries of interaction for different target, in the order
-        of decreasing priority. A shallow copy will be made.
+        Registries of interaction for different targets, in the order
+        of decreasing priority. If provided, a shallow copy will be made.
+        Default registries are always appended to the list to provide
+        builtin support for TraitsUI UI and editors.
     delay : int, optional
         Time delay (in ms) in which actions by the tester are performed. Note
-        it is propogated through to created child wrappers. The delay allows
+        it is propagated through to created child wrappers. The delay allows
+        visual confirmation test code is working as desired. Defaults to 0.
+
+    Attributes
+    ----------
+    delay : int
+        Time delay (in ms) in which actions by the tester are performed. Note
+        it is propagated through to created child wrappers. The delay allows
         visual confirmation test code is working as desired. Defaults to 0.
     """
 
     def __init__(self, registries=None, delay=0):
-        """ Instantiate the UI tester.
-        """
-
         if registries is None:
             self._registries = []
         else:

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -142,7 +142,7 @@ class UITester:
     delay : int
         Time delay (in ms) in which actions by the tester are performed. Note
         it is propagated through to created child wrappers. The delay allows
-        visual confirmation test code is working as desired. Defaults to 0.
+        visual confirmation test code is working as desired.
     """
 
     def __init__(self, registries=None, delay=0):

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -63,7 +63,7 @@ class UIWrapper:
     delay : int
         Time delay (in ms) in which actions by the wrapper are performed. Note
         it is propagated through to created child wrappers. The delay allows
-        visual confirmation test code is working as desired. Defaults to 0.
+        visual confirmation test code is working as desired.
     """
 
     def __init__(self, target, registries, delay=0):

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -42,29 +42,31 @@ class UIWrapper:
     For simulating user interactions such as a mouse click or visual
     inspection, the ``perform`` and ``inspect`` methods are provided.
 
+    Parameters
+    ----------
+    target : any
+        An object on which further UI target can be searched for, or can be
+        a leaf target that can be operated on.
+    registries : list of TargetRegistry
+        Registries of interaction for different target, in the order
+        of decreasing priority.
+    delay : int, optional
+        Time delay (in ms) in which actions by the wrapper are performed. Note
+        it is propagated through to created child wrappers. The delay allows
+        visual confirmation test code is working as desired. Defaults to 0.
+
     Attributes
     ----------
     target : any
         An object on which further UI target can be searched for, or can be
         a leaf target that can be operated on.
-    delay : int, optional
+    delay : int
         Time delay (in ms) in which actions by the wrapper are performed. Note
-        it is propogated through to created child wrappers. The delay allows
+        it is propagated through to created child wrappers. The delay allows
         visual confirmation test code is working as desired. Defaults to 0.
     """
 
     def __init__(self, target, registries, delay=0):
-        """ Initializer
-
-        Parameters
-        ----------
-        target : any
-            An object on which further UI target can be searched for, or can be
-            a leaf target that can be operated on.
-        registries : list of TargetRegistry
-            Registries of interaction for different target, in the order
-            of decreasing priority.
-        """
         self.target = target
         self._registries = registries
         self.delay = delay


### PR DESCRIPTION
This PR moves the docstrings for parameters in the `UITester` and `UIWrapper`'s  `__init__` to the class docstring.
This follows NumPy docstring guide. The clarifies parameters for initialization and attributes accessible post-instantiation.