### PR TITLE
Adding 'End' as a possible value for Key click text entry on wx

### DIFF
--- a/traitsui/testing/tester/wx/helpers.py
+++ b/traitsui/testing/tester/wx/helpers.py
@@ -282,6 +282,9 @@ def key_click_text_entry(
         wx.MilliSleep(delay)
         event = wx.CommandEvent(wx.EVT_TEXT_ENTER.typeId, control.GetId())
         control.ProcessEvent(event)
+    elif interaction.key == "End":
+        wx.MilliSleep(delay)
+        control.SetInsertionPointEnd()
     elif interaction.key == "Backspace":
         wx.MilliSleep(delay)
         start, end = get_selection(control)

--- a/traitsui/testing/tester/wx/tests/test_helpers.py
+++ b/traitsui/testing/tester/wx/tests/test_helpers.py
@@ -155,6 +155,19 @@ class TestInteractions(unittest.TestCase):
         self.assertEqual(textbox.Value, "E")
         self.assertEqual(handler.call_count, 1)
 
+    def test_key_click_end(self):
+        textbox = wx.TextCtrl(self.frame)
+        textbox.SetValue("ABCDE")
+        textbox.SetInsertionPoint(0)
+
+        # sanity check
+        self.assertEqual(textbox.GetInsertionPoint(), 0)
+
+        helpers.key_click_text_entry(textbox, command.KeyClick("End"), 0)
+        helpers.key_click_text_entry(textbox, command.KeyClick("F"), 0)
+
+        self.assertEqual(textbox.Value, "ABCDEF")
+
     def test_key_click_disabled(self):
         textbox = wx.TextCtrl(self.frame)
         textbox.SetEditable(False)


### PR DESCRIPTION
fixes #1228 
simply moves the text entry's insertion point to the end if a key click is called with "End".
Also a simple test for this is added to this PR.