### PR TITLE
Update UI Tester demo examples to import from traitsui.testing.api

### DIFF
--- a/traitsui/examples/demo/Advanced/tests/test_List_editor_notebook_selection_demo.py
+++ b/traitsui/examples/demo/Advanced/tests/test_List_editor_notebook_selection_demo.py
@@ -10,10 +10,7 @@ import os
 import runpy
 import unittest
 
-# FIXME: Import from api instead
-# enthought/traitsui#1173
-from traitsui.testing.tester import command, locator
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import Index, KeyClick, MouseClick, UITester
 
 #: Filename of the demo script
 FILENAME = "List_editor_notebook_selection_demo.py"
@@ -30,12 +27,12 @@ class TestListEditorNotebookSelectionDemo(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(demo) as ui:
             people_list = tester.find_by_name(ui, "people")
-            person2 = people_list.locate(locator.Index(2))
-            person2.perform(command.MouseClick())
+            person2 = people_list.locate(Index(2))
+            person2.perform(MouseClick())
             self.assertEqual(demo.index, 2)
             age = person2.find_by_name("age")
-            age.perform(command.KeyClick("Backspace"))
-            age.perform(command.KeyClick("9"))
+            age.perform(KeyClick("Backspace"))
+            age.perform(KeyClick("9"))
             self.assertEqual(demo.people[2].age, 39)
 
 

--- a/traitsui/examples/demo/Applications/tests/test_converter.py
+++ b/traitsui/examples/demo/Applications/tests/test_converter.py
@@ -9,10 +9,9 @@ import os
 import runpy
 import unittest
 
-# FIXME: Import from api instead
-# enthought/traitsui#1173
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText, KeyClick, KeySequence, MouseClick, UITester
+)
 
 #: Filename of the demo script
 FILENAME = "converter.py"
@@ -29,15 +28,15 @@ class TestConverter(unittest.TestCase):
             input_amount = tester.find_by_name(ui, "input_amount")
             output_amount = tester.find_by_name(ui, "output_amount")
             for _ in range(4):
-                input_amount.perform(command.KeyClick("Backspace"))
-            input_amount.perform(command.KeySequence("14.0"))
+                input_amount.perform(KeyClick("Backspace"))
+            input_amount.perform(KeySequence("14.0"))
             self.assertEqual(
-                output_amount.inspect(query.DisplayedText())[:4],
+                output_amount.inspect(DisplayedText())[:4],
                 "1.16",
             )
-            tester.find_by_id(ui, "Undo").perform(command.MouseClick())
+            tester.find_by_id(ui, "Undo").perform(MouseClick())
             self.assertEqual(
-                output_amount.inspect(query.DisplayedText()),
+                output_amount.inspect(DisplayedText()),
                 "1.0",
             )
 

--- a/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_demo.py
@@ -16,8 +16,7 @@ from pyface.toolkit import toolkit_object
 from pyface.constant import OK
 # FIXME: Import from api instead
 # enthought/traitsui#1173
-from traitsui.testing.api import MouseClick
-from traitsui.testing.api import UITester
+from traitsui.testing.api import MouseClick, UITester
 
 ModalDialogTester = toolkit_object(
     "util.modal_dialog_tester:ModalDialogTester"

--- a/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_demo.py
@@ -14,8 +14,7 @@ import unittest
 
 from pyface.toolkit import toolkit_object
 from pyface.constant import OK
-# FIXME: Import from api instead
-# enthought/traitsui#1173
+
 from traitsui.testing.api import MouseClick, UITester
 
 ModalDialogTester = toolkit_object(

--- a/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_demo.py
@@ -16,8 +16,8 @@ from pyface.toolkit import toolkit_object
 from pyface.constant import OK
 # FIXME: Import from api instead
 # enthought/traitsui#1173
-from traitsui.testing.tester import command
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import MouseClick
+from traitsui.testing.api import UITester
 
 ModalDialogTester = toolkit_object(
     "util.modal_dialog_tester:ModalDialogTester"
@@ -47,10 +47,10 @@ class TestButtonEditorDemo(unittest.TestCase):
             # function that opens the dialog
             # we want clicking the buttons to do that
             def click_simple_button():
-                simple_button.perform(command.MouseClick())
+                simple_button.perform(MouseClick())
 
             def click_custom_button():
-                custom_button.perform(command.MouseClick())
+                custom_button.perform(MouseClick())
 
             mdtester_simple = ModalDialogTester(click_simple_button)
             mdtester_simple.open_and_run(lambda x: x.click_button(OK))

--- a/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_simple_demo.py
@@ -10,8 +10,6 @@ import os
 import runpy
 import unittest
 
-# FIXME: Import from api instead
-# enthought/traitsui#1173
 from traitsui.testing.api import DisplayedText, MouseClick, UITester
 
 #: Filename of the demo script

--- a/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_ButtonEditor_simple_demo.py
@@ -12,8 +12,7 @@ import unittest
 
 # FIXME: Import from api instead
 # enthought/traitsui#1173
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import DisplayedText, MouseClick, UITester
 
 #: Filename of the demo script
 FILENAME = "ButtonEditor_simple_demo.py"
@@ -31,15 +30,15 @@ class TestButtonEditorSimpleDemo(unittest.TestCase):
         with tester.create_ui(demo) as ui:
             button = tester.find_by_name(ui, "my_button_trait")
             for index in range(5):
-                button.perform(command.MouseClick())
+                button.perform(MouseClick())
                 self.assertEqual(demo.click_counter, index + 1)
 
             click_counter = tester.find_by_name(ui, "click_counter")
-            displayed_count = click_counter.inspect(query.DisplayedText())
+            displayed_count = click_counter.inspect(DisplayedText())
             self.assertEqual(displayed_count, '5')
 
             demo.click_counter = 10
-            displayed_count = click_counter.inspect(query.DisplayedText())
+            displayed_count = click_counter.inspect(DisplayedText())
             self.assertEqual(displayed_count, '10')
 
 

--- a/traitsui/examples/demo/Standard_Editors/tests/test_CheckListEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_CheckListEditor_simple_demo.py
@@ -12,8 +12,7 @@ import unittest
 
 # FIXME: Import from api instead
 # enthought/traitsui#1173
-from traitsui.testing.tester import command, locator
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import Index, MouseClick, UITester
 
 #: Filename of the demo script
 FILENAME = "CheckListEditor_simple_demo.py"
@@ -30,10 +29,10 @@ class TestCheckListEditorSimpleDemo(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(demo) as ui:
             checklist = tester.find_by_id(ui, "custom")
-            item3 = checklist.locate(locator.Index(2))
-            item3.perform(command.MouseClick())
+            item3 = checklist.locate(Index(2))
+            item3.perform(MouseClick())
             self.assertEqual(demo.checklist, ["three"])
-            item3.perform(command.MouseClick())
+            item3.perform(MouseClick())
             self.assertEqual(demo.checklist, [])
 
 

--- a/traitsui/examples/demo/Standard_Editors/tests/test_CheckListEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_CheckListEditor_simple_demo.py
@@ -10,8 +10,6 @@ import os
 import runpy
 import unittest
 
-# FIXME: Import from api instead
-# enthought/traitsui#1173
 from traitsui.testing.api import Index, MouseClick, UITester
 
 #: Filename of the demo script

--- a/traitsui/examples/demo/Standard_Editors/tests/test_EnumEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_EnumEditor_demo.py
@@ -10,8 +10,6 @@ import os
 import runpy
 import unittest
 
-# FIXME: Import from api instead
-# enthought/traitsui#1173
 from traitsui.testing.api import (
     DisplayedText,
     Index,

--- a/traitsui/examples/demo/Standard_Editors/tests/test_EnumEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_EnumEditor_demo.py
@@ -12,8 +12,15 @@ import unittest
 
 # FIXME: Import from api instead
 # enthought/traitsui#1173
-from traitsui.testing.tester import command, locator, query
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText,
+    Index,
+    KeyClick,
+    KeySequence,
+    MouseClick,
+    SelectedText,
+    UITester
+)
 
 #: Filename of the demo script
 FILENAME = "EnumEditor_demo.py"
@@ -37,35 +44,35 @@ class TestEnumEditorDemo(unittest.TestCase):
             readonly = tester.find_by_id(ui, "readonly")
 
             self.assertEqual(demo.name_list, 'A-495')
-            simple_enum.locate(locator.Index(1)).perform(command.MouseClick())
+            simple_enum.locate(Index(1)).perform(MouseClick())
             self.assertEqual(demo.name_list, 'A-498')
 
             for _ in range(5):
-                simple_text_enum.perform(command.KeyClick("Backspace"))
-            simple_text_enum.perform(command.KeySequence("R-1226"))
-            simple_text_enum.perform(command.KeyClick("Enter"))
+                simple_text_enum.perform(KeyClick("Backspace"))
+            simple_text_enum.perform(KeySequence("R-1226"))
+            simple_text_enum.perform(KeyClick("Enter"))
             self.assertEqual(demo.name_list, 'R-1226')
 
-            radio_enum.locate(locator.Index(5)).perform(command.MouseClick())
+            radio_enum.locate(Index(5)).perform(MouseClick())
             self.assertEqual(demo.name_list, 'Foo')
 
-            list_enum.locate(locator.Index(3)).perform(command.MouseClick())
+            list_enum.locate(Index(3)).perform(MouseClick())
             self.assertEqual(demo.name_list, 'TS-17')
 
             for _ in range(5):
-                text.perform(command.KeyClick("Backspace"))
-            text.perform(command.KeySequence("A-498"))
-            text.perform(command.KeyClick("Enter"))
+                text.perform(KeyClick("Backspace"))
+            text.perform(KeySequence("A-498"))
+            text.perform(KeyClick("Enter"))
             self.assertEqual(demo.name_list, 'A-498')
 
             demo.name_list = 'Foo'
 
-            displayed_simple = simple_enum.inspect(query.DisplayedText())
-            disp_simple_text = simple_text_enum.inspect(query.DisplayedText())
-            selected_radio = radio_enum.inspect(query.SelectedText())
-            selected_list = list_enum.inspect(query.SelectedText())
-            displayed_text = text.inspect(query.DisplayedText())
-            displayed_readonly = readonly.inspect(query.DisplayedText())
+            displayed_simple = simple_enum.inspect(DisplayedText())
+            disp_simple_text = simple_text_enum.inspect(DisplayedText())
+            selected_radio = radio_enum.inspect(SelectedText())
+            selected_list = list_enum.inspect(SelectedText())
+            displayed_text = text.inspect(DisplayedText())
+            displayed_readonly = readonly.inspect(DisplayedText())
 
             displayed_selected = [
                 displayed_simple, disp_simple_text, selected_radio,

--- a/traitsui/examples/demo/Standard_Editors/tests/test_InstanceEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_InstanceEditor_demo.py
@@ -10,8 +10,6 @@ import os
 import runpy
 import unittest
 
-# FIXME: Import from api instead
-# enthought/traitsui#1173
 from traitsui.testing.api import (
     DisplayedText, KeyClick, KeySequence, MouseClick, UITester
 )

--- a/traitsui/examples/demo/Standard_Editors/tests/test_InstanceEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_InstanceEditor_demo.py
@@ -12,8 +12,9 @@ import unittest
 
 # FIXME: Import from api instead
 # enthought/traitsui#1173
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText, KeyClick, KeySequence, MouseClick, UITester
+)
 
 #: Filename of the demo script
 FILENAME = "InstanceEditor_demo.py"
@@ -32,20 +33,20 @@ class TestInstanceEditorDemo(unittest.TestCase):
             simple = tester.find_by_id(ui, "simple")
             custom = tester.find_by_id(ui, "custom")
             occupation = custom.find_by_name("occupation")
-            occupation.perform(command.KeySequence("Job"))
-            occupation.perform(command.KeyClick("Enter"))
+            occupation.perform(KeySequence("Job"))
+            occupation.perform(KeyClick("Enter"))
             self.assertEqual(demo.sample_instance.occupation, "Job")
 
-            simple.perform(command.MouseClick())
+            simple.perform(MouseClick())
             name = simple.find_by_name("name")
-            name.perform(command.KeySequence("ABC"))
-            name.perform(command.KeyClick("Enter"))
+            name.perform(KeySequence("ABC"))
+            name.perform(KeyClick("Enter"))
             self.assertEqual(demo.sample_instance.name, "ABC")
 
             demo.sample_instance.name = "XYZ"
-            simple_displayed = name.inspect(query.DisplayedText())
+            simple_displayed = name.inspect(DisplayedText())
             custom_name = custom.find_by_name("name")
-            custom_displayed = custom_name.inspect(query.DisplayedText())
+            custom_displayed = custom_name.inspect(DisplayedText())
             self.assertEqual(simple_displayed, "XYZ")
             self.assertEqual(custom_displayed, "XYZ")
 

--- a/traitsui/examples/demo/Standard_Editors/tests/test_TextEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_TextEditor_demo.py
@@ -10,11 +10,9 @@ import os
 import runpy
 import unittest
 
-# FIXME: Import from api instead
-# enthought/traitsui#1173
-from traitsui.testing.tester.command import KeyClick, KeySequence
-from traitsui.testing.tester.query import DisplayedText
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText, KeyClick, KeySequence,  UITester
+)
 
 #: Filename of the demo script
 FILENAME = "TextEditor_demo.py"


### PR DESCRIPTION
This fixes the fifth bullet of #1173 

It simply changes the import statements in the current tests of examples in `examples/demo` to import from the now populated `traitsui.testing.api`