### PR TITLE
Add a new shell command

### DIFF
--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -203,6 +203,22 @@ def install(runtime, toolkit, environment, editable):
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 @click.option('--environment', default=None)
+def shell(runtime, toolkit, environment):
+    """ Create a shell into the EDM development environment
+    (aka 'activate' it).
+
+    """
+    parameters = get_parameters(runtime, toolkit, environment)
+    commands = [
+        "edm shell -e {environment}",
+    ]
+    execute(commands, parameters)
+
+
+@cli.command()
+@click.option('--runtime', default=DEFAULT_RUNTIME)
+@click.option('--toolkit', default=DEFAULT_TOOLKIT)
+@click.option('--environment', default=None)
 def test(runtime, toolkit, environment):
     """ Run the test suite in a given environment with the specified toolkit.
 

--- a/etstool.py
+++ b/etstool.py
@@ -258,6 +258,22 @@ def install(runtime, toolkit, environment, editable, source):
 @click.option('--runtime', default=DEFAULT_RUNTIME)
 @click.option('--toolkit', default=DEFAULT_TOOLKIT)
 @click.option('--environment', default=None)
+def shell(runtime, toolkit, environment):
+    """ Create a shell into the EDM development environment
+    (aka 'activate' it).
+
+    """
+    parameters = get_parameters(runtime, toolkit, environment)
+    commands = [
+        "edm shell -e {environment}",
+    ]
+    execute(commands, parameters)
+
+
+@cli.command()
+@click.option('--runtime', default=DEFAULT_RUNTIME)
+@click.option('--toolkit', default=DEFAULT_TOOLKIT)
+@click.option('--environment', default=None)
 def test(runtime, toolkit, environment):
     """ Run the test suite in a given environment with the specified toolkit.
 


### PR DESCRIPTION
This PR adds a new `shell` click command - which when run activates the development environment for traits. The usual command line options are available to choose the environment name and the runtime version/toolkit of the development environment. Underneath the hood, the click command just uses the `edm shell` command with the appropriate environment name, which is why the docstring for the click command is _almost_ the same as that of `edm shell`.
