### PR TITLE
replacing WidgetType enum members with standalone types

### DIFF
--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -61,6 +61,6 @@ class Slider:
 
 
 class Textbox:
-    """ A locator for locating amnested textbox widget within a UI.
+    """ A locator for locating a nested textbox widget within a UI.
     """
     pass

--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -56,22 +56,6 @@ class TargetById:
         self.id = id
 
 
-class WidgetType(enum.Enum):
-    """ A locator for locating nested widgets within a UI. Many editors will
-    contain many sub-widgets (e.g. a textbox, slider, tabs, buttons, etc.).
-
-    For example when working with a range editor, one could call
-    ``tester.find_by_name(ui, "number").locate(locator.WidgetType.textbox)``
-    where number utilizes a Range Editor.
-    """
-
-    # A textbox within a UI
-    textbox = "textbox"
-
-    # A slider within a UI
-    slider = "slider"
-
-
 class slider:
     """ A locator for locating a nested slider widget within a UI.
     """

--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -56,13 +56,13 @@ class TargetById:
         self.id = id
 
 
-class slider:
+class Slider:
     """ A locator for locating a nested slider widget within a UI.
     """
     pass
 
 
-class textbox:
+class Textbox:
     """ A locator for locating amnested textbox widget within a UI.
     """
     pass

--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -17,8 +17,6 @@ a UI target where further location resolution or user interaction can be
 applied.
 """
 
-import enum
-
 
 class Index:
     """ A locator for locating a target that is uniquely specified by a single

--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -70,3 +70,15 @@ class WidgetType(enum.Enum):
 
     # A slider within a UI
     slider = "slider"
+
+
+class slider:
+    """ A locator for locating a nested slider widget within a UI.
+    """
+    pass
+
+
+class textbox:
+    """ A locator for locating amnested textbox widget within a UI.
+    """
+    pass

--- a/traitsui/testing/tester/qt4/implementation/range_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/range_editor.py
@@ -24,31 +24,6 @@ from traitsui.testing.tester.qt4.common_ui_targets import (
 )
 
 
-def resolve_location_slider(wrapper, location):
-    """ Solver from a UIWrapper wrapped Range Editor to a LocatedTextbox
-    containing the textbox of interest, or a LocatedSlider containing the
-    slider.
-
-    If there are any conflicts, an error will occur.
-
-    Parameters
-    ----------
-    wrapper : UIWrapper
-        Wrapper containing the Range Editor target.
-    location : locator.WidgetType
-        The location we are looking to resolve.
-    """
-    if location == locator.WidgetType.textbox:
-        return LocatedTextbox(textbox=wrapper.target.control.text)
-    if location in [locator.WidgetType.slider]:
-        return LocatedSlider(slider=wrapper.target.control.slider)
-    raise ValueError(
-        f"Unable to resolve {location} on {wrapper.target}."
-        " Currently supported: {locator.WidgetType.textbox} and"
-        " {locator.WidgetType.slider}"
-    )
-
-
 def register(registry):
     """ Register interactions for the given registry.
 
@@ -66,8 +41,15 @@ def register(registry):
     for target_class in targets:
         registry.register_solver(
             target_class=target_class,
-            locator_class=locator.WidgetType,
-            solver=resolve_location_slider,
+            locator_class=locator.textbox,
+            solver=lambda wrapper, _: LocatedTextbox(
+                textbox=wrapper.target.control.text),
+        )
+        registry.register_solver(
+            target_class=target_class,
+            locator_class=locator.slider,
+            solver=lambda wrapper, _: LocatedSlider(
+                slider=wrapper.target.control.slider),
         )
     registry_helper.register_editable_textbox_handlers(
         registry=registry,

--- a/traitsui/testing/tester/qt4/implementation/range_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/range_editor.py
@@ -41,13 +41,13 @@ def register(registry):
     for target_class in targets:
         registry.register_solver(
             target_class=target_class,
-            locator_class=locator.textbox,
+            locator_class=locator.Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
                 textbox=wrapper.target.control.text),
         )
         registry.register_solver(
             target_class=target_class,
-            locator_class=locator.slider,
+            locator_class=locator.Slider,
             solver=lambda wrapper, _: LocatedSlider(
                 slider=wrapper.target.control.slider),
         )

--- a/traitsui/testing/tester/wx/implementation/range_editor.py
+++ b/traitsui/testing/tester/wx/implementation/range_editor.py
@@ -40,13 +40,13 @@ def register(registry):
     for target_class in targets:
         registry.register_solver(
             target_class=target_class,
-            locator_class=locator.textbox,
+            locator_class=locator.Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
                 textbox=wrapper.target.control.text),
         )
         registry.register_solver(
             target_class=target_class,
-            locator_class=locator.slider,
+            locator_class=locator.Slider,
             solver=lambda wrapper, _: LocatedSlider(
                 slider=wrapper.target.control.slider),
         )

--- a/traitsui/testing/tester/wx/implementation/range_editor.py
+++ b/traitsui/testing/tester/wx/implementation/range_editor.py
@@ -23,31 +23,6 @@ from traitsui.testing.tester.wx.common_ui_targets import (
 )
 
 
-def resolve_location_slider(wrapper, location):
-    """ Solver from a UIWrapper wrapped Range Editor to a LocatedTextbox
-    containing the textbox of interest, or a LocatedSlider containing the
-    slider.
-
-    If there are any conflicts, an error will occur.
-
-    Parameters
-    ----------
-    wrapper : UIWrapper
-        Wrapper containing the Range Editor target.
-    location : locator.WidgetType
-        The location we are looking to resolve.
-    """
-    if location == locator.WidgetType.textbox:
-        return LocatedTextbox(textbox=wrapper.target.control.text)
-    if location in [locator.WidgetType.slider]:
-        return LocatedSlider(slider=wrapper.target.control.slider)
-    raise ValueError(
-        f"Unable to resolve {location} on {wrapper.target}."
-        " Currently supported: {locator.WidgetType.textbox} and"
-        " {locator.WidgetType.slider}"
-    )
-
-
 def register(registry):
     """ Register interactions for the given registry.
 
@@ -65,8 +40,15 @@ def register(registry):
     for target_class in targets:
         registry.register_solver(
             target_class=target_class,
-            locator_class=locator.WidgetType,
-            solver=resolve_location_slider,
+            locator_class=locator.textbox,
+            solver=lambda wrapper, _: LocatedTextbox(
+                textbox=wrapper.target.control.text),
+        )
+        registry.register_solver(
+            target_class=target_class,
+            locator_class=locator.slider,
+            solver=lambda wrapper, _: LocatedSlider(
+                slider=wrapper.target.control.slider),
         )
     registry_helper.register_editable_textbox_handlers(
         registry=registry,

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -103,7 +103,7 @@ class TestCustomListEditor(unittest.TestCase):
         with tester.create_ui(obj) as ui:
             with self.assertRaises(LocationNotSupported) as exc:
                 people_list = tester.find_by_name(ui, "people")
-                people_list.locate(locator.textbox())
+                people_list.locate(locator.Textbox())
             self.assertIn(locator.Index, exc.exception.supported)
 
     def test_index_out_of_range(self):

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -103,7 +103,7 @@ class TestCustomListEditor(unittest.TestCase):
         with tester.create_ui(obj) as ui:
             with self.assertRaises(LocationNotSupported) as exc:
                 people_list = tester.find_by_name(ui, "people")
-                people_list.locate(locator.WidgetType.textbox)
+                people_list.locate(locator.textbox())
             self.assertIn(locator.Index, exc.exception.supported)
 
     def test_index_out_of_range(self):

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -93,7 +93,7 @@ class TestRangeEditor(unittest.TestCase):
             # sanity check
             self.assertEqual(model.value, 1)
             number_field = tester.find_by_name(ui, "value")
-            text = number_field.locate(locator.WidgetType.textbox)
+            text = number_field.locate(locator.textbox())
             text.perform(command.KeyClick("0"))
             text.perform(command.KeyClick("Enter"))
             displayed = text.inspect(query.DisplayedText())
@@ -169,7 +169,7 @@ class TestRangeEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
-            text = number_field.locate(locator.WidgetType.textbox)
+            text = number_field.locate(locator.textbox())
             # Delete all contents of textbox
             for _ in range(5):
                 text.perform(command.KeyClick("Backspace"))
@@ -247,8 +247,8 @@ class TestRangeEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
-            slider = number_field.locate(locator.WidgetType.slider)
-            text = number_field.locate(locator.WidgetType.textbox)
+            slider = number_field.locate(locator.slider())
+            text = number_field.locate(locator.textbox())
             # slider values are converted to a [0, 10000] scale.  A single
             # step is a change of 100 on that scale and a page step is 1000.
             # Our range in [0, 10] so these correspond to changes of .1 and 1.
@@ -281,8 +281,8 @@ class TestRangeEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "float_value")
-            slider = number_field.locate(locator.WidgetType.slider)
-            text = number_field.locate(locator.WidgetType.textbox)
+            slider = number_field.locate(locator.slider())
+            text = number_field.locate(locator.textbox())
             # 10 steps is equivalent to 1 page step
             # on this scale either of those is equivalent to increasing the
             # trait's value from 10^n to 10^(n+1)

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -93,7 +93,7 @@ class TestRangeEditor(unittest.TestCase):
             # sanity check
             self.assertEqual(model.value, 1)
             number_field = tester.find_by_name(ui, "value")
-            text = number_field.locate(locator.textbox())
+            text = number_field.locate(locator.Textbox())
             text.perform(command.KeyClick("0"))
             text.perform(command.KeyClick("Enter"))
             displayed = text.inspect(query.DisplayedText())
@@ -169,7 +169,7 @@ class TestRangeEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
-            text = number_field.locate(locator.textbox())
+            text = number_field.locate(locator.Textbox())
             # Delete all contents of textbox
             for _ in range(5):
                 text.perform(command.KeyClick("Backspace"))
@@ -247,8 +247,8 @@ class TestRangeEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
-            slider = number_field.locate(locator.slider())
-            text = number_field.locate(locator.textbox())
+            slider = number_field.locate(locator.Slider())
+            text = number_field.locate(locator.Textbox())
             # slider values are converted to a [0, 10000] scale.  A single
             # step is a change of 100 on that scale and a page step is 1000.
             # Our range in [0, 10] so these correspond to changes of .1 and 1.
@@ -281,8 +281,8 @@ class TestRangeEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "float_value")
-            slider = number_field.locate(locator.slider())
-            text = number_field.locate(locator.textbox())
+            slider = number_field.locate(locator.Slider())
+            text = number_field.locate(locator.Textbox())
             # 10 steps is equivalent to 1 page step
             # on this scale either of those is equivalent to increasing the
             # trait's value from 10^n to 10^(n+1)


### PR DESCRIPTION
fixes #1233 
Removes the `locator.WidgetType` enum class, and replaces it  with more flexible standalone classes for each widget type.  