### PR TITLE
Remove trait change exception handler in reraise_exceptions

### DIFF
--- a/traitsui/qt4/tests/test_tabular_model.py
+++ b/traitsui/qt4/tests/test_tabular_model.py
@@ -19,6 +19,7 @@ from traitsui.api import Item, TabularEditor, View
 from traitsui.tabular_adapter import TabularAdapter
 
 from traitsui.tests._tools import (
+    BaseTestMixin,
     create_ui,
     is_qt,
     requires_toolkit,
@@ -50,7 +51,13 @@ def get_view(adapter):
 
 
 @requires_toolkit([ToolkitName.qt])
-class TestTabularModel(unittest.TestCase):
+class TestTabularModel(BaseTestMixin, unittest.TestCase):
+
+    def setUp(self):
+        BaseTestMixin.setUp(self)
+
+    def tearDown(self):
+        BaseTestMixin.tearDown(self)
 
     def test_drop_mime_data_below_list(self):
         # Test dragging an item in the list and drop it below the last item

--- a/traitsui/testing/_exception_handling.py
+++ b/traitsui/testing/_exception_handling.py
@@ -14,11 +14,6 @@ import logging
 import sys
 import traceback
 
-from traits.api import (
-    pop_exception_handler,
-    push_exception_handler,
-)
-
 _TRAITSUI_LOGGER = logging.getLogger("traitsui")
 
 
@@ -62,22 +57,11 @@ def reraise_exceptions(logger=_TRAITSUI_LOGGER):
             serialized[-1]
         )
 
-    def handler(object, name, old, new):
-        type, value, tb = sys.exc_info()
-        serialized_exceptions.append(_serialize_exception(type, value, tb))
-        logger.exception(
-            "Unexpected error occurred from change handler "
-            "(object: %r, name: %r, old: %r, new: %r).",
-            object, name, old, new,
-        )
-
-    push_exception_handler(handler=handler)
     sys.excepthook = excepthook
     try:
         yield
     finally:
         sys.excepthook = sys.__excepthook__
-        pop_exception_handler()
         if serialized_exceptions:
             msg = "Uncaught exceptions found.\n"
             msg += "\n".join(

--- a/traitsui/testing/_exception_handling.py
+++ b/traitsui/testing/_exception_handling.py
@@ -34,8 +34,6 @@ def reraise_exceptions(logger=_TRAITSUI_LOGGER):
     """ Context manager to capture all exceptions occurred in the context and
     then reraise a RuntimeError if there are any exceptions captured.
 
-    Exceptions from traits change notifications are also captured and reraised.
-
     Depending on the GUI toolkit backend, unexpected exceptions occurred in the
     GUI event loop may (1) cause fatal early exit of the test suite or (2) be
     printed to the console without causing the test to error. This context

--- a/traitsui/testing/tests/test_exception_handling.py
+++ b/traitsui/testing/tests/test_exception_handling.py
@@ -15,7 +15,6 @@ import unittest
 
 from pyface.api import GUI
 
-from traits.api import HasTraits, Int
 from traitsui.tests._tools import (
     requires_toolkit,
     ToolkitName,

--- a/traitsui/testing/tests/test_exception_handling.py
+++ b/traitsui/testing/tests/test_exception_handling.py
@@ -53,22 +53,3 @@ class TestExceptionHandling(unittest.TestCase):
         log_content1, log_content2 = watcher.output
         self.assertIn("ZeroDivisionError", log_content1)
         self.assertIn("IndexError", log_content2)
-
-    def test_error_from_trait_change_captured(self):
-
-        class Foo(HasTraits):
-            value = Int()
-
-            def _value_changed(self):
-                raise ZeroDivisionError()
-
-        obj = Foo()
-        with self.assertRaises(RuntimeError) as exception_context, \
-                self.assertLogs("traitsui") as watcher:
-            with reraise_exceptions():
-                obj.value = 2
-
-        error_msg = str(exception_context.exception)
-        self.assertIn("ZeroDivisionError", error_msg)
-        log_content, = watcher.output
-        self.assertIn("ZeroDivisionError", log_content)


### PR DESCRIPTION
Closes #1232
(Part of #1173)

This PR
- Removes setting trait change exception handler in `reraise_exceptions`.
- Apply `BaseTestMixin` to one more test case that would have lost the setting if this wasn't done before/when `reraise_exceptions` lost this behaviour. Most of the other test cases that need this should have received the treatment from #1266.
(I missed this one test case there. 😞   I searched for these test cases by finding all references to `reraise_exceptions`, but I overlooked `traitsui.qt4.tests` package back then.)
