### PR TITLE
adding UI Tester test/example for CheckListEditor_simple_demo.py

### DIFF
--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -30,7 +30,7 @@ from traitsui.tests._tools import (
     reraise_exceptions,
     ToolkitName,
 )
-from traitsui.testing.tester import command, query
+from traitsui.testing.tester import command, locator, query
 from traitsui.testing.tester.ui_tester import UITester
 
 # This test file is not distributed nor is it in a package.
@@ -346,11 +346,10 @@ class TestExample(unittest.TestCase):
                     )
                 )
 
-
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestInteractExample(unittest.TestCase):
     """ Test examples with more interactions."""
 
-    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_converter(self):
         # Test converter.py in examples/demo/Applications
         filepath = os.path.join(
@@ -373,3 +372,19 @@ class TestInteractExample(unittest.TestCase):
                 output_amount.inspect(query.DisplayedText()),
                 "1.0",
             )
+
+    def test_checklist_editor_simple_demo(self):
+        # Test CheckListEditor_simple_demo.py in examples/demo/Standard_Edtiors
+        filepath = os.path.join(
+            DEMO, "Standard_Editors", "CheckListEditor_simple_demo.py"
+        )
+        demo = load_demo(filepath, "demo")
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            checklist = tester.find_by_id(ui, "custom")
+            item3 = checklist.locate(locator.Index(2))
+            item3.perform(command.MouseClick())
+            self.assertEqual(demo.checklist, ["three"])
+            item3.perform(command.MouseClick())
+            self.assertEqual(demo.checklist, [])

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -346,6 +346,7 @@ class TestExample(unittest.TestCase):
                     )
                 )
 
+
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestInteractExample(unittest.TestCase):
     """ Test examples with more interactions."""

--- a/traitsui/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/CheckListEditor_simple_demo.py
@@ -37,11 +37,11 @@ class CheckListEditorDemo(HasTraits):
     checklist_group = Group(
         '10',  # insert vertical space (10 empty pixels)
         Label('The custom style lets you select items from a checklist:'),
-        UItem('checklist', style='custom'),
+        UItem('checklist', style='custom', id="custom"),
         '10', '_', '10',  # horizontal line with vertical space above and below
         Label('The readonly style shows you which items are selected, '
               'as a Python list:'),
-        UItem('checklist', style='readonly'),
+        UItem('checklist', style='readonly', id="readonly"),
     )
 
     traits_view = View(

--- a/traitsui/testing/tester/qt4/helpers.py
+++ b/traitsui/testing/tester/qt4/helpers.py
@@ -8,6 +8,8 @@
 #
 #  Thanks for using Enthought open source!
 #
+import time 
+
 from pyface.qt import QtCore, QtGui
 from pyface.qt.QtTest import QTest
 
@@ -105,11 +107,15 @@ def mouse_click_qwidget(control, delay):
     delay : int
         Time delay (in ms) in which click will be performed.
     """
-    QTest.mouseClick(
-        control,
-        QtCore.Qt.LeftButton,
-        delay=delay,
-    )
+    if isinstance(control, QtGui.QAbstractButton):
+        time.sleep(delay/1000)
+        control.click()
+    else:
+        QTest.mouseClick(
+            control,
+            QtCore.Qt.LeftButton,
+            delay=delay,
+        )
 
 
 def mouse_click_tab_index(tab_widget, index, delay):
@@ -150,11 +156,7 @@ def mouse_click_qlayout(layout, index, delay):
     if not 0 <= index < layout.count():
         raise IndexError(index)
     widget = layout.itemAt(index).widget()
-    QTest.mouseClick(
-        widget,
-        QtCore.Qt.LeftButton,
-        delay=delay,
-    )
+    mouse_click_qwidget(widget, delay)
 
 
 def mouse_click_item_view(model, view, index, delay):

--- a/traitsui/testing/tester/qt4/helpers.py
+++ b/traitsui/testing/tester/qt4/helpers.py
@@ -8,7 +8,7 @@
 #
 #  Thanks for using Enthought open source!
 #
-import time 
+import time
 
 from pyface.qt import QtCore, QtGui
 from pyface.qt.QtTest import QTest

--- a/traitsui/testing/tester/qt4/helpers.py
+++ b/traitsui/testing/tester/qt4/helpers.py
@@ -8,8 +8,6 @@
 #
 #  Thanks for using Enthought open source!
 #
-import time
-
 from pyface.qt import QtCore, QtGui
 from pyface.qt.QtTest import QTest
 
@@ -108,7 +106,8 @@ def mouse_click_qwidget(control, delay):
         Time delay (in ms) in which click will be performed.
     """
     if isinstance(control, QtGui.QAbstractButton):
-        time.sleep(delay/1000)
+        if delay > 0:
+            QTest.qSleep(delay)
         control.click()
     else:
         QTest.mouseClick(

--- a/traitsui/testing/tester/qt4/helpers.py
+++ b/traitsui/testing/tester/qt4/helpers.py
@@ -105,6 +105,10 @@ def mouse_click_qwidget(control, delay):
     delay : int
         Time delay (in ms) in which click will be performed.
     """
+
+    # for QAbstractButtons we do not use QTest.mouseClick as it assumes the
+    # center of the widget as the location to be clicked, which may be
+    # incorrect. For QAbstractButtons we can simply call their click method.
     if isinstance(control, QtGui.QAbstractButton):
         if delay > 0:
             QTest.qSleep(delay)


### PR DESCRIPTION
addresses part of #1220 

This PR, in addition to adding the UI Tester test/example for CheckListEditor_simple_demo.py, modifies the `mouse_click_qwidget` function to address a test failure observed here and in other places.  (see comments).  It fixed the problem by handling clicking of objects that subclass `QAbstractButton` separately. 
