### PR TITLE
TST: Expand test for ButtonEditor to handle enabled/disabled button

### DIFF
--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -1,6 +1,6 @@
 import unittest
 
-from traits.api import Button, HasTraits, List, Str
+from traits.api import Bool, Button, HasTraits, List, Str
 from traits.testing.api import UnittestTools
 from traitsui.api import ButtonEditor, Item, UItem, View
 from traitsui.tests._tools import (
@@ -20,6 +20,8 @@ class ButtonTextEdit(HasTraits):
     play_button_label = Str("I'm a play button")
 
     values = List()
+
+    button_enabled = Bool(True)
 
     traits_view = View(
         Item("play_button", style="simple"),
@@ -96,13 +98,15 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         self.check_button_fired_event(custom_view)
 
     def check_button_disabled(self, style):
-        button_text_edit = ButtonTextEdit()
+        button_text_edit = ButtonTextEdit(
+            button_enabled=False,
+        )
 
         view = View(
             Item(
                 "play_button",
                 editor=ButtonEditor(),
-                enabled_when="False",
+                enabled_when="button_enabled",
                 style=style,
             ),
         )
@@ -112,6 +116,11 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
 
             with self.assertTraitDoesNotChange(
                     button_text_edit, "play_button"):
+                button.perform(command.MouseClick())
+
+            button_text_edit.button_enabled = True
+            with self.assertTraitChanges(
+                    button_text_edit, "play_button", count=1):
                 button.perform(command.MouseClick())
 
     def test_simple_button_editor_disabled(self):

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -95,6 +95,31 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
     def test_custom_button_editor_clicked(self):
         self.check_button_fired_event(custom_view)
 
+    def check_button_disabled(self, style):
+        button_text_edit = ButtonTextEdit()
+
+        view = View(
+            Item(
+                "play_button",
+                editor=ButtonEditor(),
+                enabled_when="False",
+                style=style,
+            ),
+        )
+        tester = UITester()
+        with tester.create_ui(button_text_edit, dict(view=view)) as ui:
+            button = tester.find_by_name(ui, "play_button")
+
+            with self.assertTraitDoesNotChange(
+                    button_text_edit, "play_button"):
+                button.perform(command.MouseClick())
+
+    def test_simple_button_editor_disabled(self):
+        self.check_button_disabled("simple")
+
+    def test_custom_button_editor_disabled(self):
+        self.check_button_disabled("custom")
+
 
 @requires_toolkit([ToolkitName.qt])
 class TestButtonEditorValuesTrait(BaseTestMixin, unittest.TestCase):


### PR DESCRIPTION
This PR adds a test for ButtonEditor to verify that a button is disabled when the `enabled_when` flag results in a falsey value.

(This is motivated by wanting to get more test coverage for `traitsui.testing`, e.g. this [line](https://github.com/enthought/traitsui/blob/815cfb074cbf6063178e8607c37cb0638a30fbee/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py#L34)).