### PR TITLE
Remove codecov badge and submission of coverage from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,6 @@ script:
   - pushd ets-demo && edm run -- python etstool.py flake8 --runtime=${RUNTIME} --toolkit=${toolkit} && popd
   - pushd ets-demo && for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done && popd
 
-after_success:
-  - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov
-
 notifications:
   slack:
     secure: yOeqCtSnSSlchM7zMKcy6UrSlHSzqUgaqrDCbGC06A8lKjBVLPfJ8+xc1fZuxPBHhqf6WJ+V1lbZUJB+XaWRwiRyKXWI6+GMagV5eVdX5FUdqAqQALMyLZx1ih3tJFsh+JGfEEat0Gd/zDIToDJC4SWwxMNCfihozkCPqgGA9tw=

--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,6 @@ TraitsUI: Traits-capable windowing framework
 .. image:: https://ci.appveyor.com/api/projects/status/n2qy8kcwh8ibi9g3/branch/master?svg=true
    :target: https://ci.appveyor.com/project/EnthoughtOSS/traitsui/branch/master
 
-.. image:: https://codecov.io/github/enthought/traitsui/coverage.svg?branch=master
-   :target: https://codecov.io/github/enthought/traitsui?branch=master
-
 The TraitsUI project contains a toolkit-independent GUI abstraction layer,
 which is used to support the "visualization" features of the
 `Traits <http://github.com/enthought/traits>`__ package.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,3 @@ install:
 test_script:
   - sh: edm run -- python etstool.py test --runtime="${RUNTIME}" --toolkit="${TOOLKIT}"
   - cmd: edm run -- python etstool.py test --runtime=%RUNTIME% --toolkit=%toolkit%
-on_success:
-  - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov


### PR DESCRIPTION
The current test coverage for the code base is 60% (after combining coverage from Qt and Wx, running from an OSX machine with Python 3.6).  However the codecov badge is showing 30+%, that is misleading.
The codecov report is unlikely to useful either. See similar issue on Traits: https://github.com/enthought/traits/issues/919

This PR:
- Remove the misleading coverage badge from README
- Remove scripts to submit coverage from CI

~Unverified:~(edited) I believe the discrepancy is caused by the fact that the wx CI job is still failing (which should be fixed), the test coverage from wx build is therefore not submitted for the combined statistics.