### PR TITLE
UI Tester update List Editor implementation to not only work with nested uis

### DIFF
--- a/traitsui/examples/demo/Standard_Editors/ListEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/ListEditor_demo.py
@@ -21,13 +21,13 @@ class ListEditorDemo(HasTraits):
 
     # Items are used to define display, one per editor style:
     list_group = Group(
-        Item('play_list', style='simple', label='Simple', height=75),
+        Item('play_list', style='simple', label='Simple', height=75, id='simple'),
         Item('_'),
-        Item('play_list', style='custom', label='Custom'),
+        Item('play_list', style='custom', label='Custom', id='custom'),
         Item('_'),
-        Item('play_list', style='text', label='Text'),
+        Item('play_list', style='text', label='Text', id='text'),
         Item('_'),
-        Item('play_list', style='readonly', label='ReadOnly')
+        Item('play_list', style='readonly', label='ReadOnly', id='readonly')
     )
 
     # Demo view:

--- a/traitsui/examples/demo/Standard_Editors/tests/test_ListEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_ListEditor_demo.py
@@ -34,8 +34,10 @@ class TestListEditorDemo(unittest.TestCase):
                 item1.perform(command.KeyClick("Backspace"))
             item1.perform(command.KeySequence("Othello"))
             item1.perform(command.KeyClick("Enter"))
-            self.assertEqual(demo.play_list,
-                ["The Merchant of Venice", "Othello", "MacBeth"])
+            self.assertEqual(
+                demo.play_list,
+                ["The Merchant of Venice", "Othello", "MacBeth"]
+            )
 
 
 # Run the test(s)

--- a/traitsui/examples/demo/Standard_Editors/tests/test_ListEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_ListEditor_demo.py
@@ -1,0 +1,44 @@
+"""
+This example demonstrates how to test interacting with a ListEditor.
+
+The GUI being tested is written in the demo under the same name (minus the
+preceding 'test') in the outer directory.
+"""
+
+import os
+import runpy
+import unittest
+
+# FIXME: Import from api instead
+# enthought/traitsui#1173
+from traitsui.testing.tester import command, locator
+from traitsui.testing.tester.ui_tester import UITester
+
+#: Filename of the demo script
+FILENAME = "ListEditor_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestListEditorDemo(unittest.TestCase):
+
+    def test_list_editor_demo(self):
+        demo = runpy.run_path(DEMO_PATH)["demo"]
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            custom_list = tester.find_by_id(ui, "custom")
+            item1 = custom_list.locate(locator.Index(1))
+            for _ in range(6):
+                item1.perform(command.KeyClick("Backspace"))
+            item1.perform(command.KeySequence("Othello"))
+            item1.perform(command.KeyClick("Enter"))
+            self.assertEqual(demo.play_list,
+                ["The Merchant of Venice", "Othello", "MacBeth"])
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestListEditorDemo)
+)

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -71,7 +71,7 @@ def _get_next_target(list_editor, index):
     list_editor : CustomEditor
         The custom style list editor in which the target is contained.
     index : int
-        the index of the target of interest in the list 
+        the index of the target of interest in the list
 
     Returns
     -------
@@ -88,6 +88,7 @@ def _get_next_target(list_editor, index):
     if list_editor.scrollable:
         list_editor.control.ensureWidgetVisible(item.widget())
     return item.widget()._editor
+
 
 def register(registry):
     """ Register interactions for the given registry.

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -75,7 +75,8 @@ def _get_next_target(list_editor, index):
 
     Returns
     -------
-    The obtained target.
+    traitsui.editor.Editor
+        The obtained target.
     """
     row, column = divmod(index, list_editor.factory.columns)
     # there are two columns for each list item (one for the item itself,

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -63,48 +63,31 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
         return self.source._uis[self.location.index][1]
 
 
-class _IndexedCustomEditor(_BaseSourceWithLocation):
-    """ Wrapper for a ListEditor (custom) with an index.
+def _get_next_target(list_editor, index):
+    """ Gets the target at a given index from a Custom List Editor.
+
+    Parameters
+    ----------
+    list_editor : CustomEditor
+        The custom style list editor in which the target is contained.
+    index : int
+        the index of the target of interest in the list 
+
+    Returns
+    -------
+    The obtained target.
     """
-    source_class = CustomEditor
-    locator_class = locator.Index
-
-    @classmethod
-    def register(cls, registry):
-        """ Class method to register interactions on a _IndexedCustomEditor
-        for the given registry.
-
-        If there are any conflicts, an error will occur.
-
-        Parameters
-        ----------
-        registry : TargetRegistry
-            The registry being registered to.
-        """
-        super().register(registry)
-        register_traitsui_ui_solvers(
-            registry=registry,
-            target_class=cls,
-            traitsui_ui_getter=lambda target: target._get_nested_ui()
-        )
-
-    def _get_nested_ui(self):
-        """ Method to get the nested ui corresponding to the List element at
-        the given index.
-        """
-        row, column = divmod(self.location.index, self.source.factory.columns)
-        # there are two columns for each list item (one for the item itself,
-        # and another for the list menu button)
-        column = 2*column
-        grid_layout = self.source._list_pane.layout()
-        item = grid_layout.itemAtPosition(row, column)
-        if item is None:
-            raise IndexError(self.location.index)
-        if self.source.scrollable:
-            self.source.control.ensureWidgetVisible(item.widget())
-
-        return item.widget()._editor._ui
-
+    row, column = divmod(index, list_editor.factory.columns)
+    # there are two columns for each list item (one for the item itself,
+    # and another for the list menu button)
+    column = 2*column
+    grid_layout = list_editor._list_pane.layout()
+    item = grid_layout.itemAtPosition(row, column)
+    if item is None:
+        raise IndexError(index)
+    if list_editor.scrollable:
+        list_editor.control.ensureWidgetVisible(item.widget())
+    return item.widget()._editor
 
 def register(registry):
     """ Register interactions for the given registry.
@@ -119,4 +102,10 @@ def register(registry):
     # NotebookEditor
     _IndexedNotebookEditor.register(registry)
     # CustomEditor
-    _IndexedCustomEditor.register(registry)
+    registry.register_solver(
+        target_class=CustomEditor,
+        locator_class=locator.Index,
+        solver=lambda wrapper, location: (
+            _get_next_target(wrapper._target, location.index)
+        )
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -74,7 +74,8 @@ def _get_next_target(list_editor, index):
 
     Returns
     -------
-    The obtained target.
+    traitsui.editor.Editor
+        The obtained target.
     """
     # each list item gets a corresponding ImageControl item (allows one to
     # add items to the list before, after, delete, etc.) along with the

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -62,44 +62,29 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
         return self.source._uis[self.location.index][0].dockable.ui
 
 
-class _IndexedCustomEditor(_BaseSourceWithLocation):
-    """ Wrapper for a ListEditor (custom) with an index.
+def _get_next_target(list_editor, index):
+    """ Gets the target at a given index from a Custom List Editor.
+
+    Parameters
+    ----------
+    list_editor : CustomEditor
+        The custom style list editor in which the target is contained.
+    index : int
+        the index of the target of interest in the list 
+
+    Returns
+    -------
+    The obtained target.
     """
-    source_class = CustomEditor
-    locator_class = locator.Index
-
-    @classmethod
-    def register(cls, registry):
-        """ Class method to register interactions on a _IndexedCustomEditor
-        for the given registry.
-
-        If there are any conflicts, an error will occur.
-
-        Parameters
-        ----------
-        registry : TargetRegistry
-            The registry being registered to.
-        """
-        super().register(registry)
-        register_traitsui_ui_solvers(
-            registry=registry,
-            target_class=cls,
-            traitsui_ui_getter=lambda target: target._get_nested_ui()
-        )
-
-    def _get_nested_ui(self):
-        """ Method to get the nested ui corresponding to the List element at
-        the given index.
-        """
-        # each list item gets a corresponding ImageControl item (allows one to
-        # add items to the list before, after, delete, etc.) along with the
-        # item itself.  Thus, index is actually an index over the odd elements
-        # of the list of children corresponding to items in the list we would
-        # want to interact with
-        new_index = 2*self.location.index + 1
-        WindowList = self.source.control.GetChildren()
-        item = WindowList[new_index]
-        return item._editor._ui
+    # each list item gets a corresponding ImageControl item (allows one to
+    # add items to the list before, after, delete, etc.) along with the
+    # item itself.  Thus, index is actually an index over the odd elements
+    # of the list of children corresponding to items in the list we would
+    # want to interact with
+    new_index = 2*index + 1
+    WindowList = list_editor.control.GetChildren()
+    item = WindowList[new_index]
+    return item._editor
 
 
 def register(registry):
@@ -115,4 +100,10 @@ def register(registry):
     # NotebookEditor
     _IndexedNotebookEditor.register(registry)
     # CustomEditor
-    _IndexedCustomEditor.register(registry)
+    registry.register_solver(
+        target_class=CustomEditor,
+        locator_class=locator.Index,
+        solver=lambda wrapper, location: (
+            _get_next_target(wrapper._target, location.index)
+        )
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -70,7 +70,7 @@ def _get_next_target(list_editor, index):
     list_editor : CustomEditor
         The custom style list editor in which the target is contained.
     index : int
-        the index of the target of interest in the list 
+        the index of the target of interest in the list
 
     Returns
     -------

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -111,9 +111,8 @@ class TestCustomListEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(obj) as ui:
             people_list = tester.find_by_name(ui, "people")
-            item = people_list.locate(locator.Index(10))
             with self.assertRaises(IndexError):
-                item.find_by_name("name")
+                people_list.locate(locator.Index(10))
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])


### PR DESCRIPTION
fixes #1253 

This PR modifies the UI Tester implementation of Custom List Editor so that it works with Lists of objects that don't have nested UIs (e.g. just a list of Strings).  It does so by the means described on issue 1253 and here: https://github.com/enthought/traitsui/pull/1252#issuecomment-696385370
