### PR TITLE
Reraise exception captured when the UI is disposed from create_ui

### DIFF
--- a/traitsui/testing/tester/tests/test_ui_tester.py
+++ b/traitsui/testing/tester/tests/test_ui_tester.py
@@ -11,6 +11,7 @@
 
 import unittest
 
+from pyface.api import GUI
 from traits.api import (
     Button, Instance, HasTraits, Str,
 )
@@ -56,6 +57,23 @@ class TestUITesterCreateUI(unittest.TestCase):
         with tester.create_ui(order, dict(view=view)) as ui:
             pass
         self.assertTrue(ui.destroyed)
+
+    def test_create_ui_reraise_exception(self):
+        tester = UITester()
+        order = Order()
+        view = View(Item("submit_button"))
+
+        with self.assertRaises(RuntimeError), \
+                self.assertLogs("traitsui", level="ERROR"):
+
+            with tester.create_ui(order, dict(view=view)) as ui:
+
+                def raise_error():
+                    raise ZeroDivisionError()
+
+                GUI().invoke_later(raise_error)
+
+        self.assertIsNone(ui.control)
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -232,13 +232,14 @@ def create_ui(object, ui_kwargs=None):
         # At the end of a test, there may be events to be processed.
         # If dispose happens first, those events will be processed after
         # various editor states are removed, causing errors.
-        process_cascade_events()
-        try:
-            ui.dispose()
-        finally:
-            # dispose is not atomic and may push more events to the event
-            # queue. Flush those too.
+        with reraise_exceptions():
             process_cascade_events()
+            try:
+                ui.dispose()
+            finally:
+                # dispose is not atomic and may push more events to the event
+                # queue. Flush those too.
+                process_cascade_events()
 
 
 # ######### Utility tools to test on both qt4 and wx

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -229,10 +229,10 @@ def create_ui(object, ui_kwargs=None):
     try:
         yield ui
     finally:
-        # At the end of a test, there may be events to be processed.
-        # If dispose happens first, those events will be processed after
-        # various editor states are removed, causing errors.
         with reraise_exceptions():
+            # At the end of a test, there may be events to be processed.
+            # If dispose happens first, those events will be processed after
+            # various editor states are removed, causing errors.
             process_cascade_events()
             try:
                 ui.dispose()


### PR DESCRIPTION
The observation in https://github.com/enthought/traitsui/pull/1161#discussion_r476589718 led me to this: `create_ui` context manager should capture and reraise exceptions occurred from the GUI event loop while disposing a UI.

However this does not resolve the strangeness observed in https://github.com/enthought/traitsui/pull/1161#discussion_r476589718
The event that causes the error (which was fixed by #1161) was processed much much later.