### PR TITLE
Use current package in default_registry.py instead of hard coded path when locating toolkit specific default_registry module

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/default_registry.py
@@ -35,9 +35,10 @@ def get_default_registry():
         registry = TargetRegistry()
     else:
         toolkit = {'wx': 'wx', 'qt4': 'qt4', 'qt': 'qt4'}[ETSConfig.toolkit]
+        this_package, _ = __name__.rsplit(".", 1)
         module = importlib.import_module(
             ".default_registry",
-            "traitsui.testing.tester._ui_tester_registry." + toolkit)
+            this_package + '.' + toolkit)
         registry = module.get_default_registry()
     register_traitsui_ui_solvers(
         registry=registry,


### PR DESCRIPTION
This is a very short PR to address the issue that was brought up here: https://github.com/enthought/traitsui/pull/1264#discussion_r493637964

