### PR TITLE
Fix test for text-style RangeEditor on wx and Windows

### DIFF
--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -126,7 +126,7 @@ class TestRangeEditor(unittest.TestCase):
                 # For RangeTextEditor on wx and windows, the textbox
                 # automatically gets focus and the full content is selected.
                 # Insertion point is moved to keep the test consistent
-                number_field_text.target.textbox.SetInsertionPointEnd()
+                number_field_text.perform(command.KeyClick("End"))
             number_field_text.perform(command.KeyClick("0"))
             number_field_text.perform(command.KeyClick("Enter"))
             displayed = number_field_text.inspect(query.DisplayedText())


### PR DESCRIPTION
This PR fixes the following test failure on Windows + wx (CI allowed to fail, hence hard to spot)

```
ERROR: test_range_text_editor_set_with_text_valid (traitsui.tests.editors.test_range_editor.TestRangeEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\appveyor\.edm\envs\traitsui-test-3.6-wx\lib\site-packages\traitsui\tests\editors\test_range_editor.py", line 129, in test_range_text_editor_set_with_text_valid
    number_field_text.target.textbox.SetInsertionPointEnd()
AttributeError: 'RangeTextEditor' object has no attribute 'textbox'
```

This was caused by changes to implementation details (note the original code is wx specific). With #1229 support, we can change insertion point in test code without relying on implementation details.

(I consider accessing anything on `target` to be an attempt to rely on implementation details owned by traitsui. So if this breakage happens on a downstream project, that is totally understandable.)