### PR TITLE
Add help method to UIWrapper for self-discovery

### DIFF
--- a/traitsui/testing/tester/registry.py
+++ b/traitsui/testing/tester/registry.py
@@ -9,6 +9,8 @@
 #  Thanks for using Enthought open source!
 #
 
+import inspect
+
 from traitsui.testing.tester.exceptions import (
     InteractionNotSupported,
     LocationNotSupported,
@@ -54,6 +56,20 @@ class _TargetToKeyRegistry:
                 available_keys=list(action_to_handler),
             )
         return action_to_handler[key]
+
+    def get_keys(self, target_class):
+        """ Return all the keys for the given target.
+
+        Parameters
+        ----------
+        target_class : subclass of type
+            The type of a UI target being operated on.
+
+        Returns
+        -------
+        keys : set
+        """
+        return set(self._target_to_key_to_value.get(target_class, []))
 
 
 class TargetRegistry:
@@ -215,11 +231,55 @@ class TargetRegistry:
         handler : callable(UIWrapper, interaction) -> any
             The function to handle the particular interaction on a target.
             ``interaction`` should be an instance of ``interaction_class``.
+
+        Raises
+        ------
+        InteractionNotSupported
+            If the given target and interaction types are not supported
+            by this registry.
         """
         return self._interaction_registry.get_value(
             target_class=target_class,
             key=interaction_class,
         )
+
+    def get_interactions(self, target_class):
+        """ Returns all the interactions supported for the given target type.
+
+        Parameters
+        ----------
+        target_class : subclass of type
+            The type of a UI target being operated on.
+
+        Returns
+        -------
+        interaction_classes : set
+            Supported interaction types for the given target type.
+        """
+        return self._interaction_registry.get_keys(target_class=target_class)
+
+    def get_interaction_doc(self, target_class, interaction_class):
+        """ Return the documentation for the given target and locator type.
+
+        Parameters
+        ----------
+        target_class : subclass of type
+            The type of a UI target being operated on.
+        interaction_class : subclass of type
+            Any class.
+
+        Raises
+        ------
+        InteractionNotSupported
+            If the given target and interaction types are not supported
+            by this registry.
+        """
+        self._interaction_registry.get_value(
+            target_class=target_class,
+            key=interaction_class,
+        )
+        # This maybe configurable in the future via register_handler
+        return inspect.getdoc(interaction_class)
 
     def register_solver(self, target_class, locator_class, solver):
         """ Register a solver for resolving the next UI target for the given
@@ -266,3 +326,39 @@ class TargetRegistry:
             target_class=target_class,
             key=locator_class,
         )
+
+    def get_locations(self, target_class):
+        """ Returns all the location types supported for the given target type.
+
+        Parameters
+        ----------
+        target_class : subclass of type
+            The type of a UI target being operated on.
+
+        Returns
+        -------
+        locators_classes : set
+            Supported locator types for the given target type.
+        """
+        return self._location_registry.get_keys(target_class=target_class)
+
+    def get_location_doc(self, target_class, locator_class):
+        """ Return the documentation for the given target and locator type.
+
+        Parameters
+        ----------
+        target_class : subclass of type
+            The type of a UI target being operated on.
+        locator_class : subclass of type
+            Any class.
+
+        Raises
+        ------
+        LocationNotSupported
+        """
+        self._location_registry.get_value(
+            target_class=target_class,
+            key=locator_class,
+        )
+        # This maybe configurable in the future via register_solver
+        return inspect.getdoc(locator_class)

--- a/traitsui/testing/tester/registry.py
+++ b/traitsui/testing/tester/registry.py
@@ -268,6 +268,10 @@ class TargetRegistry:
         interaction_class : subclass of type
             Any class.
 
+        Returns
+        -------
+        doc : str
+
         Raises
         ------
         InteractionNotSupported
@@ -321,6 +325,7 @@ class TargetRegistry:
         Raises
         ------
         LocationNotSupported
+            If the given locator and target types are not supported.
         """
         return self._location_registry.get_value(
             target_class=target_class,
@@ -352,9 +357,14 @@ class TargetRegistry:
         locator_class : subclass of type
             Any class.
 
+        Returns
+        -------
+        doc : str
+
         Raises
         ------
         LocationNotSupported
+            If the given locator and target types are not supported.
         """
         self._location_registry.get_value(
             target_class=target_class,

--- a/traitsui/testing/tester/tests/test_registry.py
+++ b/traitsui/testing/tester/tests/test_registry.py
@@ -108,7 +108,7 @@ class TestInteractionRegistry(unittest.TestCase):
         with self.assertRaises(ValueError):
             registry.register_handler(SpecificEditor, UserAction, handler)
 
-    def test_error_get_interaction_coc(self):
+    def test_error_get_interaction_doc(self):
         # The registry is empty
         registry = TargetRegistry()
         with self.assertRaises(InteractionNotSupported):
@@ -192,7 +192,7 @@ class TestLocationRegistry(unittest.TestCase):
         )
         self.assertEqual(help_text, "Some default documentation.")
 
-    def test_error_get_interaction_coc(self):
+    def test_error_get_interaction_doc(self):
         # The registry is empty
         registry = TargetRegistry()
         with self.assertRaises(LocationNotSupported):

--- a/traitsui/testing/tester/tests/test_registry.py
+++ b/traitsui/testing/tester/tests/test_registry.py
@@ -108,6 +108,33 @@ class TestInteractionRegistry(unittest.TestCase):
         with self.assertRaises(ValueError):
             registry.register_handler(SpecificEditor, UserAction, handler)
 
+    def test_error_get_interaction_coc(self):
+        # The registry is empty
+        registry = TargetRegistry()
+        with self.assertRaises(InteractionNotSupported):
+            registry.get_interaction_doc(float, int)
+
+    def test_get_default_interaction_doc(self):
+
+        class Action:
+            """Some action."""
+            pass
+
+        def handler(wrapper, interaction):
+            pass
+
+        registry = TargetRegistry()
+        registry.register_handler(
+            target_class=float,
+            interaction_class=Action,
+            handler=handler,
+        )
+
+        actual = registry.get_interaction_doc(
+            target_class=float, interaction_class=Action,
+        )
+        self.assertEqual(actual, "Some action.")
+
 
 class TestLocationRegistry(unittest.TestCase):
 
@@ -146,3 +173,27 @@ class TestLocationRegistry(unittest.TestCase):
             registry.get_solver(float, None)
 
         self.assertEqual(exception_context.exception.supported, [str])
+
+    def test_get_location_help_default(self):
+
+        class Locator:
+            """ Some default documentation."""
+            pass
+
+        registry = TargetRegistry()
+        registry.register_solver(
+            target_class=float,
+            locator_class=Locator,
+            solver=lambda w, l: 1,
+        )
+
+        help_text = registry.get_location_doc(
+            target_class=float, locator_class=Locator,
+        )
+        self.assertEqual(help_text, "Some default documentation.")
+
+    def test_error_get_interaction_coc(self):
+        # The registry is empty
+        registry = TargetRegistry()
+        with self.assertRaises(LocationNotSupported):
+            registry.get_location_doc(float, int)

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -237,6 +237,7 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
 
 
 class TestUIWrapperHelp(unittest.TestCase):
+    """ Test calling UIWrapper.help """
 
     def test_help_message(self):
 

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -8,6 +8,8 @@
 #
 #  Thanks for using Enthought open source!
 #
+import io
+import textwrap
 import unittest
 from unittest import mock
 
@@ -22,6 +24,9 @@ from traitsui.tests._tools import (
 from traitsui.testing.tester.exceptions import (
     InteractionNotSupported,
     LocationNotSupported,
+)
+from traitsui.testing.tester.registry import (
+    TargetRegistry,
 )
 from traitsui.testing.tester.ui_wrapper import (
     UIWrapper,
@@ -228,6 +233,65 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         self.assertCountEqual(
             exception_context.exception.supported,
             [int, float],
+        )
+
+
+class TestUIWrapperHelp(unittest.TestCase):
+
+    def test_help_message(self):
+
+        class Action:
+            """ Say hello.
+            Say bye.
+            """
+            pass
+
+        class Locator:
+            """ Return anything you like.
+            Good day!
+            """
+            pass
+
+        registry1 = TargetRegistry()
+        registry1.register_handler(
+            target_class=str,
+            interaction_class=Action,
+            handler=mock.Mock(),
+        )
+        registry2 = TargetRegistry()
+        registry2.register_solver(
+            target_class=str,
+            locator_class=Locator,
+            solver=mock.Mock(),
+        )
+
+        stream = io.StringIO()
+        wrapper = example_ui_wrapper(
+            target="dummy", registries=[registry1, registry2]
+        )
+
+        # when
+        with mock.patch("sys.stdout", stream):
+            wrapper.help()
+
+        # then
+        self.assertEqual(
+            stream.getvalue(),
+            textwrap.dedent(f"""\
+                Interactions
+                ------------
+                {Action!r}
+                    Say hello.
+                    Say bye.
+
+
+                Locations
+                ---------
+                {Locator!r}
+                    Return anything you like.
+                    Good day!
+
+            """)
         )
 
 

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -388,7 +388,6 @@ class TestUIWrapperHelp(unittest.TestCase):
         )
 
 
-
 class NumberHasTraits(HasTraits):
     number = Int()
 

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -284,7 +284,6 @@ class TestUIWrapperHelp(unittest.TestCase):
                     Say hello.
                     Say bye.
 
-
                 Locations
                 ---------
                 {Locator!r}
@@ -356,7 +355,6 @@ class TestUIWrapperHelp(unittest.TestCase):
                 {float!r}
                     Interaction: I get a higher priority.
 
-
                 Locations
                 ---------
                 {str!r}
@@ -364,6 +362,31 @@ class TestUIWrapperHelp(unittest.TestCase):
 
             """)
         )
+
+    def test_help_message_nothing_is_supported(self):
+        registry = TargetRegistry()
+        wrapper = example_ui_wrapper(registries=[registry])
+
+        # when
+        stream = io.StringIO()
+        with mock.patch("sys.stdout", stream):
+            wrapper.help()
+
+        # then
+        self.assertEqual(
+            stream.getvalue(),
+            textwrap.dedent(f"""\
+                Interactions
+                ------------
+                No interactions are supported.
+
+                Locations
+                ---------
+                No locations are supported.
+
+            """)
+        )
+
 
 
 class NumberHasTraits(HasTraits):

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -83,6 +83,9 @@ class UIWrapper:
 
         # mapping from location types to their documentation
         location_to_doc = dict()
+
+        # Let higher priority registry override the documentation from lower
+        # priority registry.
         for registry in self._registries[::-1]:
             for type_ in registry.get_interactions(self.target.__class__):
                 interaction_to_doc[type_] = registry.get_interaction_doc(

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -94,10 +94,7 @@ class UIWrapper:
         pairs = sorted(interactions.items(), key=lambda value: repr(value[0]))
         for interaction_class, doc in pairs:
             print(repr(interaction_class))
-            print(
-                *("    " + line for line in doc.split("\n")),
-                sep="\n",
-            )
+            print(textwrap.indent(doc, prefix="    "))
             print()
 
         if not interactions:

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -100,13 +100,20 @@ class UIWrapper:
             )
             print()
 
-        print()
+        if not interactions:
+            print("No interactions are supported.")
+            print()
+
         print("Locations")
         print("---------")
         pairs = sorted(locations.items(), key=lambda value: repr(value[0]))
         for interaction_class, doc in pairs:
             print(repr(interaction_class))
             print(textwrap.indent(doc, prefix="    "))
+            print()
+
+        if not locations:
+            print("No locations are supported.")
             print()
 
     def locate(self, location):

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -84,8 +84,7 @@ class UIWrapper:
         # mapping from location types to their documentation
         location_to_doc = dict()
 
-        # Let higher priority registry override the documentation from lower
-        # priority registry.
+        # Order registries by their priority (low to high)
         for registry in self._registries[::-1]:
             for type_ in registry.get_interactions(self.target.__class__):
                 interaction_to_doc[type_] = registry.get_interaction_doc(

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -107,8 +107,8 @@ class UIWrapper:
         print("Locations")
         print("---------")
         pairs = sorted(locations.items(), key=lambda value: repr(value[0]))
-        for interaction_class, doc in pairs:
-            print(repr(interaction_class))
+        for locator_class, doc in pairs:
+            print(repr(locator_class))
             print(textwrap.indent(doc, prefix="    "))
             print()
 

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -73,6 +73,44 @@ class UIWrapper:
         self._registries = registries
         self.delay = delay
 
+    def help(self):
+        """ Print help messages.
+        (This function is intended for interactive use.)
+        """
+        interactions = dict()
+        locations = dict()
+        for registry in self._registries[::-1]:
+            for type_ in registry.get_interactions(self.target.__class__):
+                interactions[type_] = registry.get_interaction_doc(
+                    self.target.__class__, type_)
+
+            for type_ in registry.get_locations(self.target.__class__):
+                locations[type_] = registry.get_location_doc(
+                    self.target.__class__, type_)
+
+        print("Interactions")
+        print("------------")
+        pairs = sorted(interactions.items(), key=lambda value: repr(value[0]))
+        for interaction_class, doc in pairs:
+            print(repr(interaction_class))
+            print(
+                *("    " + line for line in doc.split("\n")),
+                sep="\n",
+            )
+            print()
+
+        print()
+        print("Locations")
+        print("---------")
+        pairs = sorted(locations.items(), key=lambda value: repr(value[0]))
+        for interaction_class, doc in pairs:
+            print(repr(interaction_class))
+            print(
+                *("    " + line for line in doc.split("\n")),
+                sep="\n",
+            )
+            print()
+
     def locate(self, location):
         """ Attempt to resolve the given location and return a new
         UIWrapper.

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -10,6 +10,7 @@
 #
 
 from contextlib import contextmanager
+import textwrap
 
 from traitsui.testing.exception_handling import (
     reraise_exceptions as _reraise_exceptions,
@@ -105,10 +106,7 @@ class UIWrapper:
         pairs = sorted(locations.items(), key=lambda value: repr(value[0]))
         for interaction_class, doc in pairs:
             print(repr(interaction_class))
-            print(
-                *("    " + line for line in doc.split("\n")),
-                sep="\n",
-            )
+            print(textwrap.indent(doc, prefix="    "))
             print()
 
     def locate(self, location):

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -78,38 +78,49 @@ class UIWrapper:
         """ Print help messages.
         (This function is intended for interactive use.)
         """
-        interactions = dict()
-        locations = dict()
+        # mapping from interaction types to their documentation
+        interaction_to_doc = dict()
+
+        # mapping from location types to their documentation
+        location_to_doc = dict()
         for registry in self._registries[::-1]:
             for type_ in registry.get_interactions(self.target.__class__):
-                interactions[type_] = registry.get_interaction_doc(
+                interaction_to_doc[type_] = registry.get_interaction_doc(
                     self.target.__class__, type_)
 
             for type_ in registry.get_locations(self.target.__class__):
-                locations[type_] = registry.get_location_doc(
+                location_to_doc[type_] = registry.get_location_doc(
                     self.target.__class__, type_)
 
         print("Interactions")
         print("------------")
-        pairs = sorted(interactions.items(), key=lambda value: repr(value[0]))
-        for interaction_class, doc in pairs:
-            print(repr(interaction_class))
-            print(textwrap.indent(doc, prefix="    "))
+        interaction_types = sorted(interaction_to_doc, key=repr)
+        for interaction_type in interaction_types:
+            print(repr(interaction_type))
+            print(
+                textwrap.indent(
+                    interaction_to_doc[interaction_type], prefix="    "
+                )
+            )
             print()
 
-        if not interactions:
+        if not interaction_types:
             print("No interactions are supported.")
             print()
 
         print("Locations")
         print("---------")
-        pairs = sorted(locations.items(), key=lambda value: repr(value[0]))
-        for locator_class, doc in pairs:
-            print(repr(locator_class))
-            print(textwrap.indent(doc, prefix="    "))
+        location_types = sorted(location_to_doc, key=repr)
+        for locator_type in location_types:
+            print(repr(locator_type))
+            print(
+                textwrap.indent(
+                    location_to_doc[locator_type], prefix="    "
+                )
+            )
             print()
 
-        if not locations:
+        if not location_types:
             print("No locations are supported.")
             print()
 

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -94,8 +94,7 @@ class UIWrapper:
 
         print("Interactions")
         print("------------")
-        interaction_types = sorted(interaction_to_doc, key=repr)
-        for interaction_type in interaction_types:
+        for interaction_type in sorted(interaction_to_doc, key=repr):
             print(repr(interaction_type))
             print(
                 textwrap.indent(
@@ -104,14 +103,13 @@ class UIWrapper:
             )
             print()
 
-        if not interaction_types:
+        if not interaction_to_doc:
             print("No interactions are supported.")
             print()
 
         print("Locations")
         print("---------")
-        location_types = sorted(location_to_doc, key=repr)
-        for locator_type in location_types:
+        for locator_type in sorted(location_to_doc, key=repr):
             print(repr(locator_type))
             print(
                 textwrap.indent(
@@ -120,7 +118,7 @@ class UIWrapper:
             )
             print()
 
-        if not location_types:
+        if not location_to_doc:
             print("No locations are supported.")
             print()
 


### PR DESCRIPTION
Closes #1211

Instead of implementing properties on `UIWrapper`, this PR implements a `help` method to print help messages when it is invoked.

Its current use case is only for developers to discover supported features while they are writing tests.

e.g. if I add the following in this [test](https://github.com/enthought/traitsui/blob/1b2a3933c5313f1d4d2084f197bdb6fc8e4c1ecf/traitsui/tests/editors/test_list_editor.py#L122-L128):
```
            print("Help on the list editor")
            list_.help()

            print("Help on an item in the list editor")
            list_.locate(locator.Index(1)).help()
```

Then I see this being printed:
<details>
    <summary> printed content </summary>

```
Help on the list editor
Interactions
------------
No interactions are supported.

Locations
---------
<class 'traitsui.testing.tester.locator.Index'>
    A locator for locating a target that is uniquely specified by a single
    0-based index.
    
    Attributes
    ----------
    index : int
        0-based index

Help on an item in the list editor
Interactions
------------
<class 'traitsui.testing.tester.command.MouseClick'>
    An object representing the user clicking a mouse button.
    Currently the left mouse button is assumed.
    
    In most circumstances, a widget can still be clicked on even if it is
    disabled. Therefore unlike key events, if the widget is disabled,
    implementations should not raise an exception.

Locations
---------
<class 'traitsui.testing.tester.locator.TargetById'>
    A locator for locating the next UI target using an id.
    
    Attributes
    ----------
    id : str

<class 'traitsui.testing.tester.locator.TargetByName'>
    A locator for locating the next UI target using a name.
    
    Attributes
    ----------
    name : str
```

</details>

I plan to use this feature on the user manual (see #1223)