### PR TITLE
Reverse dependency so that traitsui.tests._tools depend on traitsui.testing

### DIFF
--- a/traitsui/testing/exception_handling.py
+++ b/traitsui/testing/exception_handling.py
@@ -1,0 +1,88 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+from contextlib import contextmanager
+import logging
+import sys
+import traceback
+
+from traits.api import (
+    pop_exception_handler,
+    push_exception_handler,
+)
+
+_TRAITSUI_LOGGER = logging.getLogger("traitsui")
+
+
+def _serialize_exception(exc_type, value, tb):
+    """ Serialize exception and traceback for reporting.
+    This is such that the stack frame is not prevented from being garbage
+    collected.
+    """
+    return (
+        str(exc_type),
+        str(value),
+        str("".join(traceback.format_exception(exc_type, value, tb)))
+    )
+
+
+@contextmanager
+def reraise_exceptions(logger=_TRAITSUI_LOGGER):
+    """ Context manager to capture all exceptions occurred in the context and
+    then reraise a RuntimeError if there are any exceptions captured.
+
+    Exceptions from traits change notifications are also captured and reraised.
+
+    Depending on the GUI toolkit backend, unexpected exceptions occurred in the
+    GUI event loop may (1) cause fatal early exit of the test suite or (2) be
+    printed to the console without causing the test to error. This context
+    manager is intended for testing purpose such that unexpected exceptions
+    will result in a test error.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        Logger to use for logging errors.
+    """
+    serialized_exceptions = []
+
+    def excepthook(type, value, tb):
+        serialized = _serialize_exception(type, value, tb)
+        serialized_exceptions.append(serialized)
+        logger.error(
+            "Unexpected error captured in sys excepthook. \n%s",
+            serialized[-1]
+        )
+
+    def handler(object, name, old, new):
+        type, value, tb = sys.exc_info()
+        serialized_exceptions.append(_serialize_exception(type, value, tb))
+        logger.exception(
+            "Unexpected error occurred from change handler "
+            "(object: %r, name: %r, old: %r, new: %r).",
+            object, name, old, new,
+        )
+
+    push_exception_handler(handler=handler)
+    sys.excepthook = excepthook
+    try:
+        yield
+    finally:
+        sys.excepthook = sys.__excepthook__
+        pop_exception_handler()
+        if serialized_exceptions:
+            msg = "Uncaught exceptions found.\n"
+            msg += "\n".join(
+                "=== Exception (type: {}, value: {}) ===\n"
+                "{}".format(*record)
+                for record in serialized_exceptions
+            )
+            raise RuntimeError(msg)

--- a/traitsui/testing/gui.py
+++ b/traitsui/testing/gui.py
@@ -1,0 +1,40 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+""" Module containing GUI event processing utility for testing purposes.
+"""
+
+from traits.etsconfig.api import ETSConfig
+
+
+def process_cascade_events():
+    """ Process all posted events, and attempt to process new events posted by
+    the processed events.
+
+    Cautions:
+    - An infinite cascade of events will cause this function to enter an
+      infinite loop.
+    - There still exists technical difficulties with Qt. On Qt4 + OSX,
+      QEventLoop.processEvents may report false saying it had found no events
+      to process even though it actually had processed some.
+      Consequently the internal loop breaks too early such that there are
+      still cascaded events unprocessed. Problems are also observed on
+      Qt5 + Appveyor occasionally. At the very least, events that are already
+      posted prior to calling this function will be processed.
+      See enthought/traitsui#951
+    """
+    if ETSConfig.toolkit.startswith("qt"):
+        from pyface.qt import QtCore
+        event_loop = QtCore.QEventLoop()
+        while event_loop.processEvents(QtCore.QEventLoop.AllEvents):
+            pass
+    else:
+        from pyface.api import GUI
+        GUI.process_events()

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -11,14 +11,14 @@
 import contextlib
 
 from traitsui.ui import UI
+from traitsui.testing.gui import process_cascade_events
+from traitsui.testing.exception_handling import reraise_exceptions
 from traitsui.testing.tester.default_registry import get_default_registry
 from traitsui.testing.tester.registry import TargetRegistry
 from traitsui.testing.tester.registry_helper import (
     register_traitsui_ui_solvers,
 )
 from traitsui.testing.tester.ui_wrapper import UIWrapper
-from traitsui.testing.gui import process_cascade_events
-from traitsui.testing.exception_handling import reraise_exceptions
 
 
 class UITester:

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -16,8 +16,10 @@ from traitsui.testing.tester.exceptions import (
     LocationNotSupported,
 )
 from traitsui.testing.tester import locator
-from traitsui.tests._tools import (
+from traitsui.testing.gui import (
     process_cascade_events as _process_cascade_events,
+)
+from traitsui.testing.exception_handling import (
     reraise_exceptions as _reraise_exceptions,
 )
 

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -11,16 +11,16 @@
 
 from contextlib import contextmanager
 
-from traitsui.testing.tester.exceptions import (
-    InteractionNotSupported,
-    LocationNotSupported,
+from traitsui.testing.exception_handling import (
+    reraise_exceptions as _reraise_exceptions,
 )
-from traitsui.testing.tester import locator
 from traitsui.testing.gui import (
     process_cascade_events as _process_cascade_events,
 )
-from traitsui.testing.exception_handling import (
-    reraise_exceptions as _reraise_exceptions,
+from traitsui.testing.tester import locator
+from traitsui.testing.tester.exceptions import (
+    InteractionNotSupported,
+    LocationNotSupported,
 )
 
 

--- a/traitsui/testing/tests/test_exception_handling.py
+++ b/traitsui/testing/tests/test_exception_handling.py
@@ -1,0 +1,74 @@
+#  Copyright (c) 2008-20, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+""" Tests for traitsui.testing.exception_handling """
+
+import unittest
+
+from pyface.api import GUI
+
+from traits.api import HasTraits, Int
+from traitsui.tests._tools import (
+    requires_toolkit,
+    ToolkitName,
+)
+from traitsui.testing.exception_handling import reraise_exceptions
+
+
+class TestExceptionHandling(unittest.TestCase):
+
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
+    def test_error_from_gui_captured_and_raise(self):
+
+        def raise_error_1():
+            raise ZeroDivisionError()
+
+        def raise_error_2():
+            raise IndexError()
+
+        # without the context manager:
+        #   - with Qt5, the test run will be aborted prematurely.
+        #   - with Qt4, the traceback is printed and the test passes.
+        #   - with Wx, the traceback is printed and the test passes.
+        # With the context manager, the exception is always reraised.
+        gui = GUI()
+        with self.assertRaises(RuntimeError) as exception_context, \
+                self.assertLogs("traitsui") as watcher:
+            with reraise_exceptions():
+                gui.invoke_later(raise_error_1)
+                gui.invoke_later(raise_error_2)
+                gui.process_events()
+
+        error_msg = str(exception_context.exception)
+        self.assertIn("ZeroDivisionError", error_msg)
+        self.assertIn("IndexError", error_msg)
+        log_content1, log_content2 = watcher.output
+        self.assertIn("ZeroDivisionError", log_content1)
+        self.assertIn("IndexError", log_content2)
+
+    def test_error_from_trait_change_captured(self):
+
+        class Foo(HasTraits):
+            value = Int()
+
+            def _value_changed(self):
+                raise ZeroDivisionError()
+
+        obj = Foo()
+        with self.assertRaises(RuntimeError) as exception_context, \
+                self.assertLogs("traitsui") as watcher:
+            with reraise_exceptions():
+                obj.value = 2
+
+        error_msg = str(exception_context.exception)
+        self.assertIn("ZeroDivisionError", error_msg)
+        log_content, = watcher.output
+        self.assertIn("ZeroDivisionError", log_content)

--- a/traitsui/testing/tests/test_gui.py
+++ b/traitsui/testing/tests/test_gui.py
@@ -9,21 +9,19 @@
 #  Thanks for using Enthought open source!
 #
 
-""" Tests for traitsui.tests._tools """
+""" Tests for traitsui.testing.gui """
 
 import os
 import unittest
 
 from pyface.api import GUI
 
-from traits.api import HasTraits, Int
 from traitsui.tests._tools import (
     is_qt,
     is_wx,
     is_mac_os,
     process_cascade_events,
     requires_toolkit,
-    reraise_exceptions,
     ToolkitName,
 )
 
@@ -180,54 +178,3 @@ class TestProcessEventsRepeated(unittest.TestCase):
 
         # then
         self.assertEqual(wx_handler.n_events, max_n_events)
-
-
-class TestExceptionHandling(unittest.TestCase):
-
-    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
-    def test_error_from_gui_captured_and_raise(self):
-
-        def raise_error_1():
-            raise ZeroDivisionError()
-
-        def raise_error_2():
-            raise IndexError()
-
-        # without the context manager:
-        #   - with Qt5, the test run will be aborted prematurely.
-        #   - with Qt4, the traceback is printed and the test passes.
-        #   - with Wx, the traceback is printed and the test passes.
-        # With the context manager, the exception is always reraised.
-        gui = GUI()
-        with self.assertRaises(RuntimeError) as exception_context, \
-                self.assertLogs("traitsui") as watcher:
-            with reraise_exceptions():
-                gui.invoke_later(raise_error_1)
-                gui.invoke_later(raise_error_2)
-                gui.process_events()
-
-        error_msg = str(exception_context.exception)
-        self.assertIn("ZeroDivisionError", error_msg)
-        self.assertIn("IndexError", error_msg)
-        log_content1, log_content2 = watcher.output
-        self.assertIn("ZeroDivisionError", log_content1)
-        self.assertIn("IndexError", log_content2)
-
-    def test_error_from_trait_change_captured(self):
-
-        class Foo(HasTraits):
-            value = Int()
-
-            def _value_changed(self):
-                raise ZeroDivisionError()
-
-        obj = Foo()
-        with self.assertRaises(RuntimeError) as exception_context, \
-                self.assertLogs("traitsui") as watcher:
-            with reraise_exceptions():
-                obj.value = 2
-
-        error_msg = str(exception_context.exception)
-        self.assertIn("ZeroDivisionError", error_msg)
-        log_content, = watcher.output
-        self.assertIn("ZeroDivisionError", log_content)

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -14,94 +14,23 @@
 # ------------------------------------------------------------------------------
 
 import enum
-import logging
 import re
 import sys
-import traceback
-from contextlib import contextmanager
 from unittest import skipIf, TestSuite
 
-from pyface.api import GUI
 from pyface.toolkit import toolkit_object
-from traits.api import (
-    pop_exception_handler,
-    push_exception_handler,
-)
 from traits.etsconfig.api import ETSConfig
+
+# These functions are imported by traitsui's own tests. They can be redirected
+# to traitsui.testing and then these aliases can be removed.
+from traitsui.testing.exception_handling import reraise_exceptions  # noqa
+from traitsui.testing.gui import process_cascade_events  # noqa: F401
+from traitsui.testing.tester.ui_tester import UITester
 
 # ######### Testing tools
 
-
-_TRAITSUI_LOGGER = logging.getLogger("traitsui")
-
-
-def _serialize_exception(exc_type, value, tb):
-    """ Serialize exception and traceback for reporting.
-    This is such that the stack frame is not prevented from being garbage
-    collected.
-    """
-    return (
-        str(exc_type),
-        str(value),
-        str("".join(traceback.format_exception(exc_type, value, tb)))
-    )
-
-
-@contextmanager
-def reraise_exceptions(logger=_TRAITSUI_LOGGER):
-    """ Context manager to capture all exceptions occurred in the context and
-    then reraise a RuntimeError if there are any exceptions captured.
-
-    Exceptions from traits change notifications are also captured and reraised.
-
-    Depending on the GUI toolkit backend, unexpected exceptions occurred in the
-    GUI event loop may (1) cause fatal early exit of the test suite or (2) be
-    printed to the console without causing the test to error. This context
-    manager is intended for testing purpose such that unexpected exceptions
-    will result in a test error.
-
-    Parameters
-    ----------
-    logger : logging.Logger
-        Logger to use for logging errors.
-    """
-    serialized_exceptions = []
-
-    def excepthook(type, value, tb):
-        serialized = _serialize_exception(type, value, tb)
-        serialized_exceptions.append(serialized)
-        logger.error(
-            "Unexpected error captured in sys excepthook. \n%s",
-            serialized[-1]
-        )
-
-    def handler(object, name, old, new):
-        type, value, tb = sys.exc_info()
-        serialized_exceptions.append(_serialize_exception(type, value, tb))
-        logger.exception(
-            "Unexpected error occurred from change handler "
-            "(object: %r, name: %r, old: %r, new: %r).",
-            object, name, old, new,
-        )
-
-    push_exception_handler(handler=handler)
-    sys.excepthook = excepthook
-    try:
-        yield
-    finally:
-        sys.excepthook = sys.__excepthook__
-        pop_exception_handler()
-        if serialized_exceptions:
-            msg = "Uncaught exceptions found.\n"
-            msg += "\n".join(
-                "=== Exception (type: {}, value: {}) ===\n"
-                "{}".format(*record)
-                for record in serialized_exceptions
-            )
-            raise RuntimeError(msg)
-
-
 # Toolkit constants
+
 
 class ToolkitName(enum.Enum):
     wx = "wx"
@@ -183,32 +112,6 @@ def filter_tests(test_suite, exclusion_pattern):
     return filtered_test_suite
 
 
-def process_cascade_events():
-    """ Process all posted events, and attempt to process new events posted by
-    the processed events.
-
-    Cautions:
-    - An infinite cascade of events will cause this function to enter an
-      infinite loop.
-    - There still exists technical difficulties with Qt. On Qt4 + OSX,
-      QEventLoop.processEvents may report false saying it had found no events
-      to process even though it actually had processed some.
-      Consequently the internal loop breaks too early such that there are
-      still cascaded events unprocessed. Problems are also observed on
-      Qt5 + Appveyor occasionally. At the very least, events that are already
-      posted prior to calling this function will be processed.
-      See enthought/traitsui#951
-    """
-    if is_qt():
-        from pyface.qt import QtCore
-        event_loop = QtCore.QEventLoop()
-        while event_loop.processEvents(QtCore.QEventLoop.AllEvents):
-            pass
-    else:
-        GUI.process_events()
-
-
-@contextmanager
 def create_ui(object, ui_kwargs=None):
     """ Context manager for creating a UI and then dispose it when exiting
     the context.
@@ -224,22 +127,7 @@ def create_ui(object, ui_kwargs=None):
     ------
     ui: UI
     """
-    ui_kwargs = {} if ui_kwargs is None else ui_kwargs
-    ui = object.edit_traits(**ui_kwargs)
-    try:
-        yield ui
-    finally:
-        with reraise_exceptions():
-            # At the end of a test, there may be events to be processed.
-            # If dispose happens first, those events will be processed after
-            # various editor states are removed, causing errors.
-            process_cascade_events()
-            try:
-                ui.dispose()
-            finally:
-                # dispose is not atomic and may push more events to the event
-                # queue. Flush those too.
-                process_cascade_events()
+    return UITester().create_ui(object=object, ui_kwargs=ui_kwargs)
 
 
 # ######### Utility tools to test on both qt4 and wx


### PR DESCRIPTION
Closes #1238

- The implementation of `traitsui.tests._tools.create_ui` is now moved to `UITester.create_ui`. The `traitsui.tests._tools.create_ui` is kept to limit the scope of this PR (otherwise I need to change a lot of test)
- `traitsui.tests._tools.process_cascade_events` is moved to `traitsui.testing.gui`. Its test is also moved. Likewise, the alias in `_tools` is kept, for now to limit scope.
- `traitsui.tests._tools.reraise_exceptions` is moved to `traitsui.testing.exception_handling`. Its test is also moved. Likewise, the alias in `_tools` is kept, for now to limit scope.
