### PR TITLE
Implement load_tests to load and run tests from the demo folder(s)

### DIFF
--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -308,6 +308,45 @@ def load_demo(file_path, variable_name="demo"):
 
 
 # =============================================================================
+# load_tests protocol for unittest discover
+# =============================================================================
+
+
+def load_tests(loader, tests, pattern):
+    """ Implement load_tests protocol so that when unittest discover is run
+    with this test module, the tests in the demo folder (not a package) are
+    also loaded.
+
+    See unittest documentation on load_tests
+    """
+    # Keep all the other loaded tests.
+    suite = unittest.TestSuite()
+    suite.addTests(tests)
+
+    # Expand the test suite with tests from the examples, assuming
+    # the test for ``group/script.py`` is placed in ``group/tests/`` directory.
+    accepted_files, _ = SEARCHER.get_python_files()
+    test_dirs = set(
+        os.path.join(os.path.dirname(path), "tests") for path in accepted_files
+    )
+    test_dirs = set(path for path in test_dirs if os.path.exists(path))
+    for dirpath in sorted(test_dirs):
+
+        # Test files are scripts too and they demonstrate running the
+        # tests. Mock the run side-effect when we load the test cases.
+        with mock.patch.object(unittest.TextTestRunner, "run"):
+            test_suite = unittest.TestLoader().discover(
+                dirpath, pattern=pattern
+            )
+
+        suite.addTests(
+            requires_toolkit([ToolkitName.qt, ToolkitName.wx])(test_suite)
+        )
+
+    return suite
+
+
+# =============================================================================
 # Test cases
 # =============================================================================
 

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -96,12 +96,13 @@ class ExampleSearcher:
 
     @staticmethod
     def _is_python_file(path):
-        """ Return true if the given path is (public) Python file."""
+        """ Return true if the given path is (public) non-test Python file."""
         _, basename = os.path.split(path)
         _, ext = os.path.splitext(basename)
         return (
             ext == ".py"
             and not basename.startswith("_")
+            and not basename.startswith("test_")
         )
 
     def get_python_files(self):

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -339,10 +339,8 @@ def load_tests(loader, tests, pattern):
             test_suite = unittest.TestLoader().discover(
                 dirpath, pattern=pattern
             )
-
-        suite.addTests(
-            requires_toolkit([ToolkitName.qt, ToolkitName.wx])(test_suite)
-        )
+        if is_qt() or is_wx():
+            suite.addTests(test_suite)
 
     return suite
 

--- a/traitsui/examples/demo/Standard_Editors/TextEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/TextEditor_demo.py
@@ -42,13 +42,15 @@ class TextEditorDemo(HasTraits):
 
     # TextEditor display without multi-line capability (for an integer):
     text_int_group = Group(
-        Item('int_trait', style='simple', label='Simple'),
+        Item('int_trait', style='simple', label='Simple', id="simple_int"),
         Item('_'),
-        Item('int_trait', style='custom', label='Custom'),
+        Item('int_trait', style='custom', label='Custom', id="custom_int"),
         Item('_'),
-        Item('int_trait', style='text', label='Text'),
+        Item('int_trait', style='text', label='Text', id="text_int"),
         Item('_'),
-        Item('int_trait', style='readonly', label='ReadOnly'),
+        Item(
+            'int_trait', style='readonly', label='ReadOnly', id="readonly_int",
+        ),
         label='Integer'
     )
 

--- a/traitsui/examples/demo/Standard_Editors/tests/test_TextEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_TextEditor_demo.py
@@ -1,0 +1,61 @@
+"""
+This example demonstrates how to test interacting with a textbox created
+using TextEditor.
+
+The GUI being tested is written in the demo under the same name (minus the
+preceding 'test') in the outer directory.
+"""
+
+import os
+import runpy
+import unittest
+
+# FIXME: Import from api instead
+from traitsui.testing.tester.command import KeyClick, KeySequence
+from traitsui.testing.tester.query import DisplayedText
+from traitsui.testing.tester.ui_tester import UITester
+
+#: Filename of the demo script
+FILENAME = "TextEditor_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestTextEditorDemo(unittest.TestCase):
+
+    def test_run_demo(self):
+        demo = runpy.run_path(DEMO_PATH)["demo"]
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            simple_int_field = tester.find_by_id(ui, "simple_int")
+            custom_int_field = tester.find_by_id(ui, "custom_int")
+            text_int_field = tester.find_by_id(ui, "text_int")
+            readonly_int_field = tester.find_by_id(ui, "readonly_int")
+
+            # Modify the value to something invalid
+            simple_int_field.perform(KeyClick("Backspace"))
+            simple_int_field.perform(KeySequence("a"))  # not a number!
+
+            # Check the value has not changed
+            self.assertEqual(demo.int_trait, 1)
+            self.assertEqual(custom_int_field.inspect(DisplayedText()), "1")
+            self.assertEqual(text_int_field.inspect(DisplayedText()), "1")
+            self.assertEqual(readonly_int_field.inspect(DisplayedText()), "1")
+
+            # Modify the value on the GUI to a good value
+            simple_int_field.perform(KeyClick("Backspace"))
+            simple_int_field.perform(KeySequence("2"))
+
+            # Check
+            self.assertEqual(demo.int_trait, 2)
+            self.assertEqual(custom_int_field.inspect(DisplayedText()), "2")
+            self.assertEqual(text_int_field.inspect(DisplayedText()), "2")
+            self.assertEqual(readonly_int_field.inspect(DisplayedText()), "2")
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestTextEditorDemo)
+)

--- a/traitsui/examples/demo/Standard_Editors/tests/test_TextEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_TextEditor_demo.py
@@ -11,6 +11,7 @@ import runpy
 import unittest
 
 # FIXME: Import from api instead
+# enthought/traitsui#1173
 from traitsui.testing.tester.command import KeyClick, KeySequence
 from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester.ui_tester import UITester


### PR DESCRIPTION
This PR implements the `load_tests` protocol so that we can add tests to the nonpackage folders, e.g. inside `traitsui/examples/demo`, e.g. `traitsui/examples/demo/Standard_Editors/tests/test_TextEditor_demo.py`

- Implements `load_tests` in `test_all_examples` to load addition tests from the nonpackage folder containing demos
- Add a test in the examples/demo folder to demonstrate this works.  I can remove it. It is only added to test the load_tests and because otherwise the load_tests logic would be unused.

The test added can be run on etsdemo too. The GUI will appear for a short while as a script is always run as soon as the user clicks on it (not sure if it is desirable, but that's orthogonal).

![Screenshot 2020-09-22 at 11 49 30](https://user-images.githubusercontent.com/3673984/93873501-b3990f00-fcc9-11ea-93fa-8621b53239d3.png)
