### PR TITLE
UI Tester wx mouseclick refactor

### DIFF
--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -45,7 +45,7 @@ def mouse_click(func):
 
     Parameters
     ----------
-    func : callable
+    func : callable(*, control, delay, **kwargs)
         The mouse click function to be decorated.
 
     Returns

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -16,24 +16,62 @@ from traitsui.testing.tester.exceptions import Disabled
 
 
 def _create_event(event_type, control):
-    click_event = wx.CommandEvent(
+    """ Creates a wxEvent of a given type 
+
+    Parameters
+    ----------
+    event_type : wxEventType
+        The type of the event to be created 
+    control :
+        The wx control the event is occurring on. 
+
+    Returns
+    -------
+    wxEvent
+        The created event, of the given type, with the given control set as
+        the event object.
+    """
+    event = wx.CommandEvent(
         event_type, control.GetId()
     )
-    click_event.SetEventObject(control)
-    return click_event
+    event.SetEventObject(control)
+    return event
 
 
 def mouse_click(func):
-    def mouse_click_handler(control, delay, *args, **kwargs):
+    """ Decorator function for mouse clicks. Decorated functions will return
+    if they are not enabled. Additionally, this handles the delay for the
+    click.
+
+    Parameters
+    ----------
+    func : callable
+        The mouse click function to be decorated.
+
+    Returns
+    -------
+    callable
+        The decorated function.
+    """
+    def mouse_click_handler(*, control, delay, **kwargs):
+        """ Defines the decorated function.
+
+        Paramters
+        ---------
+        control : wxControl
+            The wx Object to be clicked.
+        delay : int 
+            Time delay (in ms) in which click will be performed.
+        """
         if not control.IsEnabled():
             return
         wx.MilliSleep(delay)
-        func(control, *args, **kwargs)
+        func(control=control, delay=delay, **kwargs)
     return mouse_click_handler
 
 
 @mouse_click
-def mouse_click_button(control):
+def mouse_click_button(control, delay):
     """ Performs a mouce click on a wx button.
 
     Parameters
@@ -48,7 +86,7 @@ def mouse_click_button(control):
 
 
 @mouse_click
-def mouse_click_checkbox(control):
+def mouse_click_checkbox(control, delay):
     """ Performs a mouce click on a wx check box.
 
     Parameters
@@ -64,7 +102,7 @@ def mouse_click_checkbox(control):
 
 
 @mouse_click
-def mouse_click_combobox_or_choice(control, index):
+def mouse_click_combobox_or_choice(control, index, delay):
     """ Performs a mouce click on either a wx combo box or a wx choice on the
     entry at the given index.
 
@@ -88,7 +126,7 @@ def mouse_click_combobox_or_choice(control, index):
     control.ProcessWindowEvent(click_event)
 
 @mouse_click
-def mouse_click_listbox(control, index):
+def mouse_click_listbox(control, index, delay):
     """Performs a mouce click on a wx list box on the entry at
     the given index.
 
@@ -107,7 +145,7 @@ def mouse_click_listbox(control, index):
 
 
 @mouse_click
-def mouse_click_radiobutton(control):
+def mouse_click_radiobutton(control, delay):
     """ Performs a mouce click on a wx radio button.
 
     Parameters
@@ -123,7 +161,7 @@ def mouse_click_radiobutton(control):
 
 
 @mouse_click
-def mouse_click_object(control):
+def mouse_click_object(control, delay):
     """ Performs a mouce click on a wxTextCtrl.
 
     Parameters
@@ -139,10 +177,7 @@ def mouse_click_object(control):
     control.ProcessWindowEvent(click_event)
 
 
-###############################################################################
-
-
-def mouse_click_notebook_tab_index(control, index, delay=0):
+def mouse_click_notebook_tab_index(control, index, delay):
     """ Performs a mouseclick on a Noteboook List Editor on the tab specified
     by index.
 
@@ -191,7 +226,7 @@ def mouse_click_checkbox_child_in_panel(control, index, delay):
     if not 0 <= index <= len(children_list) - 1:
         raise IndexError(index)
     obj = children_list[index].GetWindow()
-    mouse_click_checkbox(obj, delay)
+    mouse_click_checkbox(control=obj, delay=delay)
 
 
 def mouse_click_radiobutton_child_in_panel(control, index, delay):
@@ -210,7 +245,7 @@ def mouse_click_radiobutton_child_in_panel(control, index, delay):
     if not 0 <= index <= len(children_list) - 1:
         raise IndexError(index)
     obj = children_list[index].GetWindow()
-    mouse_click_radiobutton(obj, delay)
+    mouse_click_radiobutton(control=obj, delay=delay)
 
 
 def key_click_text_entry(

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -15,7 +15,25 @@ from traitsui.testing.tester.compat import check_key_compat
 from traitsui.testing.tester.exceptions import Disabled
 
 
-def mouse_click_button(control, delay):
+def _create_event(event_type, control):
+    click_event = wx.CommandEvent(
+        event_type, control.GetId()
+    )
+    click_event.SetEventObject(control)
+    return click_event
+
+
+def mouse_click(func):
+    def mouse_click_handler(control, delay, *args, **kwargs):
+        if not control.IsEnabled():
+            return
+        wx.MilliSleep(delay)
+        func(control, *args, **kwargs)
+    return mouse_click_handler
+
+
+@mouse_click
+def mouse_click_button(control):
     """ Performs a mouce click on a wx button.
 
     Parameters
@@ -25,16 +43,12 @@ def mouse_click_button(control, delay):
     delay: int
         Time delay (in ms) in which click will be performed.
     """
-    if not control.IsEnabled():
-        return
-    wx.MilliSleep(delay)
-    click_event = wx.CommandEvent(
-        wx.wxEVT_COMMAND_BUTTON_CLICKED, control.GetId()
-    )
-    control.ProcessEvent(click_event)
+    click_event = _create_event(wx.wxEVT_COMMAND_BUTTON_CLICKED, control)
+    control.ProcessWindowEvent(click_event)
 
 
-def mouse_click_checkbox(control, delay):
+@mouse_click
+def mouse_click_checkbox(control):
     """ Performs a mouce click on a wx check box.
 
     Parameters
@@ -44,18 +58,13 @@ def mouse_click_checkbox(control, delay):
     delay: int
         Time delay (in ms) in which click will be performed.
     """
-    if not control.IsEnabled():
-        return
-    wx.MilliSleep(delay)
-    click_event = wx.CommandEvent(
-        wx.wxEVT_COMMAND_CHECKBOX_CLICKED, control.GetId()
-    )
-    click_event.SetEventObject(control)
+    click_event = _create_event(wx.wxEVT_COMMAND_CHECKBOX_CLICKED, control)
     control.SetValue(not control.GetValue())
     control.ProcessWindowEvent(click_event)
 
 
-def mouse_click_combobox_or_choice(control, index, delay):
+@mouse_click
+def mouse_click_combobox_or_choice(control, index):
     """ Performs a mouce click on either a wx combo box or a wx choice on the
     entry at the given index.
 
@@ -68,26 +77,18 @@ def mouse_click_combobox_or_choice(control, index, delay):
     delay: int
         Time delay (in ms) in which click will be performed.
     """
-    if not control.IsEnabled():
-        return
-    wx.MilliSleep(delay)
     if isinstance(control, wx.ComboBox):
-        click_event = wx.CommandEvent(
-            wx.wxEVT_COMMAND_COMBOBOX_SELECTED, control.GetId()
-        )
+        click_event = _create_event(wx.wxEVT_COMMAND_COMBOBOX_SELECTED, control)
     elif isinstance(control, wx.Choice):
-        click_event = wx.CommandEvent(
-            wx.wxEVT_COMMAND_CHOICE_SELECTED, control.GetId()
-        )
+        click_event = _create_event(wx.wxEVT_COMMAND_CHOICE_SELECTED, control)
     else:
         raise TypeError("Only supported controls are wxComboBox or wxChoice")
-    click_event.SetEventObject(control)
     click_event.SetString(control.GetString(index))
     control.SetSelection(index)
     control.ProcessWindowEvent(click_event)
 
-
-def mouse_click_listbox(control, index, delay):
+@mouse_click
+def mouse_click_listbox(control, index):
     """Performs a mouce click on a wx list box on the entry at
     the given index.
 
@@ -100,18 +101,13 @@ def mouse_click_listbox(control, index, delay):
     delay: int
         Time delay (in ms) in which click will be performed.
     """
-    if not control.IsEnabled():
-        return
-    wx.MilliSleep(delay)
-    click_event = wx.CommandEvent(
-        wx.wxEVT_COMMAND_LISTBOX_SELECTED, control.GetId()
-    )
-    click_event.SetEventObject(control)
+    click_event = _create_event(wx.wxEVT_COMMAND_LISTBOX_SELECTED, control)
     control.SetSelection(index)
     control.ProcessWindowEvent(click_event)
 
 
-def mouse_click_radiobutton(control, delay):
+@mouse_click
+def mouse_click_radiobutton(control):
     """ Performs a mouce click on a wx radio button.
 
     Parameters
@@ -121,18 +117,13 @@ def mouse_click_radiobutton(control, delay):
     delay: int
         Time delay (in ms) in which click will be performed.
     """
-    if not control.IsEnabled():
-        return
-    wx.MilliSleep(delay)
-    click_event = wx.CommandEvent(
-        wx.wxEVT_COMMAND_RADIOBUTTON_SELECTED, control.GetId()
-    )
-    click_event.SetEventObject(control)
+    click_event = _create_event(wx.wxEVT_COMMAND_RADIOBUTTON_SELECTED, control)
     control.SetValue(not control.GetValue())
     control.ProcessWindowEvent(click_event)
 
 
-def mouse_click_object(control, delay):
+@mouse_click
+def mouse_click_object(control):
     """ Performs a mouce click on a wxTextCtrl.
 
     Parameters
@@ -142,15 +133,13 @@ def mouse_click_object(control, delay):
     delay: int
         Time delay (in ms) in which click will be performed.
     """
-    if not control.IsEnabled():
-        return
     if not control.HasFocus():
         control.SetFocus()
-    wx.MilliSleep(delay)
-    click_event = wx.CommandEvent(
-        wx.wxEVT_COMMAND_LEFT_CLICK, control.GetId()
-    )
-    control.ProcessEvent(click_event)
+    click_event = _create_event(wx.wxEVT_COMMAND_LEFT_CLICK, control)
+    control.ProcessWindowEvent(click_event)
+
+
+###############################################################################
 
 
 def mouse_click_notebook_tab_index(control, index, delay=0):

--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -16,14 +16,14 @@ from traitsui.testing.tester.exceptions import Disabled
 
 
 def _create_event(event_type, control):
-    """ Creates a wxEvent of a given type 
+    """ Creates a wxEvent of a given type
 
     Parameters
     ----------
     event_type : wxEventType
-        The type of the event to be created 
+        The type of the event to be created
     control :
-        The wx control the event is occurring on. 
+        The wx control the event is occurring on.
 
     Returns
     -------
@@ -60,7 +60,7 @@ def mouse_click(func):
         ---------
         control : wxControl
             The wx Object to be clicked.
-        delay : int 
+        delay : int
             Time delay (in ms) in which click will be performed.
         """
         if not control.IsEnabled():
@@ -116,7 +116,9 @@ def mouse_click_combobox_or_choice(control, index, delay):
         Time delay (in ms) in which click will be performed.
     """
     if isinstance(control, wx.ComboBox):
-        click_event = _create_event(wx.wxEVT_COMMAND_COMBOBOX_SELECTED, control)
+        click_event = _create_event(
+            wx.wxEVT_COMMAND_COMBOBOX_SELECTED, control
+        )
     elif isinstance(control, wx.Choice):
         click_event = _create_event(wx.wxEVT_COMMAND_CHOICE_SELECTED, control)
     else:
@@ -124,6 +126,7 @@ def mouse_click_combobox_or_choice(control, index, delay):
     click_event.SetString(control.GetString(index))
     control.SetSelection(index)
     control.ProcessWindowEvent(click_event)
+
 
 @mouse_click
 def mouse_click_listbox(control, index, delay):

--- a/traitsui/testing/tester/wx/implementation/button_editor.py
+++ b/traitsui/testing/tester/wx/implementation/button_editor.py
@@ -59,7 +59,7 @@ def register(registry):
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=(lambda wrapper, _: helpers.mouse_click_button(
-                 wrapper.target.control, wrapper.delay))
+                 control=wrapper.target.control, delay=wrapper.delay))
     )
 
     registry.register_handler(

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -52,7 +52,7 @@ def register(registry):
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=lambda wrapper, _: mouse_click_button(
-            wrapper.target._button, delay=wrapper.delay,
+            control=wrapper.target._button, delay=wrapper.delay,
         )
     )
     register_nested_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)

--- a/traitsui/testing/tester/wx/implementation/ui_base.py
+++ b/traitsui/testing/tester/wx/implementation/ui_base.py
@@ -28,7 +28,7 @@ def register(registry):
         target_class=ButtonEditor,
         interaction_class=command.MouseClick,
         handler=(lambda wrapper, _: helpers.mouse_click_button(
-                 wrapper.target.control, wrapper.delay))
+                 control=wrapper.target.control, delay=wrapper.delay))
     )
 
     registry.register_handler(

--- a/traitsui/testing/tester/wx/registry_helper.py
+++ b/traitsui/testing/tester/wx/registry_helper.py
@@ -39,7 +39,7 @@ def register_editable_textbox_handlers(registry, target_class, widget_getter):
                 widget_getter(wrapper), interaction, wrapper.delay))),
         (command.MouseClick,
             (lambda wrapper, _: helpers.mouse_click_object(
-                widget_getter(wrapper), wrapper.delay))),
+                control=widget_getter(wrapper), delay=wrapper.delay))),
         (query.DisplayedText,
             lambda wrapper, _: widget_getter(wrapper).GetValue()),
     ]

--- a/traitsui/testing/tester/wx/tests/test_helpers.py
+++ b/traitsui/testing/tester/wx/tests/test_helpers.py
@@ -46,7 +46,7 @@ class TestInteractions(unittest.TestCase):
         button.Bind(wx.EVT_BUTTON, handler)
 
         # when
-        helpers.mouse_click_button(button, 0)
+        helpers.mouse_click_button(control=button, delay=0)
 
         # then
         self.assertEqual(handler.call_count, 1)
@@ -58,7 +58,7 @@ class TestInteractions(unittest.TestCase):
         button.Enable(False)
 
         # when
-        helpers.mouse_click_button(button, 0)
+        helpers.mouse_click_button(control=button, delay=0)
 
         # then
         self.assertEqual(handler.call_count, 0)


### PR DESCRIPTION
Fixes #1194 

Introduces new `_create_event` helper function, and `mouse_click` decorator.  
Also, note that the decorator enforces arguments to mouse click functions to be key word and not positional arguments.  When calling these mouse click functions we typically already passed arguments with a keyword, but in a few cases we had passed them by position.  Those have been replaced in this PR.