### PR TITLE
Rename UIWrapper.target to UIWrapper._target

### DIFF
--- a/traitsui/testing/tester/common_ui_targets.py
+++ b/traitsui/testing/tester/common_ui_targets.py
@@ -69,7 +69,7 @@ class _BaseSourceWithLocation:
         registry.register_solver(
             target_class=cls.source_class,
             locator_class=cls.locator_class,
-            solver=lambda wrapper, location: cls(wrapper.target, location),
+            solver=lambda wrapper, location: cls(wrapper._target, location),
         )
         for interaction_class, handler in cls.handlers:
             registry.register_handler(

--- a/traitsui/testing/tester/qt4/common_ui_targets.py
+++ b/traitsui/testing/tester/qt4/common_ui_targets.py
@@ -46,7 +46,7 @@ class LocatedTextbox:
         registry_helper.register_editable_textbox_handlers(
             registry=registry,
             target_class=cls,
-            widget_getter=lambda wrapper: wrapper.target.textbox,
+            widget_getter=lambda wrapper: wrapper._target.textbox,
         )
 
 
@@ -77,5 +77,5 @@ class LocatedSlider:
             target_class=cls,
             interaction_class=command.KeyClick,
             handler=lambda wrapper, interaction: helpers.key_click_qslider(
-                wrapper.target.slider, interaction, wrapper.delay)
+                wrapper._target.slider, interaction, wrapper.delay)
         )

--- a/traitsui/testing/tester/qt4/implementation/button_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/button_editor.py
@@ -27,7 +27,8 @@ def register(registry):
     handlers = [
         (command.MouseClick, (lambda wrapper, _:  helpers.mouse_click_qwidget(
                               wrapper._target.control, wrapper.delay))),
-        (query.DisplayedText, lambda wrapper, _: wrapper._target.control.text())
+        (query.DisplayedText,
+            lambda wrapper, _: wrapper._target.control.text())
     ]
 
     for target_class in [SimpleEditor, CustomEditor]:

--- a/traitsui/testing/tester/qt4/implementation/button_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/button_editor.py
@@ -26,8 +26,8 @@ def register(registry):
 
     handlers = [
         (command.MouseClick, (lambda wrapper, _:  helpers.mouse_click_qwidget(
-                              wrapper.target.control, wrapper.delay))),
-        (query.DisplayedText, lambda wrapper, _: wrapper.target.control.text())
+                              wrapper._target.control, wrapper.delay))),
+        (query.DisplayedText, lambda wrapper, _: wrapper._target.control.text())
     ]
 
     for target_class in [SimpleEditor, CustomEditor]:

--- a/traitsui/testing/tester/qt4/implementation/check_list_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/check_list_editor.py
@@ -22,10 +22,10 @@ class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
     locator_class = locator.Index
     handlers = [
         (command.MouseClick, (lambda wrapper, _: helpers.mouse_click_qlayout(
-            layout=wrapper.target.source.control.layout(),
+            layout=wrapper._target.source.control.layout(),
             index=convert_index(
-                layout=wrapper.target.source.control.layout(),
-                index=wrapper.target.location.index,
+                layout=wrapper._target.source.control.layout(),
+                index=wrapper._target.location.index,
             ),
             delay=wrapper.delay))),
     ]

--- a/traitsui/testing/tester/qt4/implementation/enum_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/enum_editor.py
@@ -27,10 +27,10 @@ class _IndexedListEditor(_BaseSourceWithLocation):
     locator_class = locator.Index
     handlers = [
         (command.MouseClick, (lambda wrapper, _: helpers.mouse_click_item_view(
-            model=wrapper.target.source.control.model(),
-            view=wrapper.target.source.control,
-            index=wrapper.target.source.control.model().index(
-                wrapper.target.location.index, 0),
+            model=wrapper._target.source.control.model(),
+            view=wrapper._target.source.control,
+            index=wrapper._target.source.control.model().index(
+                wrapper._target.location.index, 0),
             delay=wrapper.delay))),
     ]
 
@@ -42,11 +42,11 @@ class _IndexedRadioEditor(_BaseSourceWithLocation):
     locator_class = locator.Index
     handlers = [
         (command.MouseClick, (lambda wrapper, _: helpers.mouse_click_qlayout(
-            layout=wrapper.target.source.control.layout(),
+            layout=wrapper._target.source.control.layout(),
             index=convert_index(
-                layout=wrapper.target.source.control.layout(),
-                index=wrapper.target.location.index,
-                row_major=wrapper.target.source.row_major
+                layout=wrapper._target.source.control.layout(),
+                index=wrapper._target.location.index,
+                row_major=wrapper._target.source.row_major
             ),
             delay=wrapper.delay))),
     ]
@@ -87,8 +87,8 @@ class _IndexedSimpleEditor(_BaseSourceWithLocation):
     locator_class = locator.Index
     handlers = [
         (command.MouseClick, (lambda wrapper, _: helpers.mouse_click_combobox(
-            combobox=wrapper.target.source.control,
-            index=wrapper.target.location.index,
+            combobox=wrapper._target.source.control,
+            index=wrapper._target.location.index,
             delay=wrapper.delay))),
     ]
 
@@ -104,7 +104,7 @@ def radio_selected_text_handler(wrapper, interaction):
         Unused in this function but included to match the expected format of a
         handler.  Should only be query.SelectedText
     """
-    control = wrapper.target.control
+    control = wrapper._target.control
     for index in range(control.layout().count()):
         if control.layout().itemAt(index).widget().isChecked():
             return control.layout().itemAt(index).widget().text()
@@ -125,18 +125,18 @@ def register(registry):
     simple_editor_text_handlers = [
         (command.KeyClick,
             (lambda wrapper, interaction: helpers.key_click_qwidget(
-                control=wrapper.target.control,
+                control=wrapper._target.control,
                 interaction=interaction,
                 delay=wrapper.delay))),
         (command.KeySequence,
             (lambda wrapper, interaction: helpers.key_sequence_qwidget(
-                control=wrapper.target.control,
+                control=wrapper._target.control,
                 interaction=interaction,
                 delay=wrapper.delay))),
         (query.DisplayedText,
-            lambda wrapper, _: wrapper.target.control.currentText()),
+            lambda wrapper, _: wrapper._target.control.currentText()),
         (query.SelectedText,
-            lambda wrapper, _: wrapper.target.control.currentText())
+            lambda wrapper, _: wrapper._target.control.currentText())
     ]
 
     for interaction_class, handler in simple_editor_text_handlers:
@@ -155,5 +155,5 @@ def register(registry):
     registry.register_handler(
         target_class=ListEditor,
         interaction_class=query.SelectedText,
-        handler=lambda wrapper, _: wrapper.target.control.currentItem().text(),
+        handler=lambda wrapper, _: wrapper._target.control.currentItem().text(),
     )

--- a/traitsui/testing/tester/qt4/implementation/enum_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/enum_editor.py
@@ -155,5 +155,6 @@ def register(registry):
     registry.register_handler(
         target_class=ListEditor,
         interaction_class=query.SelectedText,
-        handler=lambda wrapper, _: wrapper._target.control.currentItem().text(),
+        handler=lambda wrapper, _:
+            wrapper._target.control.currentItem().text(),
     )

--- a/traitsui/testing/tester/qt4/implementation/font_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/font_editor.py
@@ -27,5 +27,5 @@ def register(registry):
     register_editable_textbox_handlers(
         registry=registry,
         target_class=TextFontEditor,
-        widget_getter=lambda wrapper: wrapper.target.control,
+        widget_getter=lambda wrapper: wrapper._target.control,
     )

--- a/traitsui/testing/tester/qt4/implementation/instance_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/instance_editor.py
@@ -54,7 +54,7 @@ def register(registry):
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=lambda wrapper, _: (
-            mouse_click_qwidget(wrapper.target._button, delay=wrapper.delay)
+            mouse_click_qwidget(wrapper._target._button, delay=wrapper.delay)
         )
     )
     register_traitsui_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)

--- a/traitsui/testing/tester/qt4/implementation/list_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/list_editor.py
@@ -28,8 +28,8 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
     handlers = [
         (command.MouseClick,
             (lambda wrapper, _: helpers.mouse_click_tab_index(
-                tab_widget=wrapper.target.source.control,
-                index=wrapper.target.location.index,
+                tab_widget=wrapper._target.source.control,
+                index=wrapper._target.location.index,
                 delay=wrapper.delay))),
     ]
 

--- a/traitsui/testing/tester/qt4/implementation/range_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/range_editor.py
@@ -43,16 +43,16 @@ def register(registry):
             target_class=target_class,
             locator_class=locator.Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
-                textbox=wrapper.target.control.text),
+                textbox=wrapper._target.control.text),
         )
         registry.register_solver(
             target_class=target_class,
             locator_class=locator.Slider,
             solver=lambda wrapper, _: LocatedSlider(
-                slider=wrapper.target.control.slider),
+                slider=wrapper._target.control.slider),
         )
     registry_helper.register_editable_textbox_handlers(
         registry=registry,
         target_class=RangeTextEditor,
-        widget_getter=lambda wrapper: wrapper.target.control,
+        widget_getter=lambda wrapper: wrapper._target.control,
     )

--- a/traitsui/testing/tester/qt4/implementation/text_editor.py
+++ b/traitsui/testing/tester/qt4/implementation/text_editor.py
@@ -32,12 +32,12 @@ def register(registry):
         register_editable_textbox_handlers(
             registry=registry,
             target_class=target_class,
-            widget_getter=lambda wrapper: wrapper.target.control,
+            widget_getter=lambda wrapper: wrapper._target.control,
         )
 
     registry.register_handler(
         target_class=ReadonlyEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _: helpers.displayed_text_qobject(
-            wrapper.target.control),
+            wrapper._target.control),
     )

--- a/traitsui/testing/tester/qt4/implementation/ui_base.py
+++ b/traitsui/testing/tester/qt4/implementation/ui_base.py
@@ -26,7 +26,8 @@ def register(registry):
     handlers = [
         (command.MouseClick, (lambda wrapper, _:  helpers.mouse_click_qwidget(
                               wrapper._target.control, wrapper.delay))),
-        (query.DisplayedText, lambda wrapper, _: wrapper._target.control.text())
+        (query.DisplayedText,
+            lambda wrapper, _: wrapper._target.control.text())
     ]
     for interaction_class, handler in handlers:
         registry.register_handler(

--- a/traitsui/testing/tester/qt4/implementation/ui_base.py
+++ b/traitsui/testing/tester/qt4/implementation/ui_base.py
@@ -25,8 +25,8 @@ def register(registry):
     """
     handlers = [
         (command.MouseClick, (lambda wrapper, _:  helpers.mouse_click_qwidget(
-                              wrapper.target.control, wrapper.delay))),
-        (query.DisplayedText, lambda wrapper, _: wrapper.target.control.text())
+                              wrapper._target.control, wrapper.delay))),
+        (query.DisplayedText, lambda wrapper, _: wrapper._target.control.text())
     ]
     for interaction_class, handler in handlers:
         registry.register_handler(

--- a/traitsui/testing/tester/registry.py
+++ b/traitsui/testing/tester/registry.py
@@ -88,7 +88,7 @@ class TargetRegistry:
 
         def mouse_click_qt_button(wrapper, interaction):
             # wrapper is an instance of UIWrapper
-            wrapper.target.control.click()
+            wrapper._target.control.click()
 
     The function can then be registered with the target type and an interaction
     type::
@@ -118,7 +118,7 @@ class TargetRegistry:
 
     ``UIWrapper.locate`` accepts an object, ``location``, which provides
     information for navigating into a specific element from
-    ``UIWrapper.target``. The ``location`` content varies from use case
+    ``UIWrapper._target``. The ``location`` content varies from use case
     to use case and a target is typically a rich container of multiple GUI
     elements. With that, for a given target type, multiple location types may
     be supported. For the given location type, the logic for resolving a
@@ -127,7 +127,7 @@ class TargetRegistry:
     how to interpret a location given its type and the type of the target it
     is used with.
 
-    For example, suppose we have a ``UIWrapper`` whose ``target`` is an
+    For example, suppose we have a ``UIWrapper`` whose ``_target`` is an
     instance of ``MyUIContainer``. This object has some buttons and the
     objective of a test is to click a specific button with a given
     label. We will therefore need to locate the button with the given label
@@ -151,7 +151,7 @@ class TargetRegistry:
     dictionary called ``_buttons``::
 
         def get_button(wrapper, location):
-            return wrapper.target._buttons[location.label]
+            return wrapper._target._buttons[location.label]
 
     The solvers can then be registered for the container UI target::
 
@@ -163,7 +163,7 @@ class TargetRegistry:
         )
 
     When the solver is registered this way, the ``wrapper`` argument will be
-    an instance of ``UIWrapper`` whose ``target`` attribute is an instance of
+    an instance of ``UIWrapper`` whose ``_target`` attribute is an instance of
     ``MyUIContainer``, and ``location`` will be an instance of ``Button``, as
     is provided via ``UIWrapper.locate``.
     """

--- a/traitsui/testing/tester/registry_helper.py
+++ b/traitsui/testing/tester/registry_helper.py
@@ -95,7 +95,7 @@ def register_traitsui_ui_solvers(registry, target_class, traitsui_ui_getter):
         locator_class=locator.TargetByName,
         solver=lambda wrapper, location: (
             _get_editor_by_name(
-                ui=traitsui_ui_getter(wrapper.target),
+                ui=traitsui_ui_getter(wrapper._target),
                 name=location.name,
             )
         ),
@@ -105,7 +105,7 @@ def register_traitsui_ui_solvers(registry, target_class, traitsui_ui_getter):
         locator_class=locator.TargetById,
         solver=lambda wrapper, location: (
             _get_editor_by_id(
-                ui=traitsui_ui_getter(wrapper.target),
+                ui=traitsui_ui_getter(wrapper._target),
                 id=location.id,
             )
         ),

--- a/traitsui/testing/tester/tests/test_ui_tester.py
+++ b/traitsui/testing/tester/tests/test_ui_tester.py
@@ -88,7 +88,7 @@ class TestUITesterFindEditor(unittest.TestCase):
             self.assertIsInstance(wrapper, UIWrapper)
 
             expected, = ui.get_editors("submit_button")
-            self.assertEqual(wrapper.target, expected)
+            self.assertEqual(wrapper._target, expected)
             self.assertEqual(
                 wrapper._registries,
                 tester._registries,
@@ -133,7 +133,7 @@ class TestUITesterFindEditor(unittest.TestCase):
         view = View(item1, item2)
         with tester.create_ui(Order(), dict(view=view)) as ui:
             wrapper = tester.find_by_id(ui, "item2")
-            self.assertIs(wrapper.target.item, item2)
+            self.assertIs(wrapper._target.item, item2)
             self.assertEqual(wrapper._registries, tester._registries)
             self.assertEqual(wrapper.delay, tester.delay)
 
@@ -146,4 +146,4 @@ class TestUITesterFindEditor(unittest.TestCase):
         view = View(item1, item2, item3)
         with tester.create_ui(Order(), dict(view=view)) as ui:
             wrapper = tester.find_by_id(ui, "item2")
-            self.assertIs(wrapper.target.item, item2)
+            self.assertIs(wrapper._target.item, item2)

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -164,7 +164,7 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         )
         wrapper = wrapper.locate(None)
 
-        self.assertEqual(wrapper.target, 2)
+        self.assertEqual(wrapper._target, 2)
 
         # swap the order
         wrapper = example_ui_wrapper(
@@ -172,7 +172,7 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         )
         wrapper = wrapper.locate(None)
 
-        self.assertEqual(wrapper.target, 1)
+        self.assertEqual(wrapper._target, 1)
 
     def test_location_registry_selection(self):
         # If the first registry says it can't handle the interaction, the next
@@ -197,7 +197,7 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         )
         new_wrapper = wrapper.locate(None)
 
-        self.assertEqual(new_wrapper.target, 2)
+        self.assertEqual(new_wrapper._target, 2)
         self.assertEqual(
             new_wrapper._registries,
             wrapper._registries,

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -112,7 +112,7 @@ class UITester:
         custom_registry.register_handler(
             target_class=MyEditor,
             interaction_class=ManyMouseClick,
-            handler=lambda wrapper, interaction: wrapper.target.do_something()
+            handler=lambda wrapper, interaction: wrapper._target.do_something()
         )
 
     Then the registry can be used in a UITester::

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -70,7 +70,7 @@ class UIWrapper:
     """
 
     def __init__(self, target, registries, delay=0):
-        self.target = target
+        self._target = target
         self._registries = registries
         self.delay = delay
 
@@ -86,13 +86,13 @@ class UIWrapper:
 
         # Order registries by their priority (low to high)
         for registry in self._registries[::-1]:
-            for type_ in registry.get_interactions(self.target.__class__):
+            for type_ in registry.get_interactions(self._target.__class__):
                 interaction_to_doc[type_] = registry.get_interaction_doc(
-                    self.target.__class__, type_)
+                    self._target.__class__, type_)
 
-            for type_ in registry.get_locations(self.target.__class__):
+            for type_ in registry.get_locations(self._target.__class__):
                 location_to_doc[type_] = registry.get_location_doc(
-                    self.target.__class__, type_)
+                    self._target.__class__, type_)
 
         print("Interactions")
         print("------------")
@@ -220,7 +220,7 @@ class UIWrapper:
         for registry in self._registries:
             try:
                 handler = registry.get_handler(
-                    target_class=self.target.__class__,
+                    target_class=self._target.__class__,
                     interaction_class=interaction_class,
                 )
             except InteractionNotSupported as e:
@@ -231,7 +231,7 @@ class UIWrapper:
                     return handler(self, interaction)
 
         raise InteractionNotSupported(
-            target_class=self.target.__class__,
+            target_class=self._target.__class__,
             interaction_class=interaction.__class__,
             supported=supported,
         )
@@ -258,7 +258,7 @@ class UIWrapper:
         for registry in self._registries:
             try:
                 handler = registry.get_solver(
-                    self.target.__class__,
+                    self._target.__class__,
                     location.__class__,
                 )
             except LocationNotSupported as e:
@@ -267,7 +267,7 @@ class UIWrapper:
                 return handler(self, location)
 
         raise LocationNotSupported(
-            target_class=self.target.__class__,
+            target_class=self._target.__class__,
             locator_class=location.__class__,
             supported=list(supported),
         )

--- a/traitsui/testing/tester/wx/common_ui_targets.py
+++ b/traitsui/testing/tester/wx/common_ui_targets.py
@@ -46,7 +46,7 @@ class LocatedTextbox:
         registry_helper.register_editable_textbox_handlers(
             registry=registry,
             target_class=cls,
-            widget_getter=lambda wrapper: wrapper.target.textbox,
+            widget_getter=lambda wrapper: wrapper._target.textbox,
         )
 
 
@@ -77,5 +77,5 @@ class LocatedSlider:
             target_class=cls,
             interaction_class=command.KeyClick,
             handler=lambda wrapper, interaction: helpers.key_click_slider(
-                wrapper.target.slider, interaction, wrapper.delay)
+                wrapper._target.slider, interaction, wrapper.delay)
         )

--- a/traitsui/testing/tester/wx/implementation/button_editor.py
+++ b/traitsui/testing/tester/wx/implementation/button_editor.py
@@ -29,7 +29,7 @@ def mouse_click_ImageButton(wrapper, interaction):
         intended to be used with an interaction_class of a MouseClick.
     """
 
-    control = wrapper.target.control
+    control = wrapper._target.control
     if not control.IsEnabled():
         return
     wx.MilliSleep(wrapper.delay)
@@ -59,13 +59,13 @@ def register(registry):
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=(lambda wrapper, _: helpers.mouse_click_button(
-                 control=wrapper.target.control, delay=wrapper.delay))
+                 control=wrapper._target.control, delay=wrapper.delay))
     )
 
     registry.register_handler(
         target_class=SimpleEditor,
         interaction_class=query.DisplayedText,
-        handler=lambda wrapper, _: wrapper.target.control.GetLabel()
+        handler=lambda wrapper, _: wrapper._target.control.GetLabel()
     )
 
     registry.register_handler(
@@ -77,5 +77,5 @@ def register(registry):
     registry.register_handler(
         target_class=CustomEditor,
         interaction_class=query.DisplayedText,
-        handler=lambda wrapper, _: wrapper.target.control.GetLabel()
+        handler=lambda wrapper, _: wrapper._target.control.GetLabel()
     )

--- a/traitsui/testing/tester/wx/implementation/check_list_editor.py
+++ b/traitsui/testing/tester/wx/implementation/check_list_editor.py
@@ -25,10 +25,10 @@ class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
     handlers = [
         (command.MouseClick,
             (lambda wrapper, _: helpers.mouse_click_checkbox_child_in_panel(
-                control=wrapper.target.source.control,
+                control=wrapper._target.source.control,
                 index=convert_index(
-                    source=wrapper.target.source,
-                    index=wrapper.target.location.index
+                    source=wrapper._target.source,
+                    index=wrapper._target.location.index
                 ),
                 delay=wrapper.delay))),
     ]

--- a/traitsui/testing/tester/wx/implementation/enum_editor.py
+++ b/traitsui/testing/tester/wx/implementation/enum_editor.py
@@ -28,8 +28,8 @@ class _IndexedListEditor(_BaseSourceWithLocation):
     locator_class = locator.Index
     handlers = [
         (command.MouseClick, (lambda wrapper, _: helpers.mouse_click_listbox(
-            control=wrapper.target.source.control,
-            index=wrapper.target.location.index,
+            control=wrapper._target.source.control,
+            index=wrapper._target.location.index,
             delay=wrapper.delay))),
     ]
 
@@ -42,10 +42,10 @@ class _IndexedRadioEditor(_BaseSourceWithLocation):
     handlers = [
         (command.MouseClick,
             (lambda wrapper, _: helpers.mouse_click_radiobutton_child_in_panel(
-                control=wrapper.target.source.control,
+                control=wrapper._target.source.control,
                 index=convert_index(
-                    source=wrapper.target.source,
-                    index=wrapper.target.location.index
+                    source=wrapper._target.source,
+                    index=wrapper._target.location.index
                 ),
                 delay=wrapper.delay))),
     ]
@@ -86,8 +86,8 @@ class _IndexedSimpleEditor(_BaseSourceWithLocation):
     handlers = [
         (command.MouseClick,
             (lambda wrapper, _: helpers.mouse_click_combobox_or_choice(
-                control=wrapper.target.source.control,
-                index=wrapper.target.location.index,
+                control=wrapper._target.source.control,
+                index=wrapper._target.location.index,
                 delay=wrapper.delay))),
     ]
 
@@ -105,7 +105,7 @@ def simple_displayed_selected_text_handler(wrapper, interaction):
         Unused in this function but included to match the expected format of a
         handler.  Should only be query.DisplayedText
     """
-    control = wrapper.target.control
+    control = wrapper._target.control
     if isinstance(control, wx.ComboBox):
         return control.GetValue()
     else:  # wx.Choice
@@ -123,7 +123,7 @@ def radio_selected_text_handler(wrapper, interaction):
         Unused in this function but included to match the expected format of a
         handler.  Should only be query.SelectedText
     """
-    children_list = wrapper.target.control.GetSizer().GetChildren()
+    children_list = wrapper._target.control.GetSizer().GetChildren()
     for child in children_list:
         if child.GetWindow().GetValue():
             return child.GetWindow().GetLabel()
@@ -144,12 +144,12 @@ def register(registry):
     simple_editor_text_handlers = [
         (command.KeyClick,
             (lambda wrapper, interaction: helpers.key_click_combobox(
-                control=wrapper.target.control,
+                control=wrapper._target.control,
                 interaction=interaction,
                 delay=wrapper.delay))),
         (command.KeySequence,
             (lambda wrapper, interaction: helpers.key_sequence_text_ctrl(
-                control=wrapper.target.control,
+                control=wrapper._target.control,
                 interaction=interaction,
                 delay=wrapper.delay))),
         (query.DisplayedText, simple_displayed_selected_text_handler),
@@ -171,6 +171,6 @@ def register(registry):
     registry.register_handler(
         target_class=ListEditor,
         interaction_class=query.SelectedText,
-        handler=lambda wrapper, _: wrapper.target.control.GetString(
-            wrapper.target.control.GetSelection()),
+        handler=lambda wrapper, _: wrapper._target.control.GetString(
+            wrapper._target.control.GetSelection()),
     )

--- a/traitsui/testing/tester/wx/implementation/font_editor.py
+++ b/traitsui/testing/tester/wx/implementation/font_editor.py
@@ -27,5 +27,5 @@ def register(registry):
     register_editable_textbox_handlers(
         registry=registry,
         target_class=TextFontEditor,
-        widget_getter=lambda wrapper: wrapper.target.control,
+        widget_getter=lambda wrapper: wrapper._target.control,
     )

--- a/traitsui/testing/tester/wx/implementation/instance_editor.py
+++ b/traitsui/testing/tester/wx/implementation/instance_editor.py
@@ -54,7 +54,7 @@ def register(registry):
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=lambda wrapper, _: mouse_click_button(
-            control=wrapper.target._button, delay=wrapper.delay,
+            control=wrapper._target._button, delay=wrapper.delay,
         )
     )
     register_traitsui_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)

--- a/traitsui/testing/tester/wx/implementation/list_editor.py
+++ b/traitsui/testing/tester/wx/implementation/list_editor.py
@@ -28,8 +28,8 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
     handlers = [
         (command.MouseClick,
             (lambda wrapper, _: helpers.mouse_click_notebook_tab_index(
-                control=wrapper.target.source.control,
-                index=wrapper.target.location.index,
+                control=wrapper._target.source.control,
+                index=wrapper._target.location.index,
                 delay=wrapper.delay))),
     ]
 

--- a/traitsui/testing/tester/wx/implementation/range_editor.py
+++ b/traitsui/testing/tester/wx/implementation/range_editor.py
@@ -42,16 +42,16 @@ def register(registry):
             target_class=target_class,
             locator_class=locator.Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
-                textbox=wrapper.target.control.text),
+                textbox=wrapper._target.control.text),
         )
         registry.register_solver(
             target_class=target_class,
             locator_class=locator.Slider,
             solver=lambda wrapper, _: LocatedSlider(
-                slider=wrapper.target.control.slider),
+                slider=wrapper._target.control.slider),
         )
     registry_helper.register_editable_textbox_handlers(
         registry=registry,
         target_class=RangeTextEditor,
-        widget_getter=lambda wrapper: wrapper.target.control,
+        widget_getter=lambda wrapper: wrapper._target.control,
     )

--- a/traitsui/testing/tester/wx/implementation/text_editor.py
+++ b/traitsui/testing/tester/wx/implementation/text_editor.py
@@ -35,14 +35,14 @@ def readonly_displayed_text_handler(wrapper, interaction):
     wx Readonly Editors occassionally use wx.TextCtrl as their control, and
     other times use wx.StaticText.
     '''
-    if isinstance(wrapper.target.control, wx.TextCtrl):
-        return wrapper.target.control.GetValue()
-    elif isinstance(wrapper.target.control, wx.StaticText):
-        return wrapper.target.control.GetLabel()
+    if isinstance(wrapper._target.control, wx.TextCtrl):
+        return wrapper._target.control.GetValue()
+    elif isinstance(wrapper._target.control, wx.StaticText):
+        return wrapper._target.control.GetLabel()
     raise TypeError("readonly_displayed_text_handler expected a UIWrapper with"
                     " a ReadonlyEditor as a target. ReadonlyEditor control"
                     " should always be either wx.TextCtrl, or wx.StaticText."
-                    " {} was found".format(wrapper.target.control))
+                    " {} was found".format(wrapper._target.control))
 
 
 def register(registry):
@@ -59,7 +59,7 @@ def register(registry):
         register_editable_textbox_handlers(
             registry=registry,
             target_class=target_class,
-            widget_getter=lambda wrapper: wrapper.target.control,
+            widget_getter=lambda wrapper: wrapper._target.control,
         )
 
     registry.register_handler(

--- a/traitsui/testing/tester/wx/implementation/ui_base.py
+++ b/traitsui/testing/tester/wx/implementation/ui_base.py
@@ -28,11 +28,11 @@ def register(registry):
         target_class=ButtonEditor,
         interaction_class=command.MouseClick,
         handler=(lambda wrapper, _: helpers.mouse_click_button(
-                 control=wrapper.target.control, delay=wrapper.delay))
+                 control=wrapper._target.control, delay=wrapper.delay))
     )
 
     registry.register_handler(
         target_class=ButtonEditor,
         interaction_class=query.DisplayedText,
-        handler=lambda wrapper, _: wrapper.target.control.GetLabel()
+        handler=lambda wrapper, _: wrapper._target.control.GetLabel()
     )

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -347,8 +347,8 @@ class TestRadioEnumEditor(unittest.TestCase):
                     self.assertEqual(enum_edit.value, "one")
                     radio_editor = tester.find_by_name(ui, "value")
                     if is_qt():
-                        radio_editor.target.row_major = row_major
-                        radio_editor.target.rebuild_editor()
+                        radio_editor._target.row_major = row_major
+                        radio_editor._target.rebuild_editor()
                     item = radio_editor.locate(locator.Index(3))
                     item.perform(command.MouseClick())
                     self.assertEqual(enum_edit.value, "four")

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -35,7 +35,7 @@ def _register_simple_spin(registry):
     registry_helper.register_editable_textbox_handlers(
         registry=registry,
         target_class=SimpleSpinEditor,
-        widget_getter=lambda wrapper: wrapper.target.control.lineEdit(),
+        widget_getter=lambda wrapper: wrapper._target.control.lineEdit(),
     )
 
 


### PR DESCRIPTION
fixes #1249 
This pr replaces UIWrapper.target with UIWrapper._target. I also tried to make the change where appropriate in the documentation (in docstrings). 

Note this may cause some currently open PRs to have test failures (e.g. #1243).  They will simply need to update and uses of .target to ._target, which should be an easy fix.