### PR TITLE
Populating the traitsui.testing.api module

### DIFF
--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -8,3 +8,32 @@
 #
 #  Thanks for using Enthought open source!
 #
+from .tester.command import (
+    MouseClick,
+    KeyClick,
+    KeySequence
+)
+
+from .tester.exceptions import (
+    Disabled,
+    InteractionNotSupported,
+    LocationNotSupported,
+    TesterError
+)
+
+from .tester.locator import (
+    Index,
+    TargetById,
+    TargetByName,
+    Textbox,
+    Slider
+)
+
+from .tester.registry import TargetRegistry
+
+from .tester.query import (
+    DisplayedText,
+    SelectedText
+)
+
+from .tester.ui_tester import UITester


### PR DESCRIPTION
Part of #1173 

Note to keep this PR small and easier to review, this PR simply adds the import statements to `traitsui.testing.api.py`.  It does not change any other code to actually use the api (see the fifth bullet on 1173). These changes will be made in a separate PR after this is merged.  

I don't believe anything else belongs in the api atm?  One thing I wasn't sure about was if `UIWrapper` should be included, but I could not think of a case where a user would need a wrapper separate from having a UITester.  In all the test code we have written so far we never needed to import `UIWrapper`.  However, I very well may be wrong and it can easily be added here. 