### PR TITLE
adding UI Tester test/example for InstanceEditor_demo.py

### DIFF
--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -467,3 +467,10 @@ class TestInteractExample(unittest.TestCase):
             name.perform(command.KeySequence("ABC"))
             name.perform(command.KeyClick("Enter"))
             self.assertEqual(demo.sample_instance.name, "ABC")
+
+            demo.sample_instance.name = "XYZ"
+            simple_displayed = name.inspect(query.DisplayedText())
+            custom_name = custom.find_by_name("name")
+            custom_displayed = custom_name.inspect(query.DisplayedText())
+            self.assertEqual(simple_displayed, "XYZ")
+            self.assertEqual(custom_displayed, "XYZ")

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -445,3 +445,25 @@ class TestInteractExample(unittest.TestCase):
             self.assertEqual(demo.checklist, ["three"])
             item3.perform(command.MouseClick())
             self.assertEqual(demo.checklist, [])
+
+    def test_instance_editor_demo(self):
+        # Test InstanceEditor_demo.py in examples/demo/Standard_Edtiors
+        filepath = os.path.join(
+            DEMO, "Standard_Editors", "InstanceEditor_demo.py"
+        )
+        demo = load_demo(filepath, "demo")
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            simple = tester.find_by_id(ui, "simple")
+            custom = tester.find_by_id(ui, "custom")
+            occupation = custom.find_by_name("occupation")
+            occupation.perform(command.KeySequence("Job"))
+            occupation.perform(command.KeyClick("Enter"))
+            self.assertEqual(demo.sample_instance.occupation, "Job")
+
+            simple.perform(command.MouseClick())
+            name = simple.find_by_name("name")
+            name.perform(command.KeySequence("ABC"))
+            name.perform(command.KeyClick("Enter"))
+            self.assertEqual(demo.sample_instance.name, "ABC")

--- a/traitsui/examples/demo/Standard_Editors/InstanceEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/InstanceEditor_demo.py
@@ -54,9 +54,9 @@ class InstanceEditorDemo(HasTraits):
 
     # Items are used to define the demo display, one item per editor style:
     inst_group = Group(
-        Item('sample_instance', style='simple', label='Simple'),
+        Item('sample_instance', style='simple', label='Simple', id="simple"),
         Item('_'),
-        Item('sample_instance', style='custom', label='Custom'),
+        Item('sample_instance', style='custom', label='Custom', id="custom"),
         Item('_'),
         Item('sample_instance', style='text', label='Text'),
         Item('_'),


### PR DESCRIPTION
part of #1220 

This PR adds a very simply test for the instance editor demo.  
One thing to note, I originally intended to test by using the simple style first and then custom.  However, once the tester clicks on the button for the simple style and the new ui for the instance pops up, I don't believe we currently have a way to close that ui.  Might be something we eventually want to add