### PR TITLE
Rename register_nested_ui_solvers to register_traitsui_ui_solvers

### DIFF
--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -11,7 +11,9 @@
 
 from traitsui.testing.tester import command
 from traitsui.testing.tester.qt4.helpers import mouse_click_qwidget
-from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.testing.tester.registry_helper import (
+    register_traitsui_ui_solvers,
+)
 from traitsui.qt4.instance_editor import (
     CustomEditor,
     SimpleEditor
@@ -55,5 +57,5 @@ def register(registry):
             mouse_click_qwidget(wrapper.target._button, delay=wrapper.delay)
         )
     )
-    register_nested_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
-    register_nested_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)
+    register_traitsui_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
+    register_traitsui_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)

--- a/traitsui/testing/tester/qt4/implementation/list_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/list_editor.py
@@ -10,7 +10,9 @@
 #
 from traitsui.testing.tester import command, locator
 from traitsui.testing.tester.common_ui_targets import _BaseSourceWithLocation
-from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.testing.tester.registry_helper import (
+    register_traitsui_ui_solvers,
+)
 from traitsui.testing.tester.qt4 import helpers
 from traitsui.qt4.list_editor import (
     CustomEditor,
@@ -44,10 +46,10 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
             The registry being registered to.
         """
         super().register(registry)
-        register_nested_ui_solvers(
+        register_traitsui_ui_solvers(
             registry=registry,
             target_class=cls,
-            nested_ui_getter=lambda target: target._get_nested_ui()
+            traitsui_ui_getter=lambda target: target._get_nested_ui()
         )
 
     def _get_nested_ui(self):
@@ -76,10 +78,10 @@ class _IndexedCustomEditor(_BaseSourceWithLocation):
             The registry being registered to.
         """
         super().register(registry)
-        register_nested_ui_solvers(
+        register_traitsui_ui_solvers(
             registry=registry,
             target_class=cls,
-            nested_ui_getter=lambda target: target._get_nested_ui()
+            traitsui_ui_getter=lambda target: target._get_nested_ui()
         )
 
     def _get_nested_ui(self):

--- a/traitsui/testing/tester/registry_helper.py
+++ b/traitsui/testing/tester/registry_helper.py
@@ -69,14 +69,14 @@ def _get_editor_by_id(ui, id):
     return editor
 
 
-def register_nested_ui_solvers(registry, target_class, nested_ui_getter):
+def register_traitsui_ui_solvers(registry, target_class, traitsui_ui_getter):
     """ Function to register solvers for obtaining nested targets inside a
-    nested traitsui.ui.UI inside a (parent) target.
+    traitsui.ui.UI inside a (parent) target.
 
     For example, an instance of TreeEditor may contain a nested
     ``traitsui.ui.UI`` instance. In that case, the ``target_class`` will the
-    TreeEditor and the ``nested_ui_getter`` specifies how to obtain the nested
-    ``traitsui.ui.UI`` UI from it.
+    TreeEditor and the ``traitsui_ui_getter`` specifies how to obtain the
+    nested ``traitsui.ui.UI`` UI from it.
 
     Parameters
     ----------
@@ -85,7 +85,7 @@ def register_nested_ui_solvers(registry, target_class, nested_ui_getter):
     target_class : subclass of type
         The type of a UI target being used as the target_class for the
         solvers
-    nested_ui_getter : callable(target: target_class) -> traitsui.ui.UI
+    traitsui_ui_getter : callable(target: target_class) -> traitsui.ui.UI
         A callable specific to the particular target_class to obtain a nested
         UI.
     """
@@ -95,7 +95,7 @@ def register_nested_ui_solvers(registry, target_class, nested_ui_getter):
         locator_class=locator.TargetByName,
         solver=lambda wrapper, location: (
             _get_editor_by_name(
-                ui=nested_ui_getter(wrapper.target),
+                ui=traitsui_ui_getter(wrapper.target),
                 name=location.name,
             )
         ),
@@ -105,7 +105,7 @@ def register_nested_ui_solvers(registry, target_class, nested_ui_getter):
         locator_class=locator.TargetById,
         solver=lambda wrapper, location: (
             _get_editor_by_id(
-                ui=nested_ui_getter(wrapper.target),
+                ui=traitsui_ui_getter(wrapper.target),
                 id=location.id,
             )
         ),

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -12,7 +12,9 @@
 from traitsui.ui import UI
 from traitsui.testing.tester.default_registry import get_default_registry
 from traitsui.testing.tester.registry import TargetRegistry
-from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.testing.tester.registry_helper import (
+    register_traitsui_ui_solvers,
+)
 from traitsui.testing.tester.ui_wrapper import UIWrapper
 from traitsui.tests._tools import (
     create_ui as _create_ui,
@@ -226,9 +228,9 @@ def _get_ui_registry():
     """
 
     registry = TargetRegistry()
-    register_nested_ui_solvers(
+    register_traitsui_ui_solvers(
         registry=registry,
         target_class=UI,
-        nested_ui_getter=lambda target: target,
+        traitsui_ui_getter=lambda target: target,
     )
     return registry

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -10,7 +10,9 @@
 #
 
 from traitsui.testing.tester import command
-from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.testing.tester.registry_helper import (
+    register_traitsui_ui_solvers,
+)
 from traitsui.testing.tester.wx.helpers import mouse_click_button
 from traitsui.wx.instance_editor import (
     CustomEditor,
@@ -55,5 +57,5 @@ def register(registry):
             control=wrapper.target._button, delay=wrapper.delay,
         )
     )
-    register_nested_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
-    register_nested_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)
+    register_traitsui_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
+    register_traitsui_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)

--- a/traitsui/testing/tester/wx/implementation/list_editor.py
+++ b/traitsui/testing/tester/wx/implementation/list_editor.py
@@ -10,7 +10,9 @@
 #
 from traitsui.testing.tester import command, locator
 from traitsui.testing.tester.common_ui_targets import _BaseSourceWithLocation
-from traitsui.testing.tester.registry_helper import register_nested_ui_solvers
+from traitsui.testing.tester.registry_helper import (
+    register_traitsui_ui_solvers,
+)
 from traitsui.testing.tester.wx import helpers
 from traitsui.wx.list_editor import (
     CustomEditor,
@@ -44,10 +46,10 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
             The registry being registered to.
         """
         super().register(registry)
-        register_nested_ui_solvers(
+        register_traitsui_ui_solvers(
             registry=registry,
             target_class=cls,
-            nested_ui_getter=lambda target: target._get_nested_ui()
+            traitsui_ui_getter=lambda target: target._get_nested_ui()
         )
 
     def _get_nested_ui(self):
@@ -76,10 +78,10 @@ class _IndexedCustomEditor(_BaseSourceWithLocation):
             The registry being registered to.
         """
         super().register(registry)
-        register_nested_ui_solvers(
+        register_traitsui_ui_solvers(
             registry=registry,
             target_class=cls,
-            nested_ui_getter=lambda target: target._get_nested_ui()
+            traitsui_ui_getter=lambda target: target._get_nested_ui()
         )
 
     def _get_nested_ui(self):


### PR DESCRIPTION
Follow this https://github.com/enthought/traitsui/pull/1227#discussion_r490837104

This PR renames `register_nested_ui_solvers` to `register_traitsui_ui_solvers`
The function does not care if the `traitsui.ui.UI` instance is nested or not. The name is slightly long, but verbosity for understanding trumps ~conciseness~.

Note: Could not use the name `register_ui_solvers` here because the function is only about `traitsui.ui.UI`. The word "UI" is too broad and is used in many other context.