### PR TITLE
Rename TargetRegister.register_handler and register_solver

### DIFF
--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -513,7 +513,7 @@ Add Support for Locating a Nested GUI Element
 ---------------------------------------------
 
 Support for |UIWrapper.locate| can be extended by registering additional
-location type and resolution logic via |TargetRegistry.register_solver| on
+location type and resolution logic via |TargetRegistry.register_location| on
 a |TargetRegistry|.
 
 Suppose we have a custom UI editor that contains some buttons. The objective of
@@ -554,14 +554,14 @@ label can be written like this::
 The solvers can then be registered for the container UI target::
 
     registry = TargetRegistry()
-    registry.register_solver(
+    registry.register_location(
         target_class=ShinyPanel,
         locator_class=NamedButton,
         solver=get_button,
     )
 
 Similar to |TargetRegistry.register_handler|, the signature of
-``get_button`` is required by the |TargetRegistry.register_solver|
+``get_button`` is required by the |TargetRegistry.register_location|
 method. By setting the ``target_class`` and ``locator_class``, we restrict the
 types of ``wrapper._target`` and ``location`` received by ``get_button``
 respectively.
@@ -620,7 +620,7 @@ interaction handler and/or location solver via an instance of
 
 .. |TargetRegistry| replace:: :class:`~traitsui.testing.tester.registry.TargetRegistry`
 .. |TargetRegistry.register_handler| replace:: :func:`~traitsui.testing.tester.registry.TargetRegistry.register_handler`
-.. |TargetRegistry.register_solver| replace:: :class:`~traitsui.testing.tester.registry.TargetRegistry.register_solver`
+.. |TargetRegistry.register_location| replace:: :class:`~traitsui.testing.tester.registry.TargetRegistry.register_location`
 
 .. |UITester| replace:: :class:`~traitsui.testing.tester.ui_tester.UITester`
 .. |UITester.create_ui| replace:: :func:`~traitsui.testing.tester.ui_tester.UITester.create_ui`

--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -419,7 +419,7 @@ Add Support for Performing a User Interaction
 ---------------------------------------------
 
 Support for |UIWrapper.perform| can be extended by registering additional
-interaction type and handling logic via |TargetRegistry.register_handler| on
+interaction type and handling logic via |TargetRegistry.register_interaction| on
 a |TargetRegistry|.
 
 For the purpose of this document, suppose we want to perform many mouse clicks
@@ -475,13 +475,13 @@ Then we need to register this function with an instance of |TargetRegistry|::
     from package.ui.qt.shiny_button import ShinyButton
 
     custom_registry = TargetRegistry()
-    custom_registry.register_handler(
+    custom_registry.register_interaction(
         target_class=ShinyButton,
         interaction_class=ManyMouseClick,
         handler=many_mouse_click,
     )
 
-The signature of ``many_mouse_click`` is required by the |TargetRegistry.register_handler|
+The signature of ``many_mouse_click`` is required by the |TargetRegistry.register_interaction|
 method on |TargetRegistry|. By setting the ``target_class`` and
 ``interaction_class``, we restrict the types of ``wrapper._target`` and
 ``interaction`` received by ``many_mouse_click`` respectively.
@@ -560,7 +560,7 @@ The solvers can then be registered for the container UI target::
         solver=get_button,
     )
 
-Similar to |TargetRegistry.register_handler|, the signature of
+Similar to |TargetRegistry.register_interaction|, the signature of
 ``get_button`` is required by the |TargetRegistry.register_location|
 method. By setting the ``target_class`` and ``locator_class``, we restrict the
 types of ``wrapper._target`` and ``location`` received by ``get_button``
@@ -619,7 +619,7 @@ interaction handler and/or location solver via an instance of
 .. |TargetByName| replace:: :class:`~traitsui.testing.tester.locator.TargetByName`
 
 .. |TargetRegistry| replace:: :class:`~traitsui.testing.tester.registry.TargetRegistry`
-.. |TargetRegistry.register_handler| replace:: :func:`~traitsui.testing.tester.registry.TargetRegistry.register_handler`
+.. |TargetRegistry.register_interaction| replace:: :func:`~traitsui.testing.tester.registry.TargetRegistry.register_interaction`
 .. |TargetRegistry.register_location| replace:: :class:`~traitsui.testing.tester.registry.TargetRegistry.register_location`
 
 .. |UITester| replace:: :class:`~traitsui.testing.tester.ui_tester.UITester`

--- a/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
@@ -36,7 +36,8 @@ class _BaseSourceWithLocation:
     # the handlers we want to register for the given source_class
     # must be given as a list of tuples where the first element is the
     # interaction class (e.g. command.MouseClick) and the second is the
-    # actual handler function.  See registry.TargetRegistry.register_interaction
+    # actual handler function.
+    # See registry.TargetRegistry.register_interaction
     # for the signature of the callable.
     handlers = []
 

--- a/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
@@ -66,7 +66,7 @@ class _BaseSourceWithLocation:
         registry : TargetRegistry
             The registry being registered to.
         """
-        registry.register_solver(
+        registry.register_location(
             target_class=cls.source_class,
             locator_class=cls.locator_class,
             solver=lambda wrapper, location: cls(wrapper._target, location),

--- a/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
@@ -36,7 +36,7 @@ class _BaseSourceWithLocation:
     # the handlers we want to register for the given source_class
     # must be given as a list of tuples where the first element is the
     # interaction class (e.g. command.MouseClick) and the second is the
-    # actual handler function.  See registry.TargetRegistry.register_handler
+    # actual handler function.  See registry.TargetRegistry.register_interaction
     # for the signature of the callable.
     handlers = []
 
@@ -72,7 +72,7 @@ class _BaseSourceWithLocation:
             solver=lambda wrapper, location: cls(wrapper._target, location),
         )
         for interaction_class, handler in cls.handlers:
-            registry.register_handler(
+            registry.register_interaction(
                 target_class=cls,
                 interaction_class=interaction_class,
                 handler=handler

--- a/traitsui/testing/tester/_ui_tester_registry/_traitsui_ui.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_traitsui_ui.py
@@ -90,7 +90,7 @@ def register_traitsui_ui_solvers(registry, target_class, traitsui_ui_getter):
         UI.
     """
 
-    registry.register_solver(
+    registry.register_location(
         target_class=target_class,
         locator_class=locator.TargetByName,
         solver=lambda wrapper, location: (
@@ -100,7 +100,7 @@ def register_traitsui_ui_solvers(registry, target_class, traitsui_ui_getter):
             )
         ),
     )
-    registry.register_solver(
+    registry.register_location(
         target_class=target_class,
         locator_class=locator.TargetById,
         solver=lambda wrapper, location: (

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_registry_helper.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_registry_helper.py
@@ -50,7 +50,7 @@ def register_editable_textbox_handlers(registry, target_class, widget_getter):
                 widget_getter(wrapper))),
     ]
     for interaction_class, handler in handlers:
-        registry.register_handler(
+        registry.register_interaction(
             target_class=target_class,
             interaction_class=interaction_class,
             handler=handler,

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
@@ -36,7 +36,7 @@ def register(registry):
 
     for target_class in [SimpleEditor, CustomEditor]:
         for interaction_class, handler in handlers:
-            registry.register_handler(
+            registry.register_interaction(
                 target_class=target_class,
                 interaction_class=interaction_class,
                 handler=handler

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/editor_factory.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/editor_factory.py
@@ -31,7 +31,7 @@ def register(registry):
         target_class=TextEditor,
         widget_getter=lambda wrapper: wrapper._target.control,
     )
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ReadonlyEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.text()

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
@@ -151,19 +151,19 @@ def register(registry):
     ]
 
     for interaction_class, handler in simple_editor_text_handlers:
-        registry.register_handler(
+        registry.register_interaction(
             target_class=SimpleEditor,
             interaction_class=interaction_class,
             handler=handler
         )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=RadioEditor,
         interaction_class=query.SelectedText,
         handler=radio_selected_text_handler,
     )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ListEditor,
         interaction_class=query.SelectedText,
         handler=lambda wrapper, _:

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/instance_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/instance_editor.py
@@ -52,7 +52,7 @@ def register(registry):
     registry : TargetRegistry
         The registry being registered to.
     """
-    registry.register_handler(
+    registry.register_interaction(
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=lambda wrapper, _: (

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -104,7 +104,7 @@ def register(registry):
     # NotebookEditor
     _IndexedNotebookEditor.register(registry)
     # CustomEditor
-    registry.register_solver(
+    registry.register_location(
         target_class=CustomEditor,
         locator_class=locator.Index,
         solver=lambda wrapper, location: (

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
@@ -100,13 +100,13 @@ def register(registry):
                LogRangeSliderEditor,
                LargeRangeSliderEditor]
     for target_class in targets:
-        registry.register_solver(
+        registry.register_location(
             target_class=target_class,
             locator_class=locator.Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
                 textbox=wrapper._target.control.text),
         )
-        registry.register_solver(
+        registry.register_location(
             target_class=target_class,
             locator_class=locator.Slider,
             solver=lambda wrapper, _: LocatedSlider(

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
@@ -76,7 +76,7 @@ class LocatedSlider:
         registry : TargetRegistry
             The registry being registered to.
         """
-        registry.register_handler(
+        registry.register_interaction(
             target_class=cls,
             interaction_class=command.KeyClick,
             handler=lambda wrapper, interaction:

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/text_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/text_editor.py
@@ -37,7 +37,7 @@ def register(registry):
             widget_getter=lambda wrapper: wrapper._target.control,
         )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ReadonlyEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _: _interaction_helpers.displayed_text_qobject(

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
@@ -33,7 +33,7 @@ def register(registry):
             lambda wrapper, _: wrapper._target.control.text())
     ]
     for interaction_class, handler in handlers:
-        registry.register_handler(
+        registry.register_interaction(
             target_class=ButtonEditor,
             interaction_class=interaction_class,
             handler=handler

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_registry_helper.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_registry_helper.py
@@ -46,7 +46,7 @@ def register_editable_textbox_handlers(registry, target_class, widget_getter):
             lambda wrapper, _: widget_getter(wrapper).GetValue()),
     ]
     for interaction_class, handler in handlers:
-        registry.register_handler(
+        registry.register_interaction(
             target_class=target_class,
             interaction_class=interaction_class,
             handler=handler,

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
@@ -55,26 +55,26 @@ def register(registry):
     registry : TargetRegistry
     """
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=(lambda wrapper, _: _interaction_helpers.mouse_click_button(
                  control=wrapper._target.control, delay=wrapper.delay))
     )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=SimpleEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
     )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=CustomEditor,
         interaction_class=command.MouseClick,
         handler=mouse_click_ImageButton
     )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=CustomEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/editor_factory.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/editor_factory.py
@@ -31,7 +31,7 @@ def register(registry):
         target_class=TextEditor,
         widget_getter=lambda wrapper: wrapper._target.control,
     )
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ReadonlyEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _:

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
@@ -167,18 +167,18 @@ def register(registry):
     ]
 
     for interaction_class, handler in simple_editor_text_handlers:
-        registry.register_handler(
+        registry.register_interaction(
             target_class=SimpleEditor,
             interaction_class=interaction_class,
             handler=handler
         )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=RadioEditor,
         interaction_class=query.SelectedText,
         handler=radio_selected_text_handler,
     )
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ListEditor,
         interaction_class=query.SelectedText,
         handler=lambda wrapper, _: wrapper._target.control.GetString(

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
@@ -50,7 +50,7 @@ def register(registry):
     registry : TargetRegistry
         The registry being registered to.
     """
-    registry.register_handler(
+    registry.register_interaction(
         target_class=SimpleEditor,
         interaction_class=command.MouseClick,
         handler=lambda wrapper, _: mouse_click_button(

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -101,7 +101,7 @@ def register(registry):
     # NotebookEditor
     _IndexedNotebookEditor.register(registry)
     # CustomEditor
-    registry.register_solver(
+    registry.register_location(
         target_class=CustomEditor,
         locator_class=locator.Index,
         solver=lambda wrapper, location: (

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
@@ -75,7 +75,7 @@ class LocatedSlider:
         registry : TargetRegistry
             The registry being registered to.
         """
-        registry.register_handler(
+        registry.register_interaction(
             target_class=cls,
             interaction_class=command.KeyClick,
             handler=lambda wrapper, interaction:

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
@@ -99,13 +99,13 @@ def register(registry):
                LogRangeSliderEditor,
                LargeRangeSliderEditor]
     for target_class in targets:
-        registry.register_solver(
+        registry.register_location(
             target_class=target_class,
             locator_class=locator.Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
                 textbox=wrapper._target.control.text),
         )
-        registry.register_solver(
+        registry.register_location(
             target_class=target_class,
             locator_class=locator.Slider,
             solver=lambda wrapper, _: LocatedSlider(

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/text_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/text_editor.py
@@ -33,7 +33,7 @@ def register(registry):
             widget_getter=lambda wrapper: wrapper._target.control,
         )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ReadonlyEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _:

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
@@ -24,14 +24,14 @@ def register(registry):
     registry : TargetRegistry
     """
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ButtonEditor,
         interaction_class=command.MouseClick,
         handler=(lambda wrapper, _: _interaction_helpers.mouse_click_button(
                  control=wrapper._target.control, delay=wrapper.delay))
     )
 
-    registry.register_handler(
+    registry.register_interaction(
         target_class=ButtonEditor,
         interaction_class=query.DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()

--- a/traitsui/testing/tester/registry.py
+++ b/traitsui/testing/tester/registry.py
@@ -79,7 +79,7 @@ class TargetRegistry:
     ``register_handler`` supports extending ``UIWrapper.perform`` and
     ``UIWrapper.inspect`` for a given UI target type and interaction type.
 
-    ``register_solver`` supports extending ``UIWrapper.locate`` for a given
+    ``register_location`` supports extending ``UIWrapper.locate`` for a given
     UI target type and location type.
 
     See :ref:`advanced-testing` Section in the User Manual for further details.
@@ -202,7 +202,7 @@ class TargetRegistry:
         # This maybe configurable in the future via register_handler
         return inspect.getdoc(interaction_class)
 
-    def register_solver(self, target_class, locator_class, solver):
+    def register_location(self, target_class, locator_class, solver):
         """ Register a solver for resolving the next UI target for the given
         target type and locator type.
 
@@ -287,5 +287,5 @@ class TargetRegistry:
             target_class=target_class,
             key=locator_class,
         )
-        # This maybe configurable in the future via register_solver
+        # This maybe configurable in the future via register_location
         return inspect.getdoc(locator_class)

--- a/traitsui/testing/tester/registry.py
+++ b/traitsui/testing/tester/registry.py
@@ -76,7 +76,7 @@ class TargetRegistry:
     """ An object for registering interaction and location resolution logic
     for different UI target types.
 
-    ``register_handler`` supports extending ``UIWrapper.perform`` and
+    ``register_interaction`` supports extending ``UIWrapper.perform`` and
     ``UIWrapper.inspect`` for a given UI target type and interaction type.
 
     ``register_location`` supports extending ``UIWrapper.locate`` for a given
@@ -107,7 +107,7 @@ class TargetRegistry:
             ),
         )
 
-    def register_handler(self, target_class, interaction_class, handler):
+    def register_interaction(self, target_class, interaction_class, handler):
         """ Register a handler for a given target type and interaction type.
 
         Parameters
@@ -199,7 +199,7 @@ class TargetRegistry:
             target_class=target_class,
             key=interaction_class,
         )
-        # This maybe configurable in the future via register_handler
+        # This maybe configurable in the future via register_interaction
         return inspect.getdoc(interaction_class)
 
     def register_location(self, target_class, locator_class, solver):

--- a/traitsui/testing/tester/tests/test_registry.py
+++ b/traitsui/testing/tester/tests/test_registry.py
@@ -155,7 +155,7 @@ class TestLocationRegistry(unittest.TestCase):
             return 1
 
         registry = TargetRegistry()
-        registry.register_solver(
+        registry.register_location(
             target_class=float, locator_class=str, solver=solver)
 
         self.assertIs(registry.get_solver(float, str), solver)
@@ -166,7 +166,7 @@ class TestLocationRegistry(unittest.TestCase):
             return 1
 
         registry = TargetRegistry()
-        registry.register_solver(
+        registry.register_location(
             target_class=float, locator_class=str, solver=solver)
 
         with self.assertRaises(LocationNotSupported) as exception_context:
@@ -181,7 +181,7 @@ class TestLocationRegistry(unittest.TestCase):
             pass
 
         registry = TargetRegistry()
-        registry.register_solver(
+        registry.register_location(
             target_class=float,
             locator_class=Locator,
             solver=lambda w, l: 1,

--- a/traitsui/testing/tester/tests/test_registry.py
+++ b/traitsui/testing/tester/tests/test_registry.py
@@ -46,7 +46,7 @@ class TestInteractionRegistry(unittest.TestCase):
             pass
 
         # when
-        registry.register_handler(
+        registry.register_interaction(
             target_class=SpecificEditor,
             interaction_class=UserAction,
             handler=handler,
@@ -79,9 +79,9 @@ class TestInteractionRegistry(unittest.TestCase):
             pass
 
         registry = TargetRegistry()
-        registry.register_handler(SpecificEditor, UserAction, handler)
-        registry.register_handler(SpecificEditor2, UserAction2, handler)
-        registry.register_handler(SpecificEditor2, UserAction3, handler)
+        registry.register_interaction(SpecificEditor, UserAction, handler)
+        registry.register_interaction(SpecificEditor2, UserAction2, handler)
+        registry.register_interaction(SpecificEditor2, UserAction3, handler)
 
         with self.assertRaises(InteractionNotSupported) as exception_context:
             registry.get_handler(SpecificEditor2, None)
@@ -103,10 +103,10 @@ class TestInteractionRegistry(unittest.TestCase):
             pass
 
         registry = TargetRegistry()
-        registry.register_handler(SpecificEditor, UserAction, handler)
+        registry.register_interaction(SpecificEditor, UserAction, handler)
 
         with self.assertRaises(ValueError):
-            registry.register_handler(SpecificEditor, UserAction, handler)
+            registry.register_interaction(SpecificEditor, UserAction, handler)
 
     def test_error_get_interaction_doc(self):
         # The registry is empty
@@ -124,7 +124,7 @@ class TestInteractionRegistry(unittest.TestCase):
             pass
 
         registry = TargetRegistry()
-        registry.register_handler(
+        registry.register_interaction(
             target_class=float,
             interaction_class=Action,
             handler=handler,

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -254,7 +254,7 @@ class TestUIWrapperHelp(unittest.TestCase):
             pass
 
         registry1 = TargetRegistry()
-        registry1.register_handler(
+        registry1.register_interaction(
             target_class=str,
             interaction_class=Action,
             handler=mock.Mock(),
@@ -313,7 +313,7 @@ class TestUIWrapperHelp(unittest.TestCase):
                 return "Location: I get a lower priority."
 
         high_priority_registry = HighPriorityRegistry()
-        high_priority_registry.register_handler(
+        high_priority_registry.register_interaction(
             target_class=str,
             interaction_class=float,
             handler=mock.Mock(),
@@ -325,7 +325,7 @@ class TestUIWrapperHelp(unittest.TestCase):
         )
 
         low_priority_registry = LowPriorityRegistry()
-        low_priority_registry.register_handler(
+        low_priority_registry.register_interaction(
             target_class=str,
             interaction_class=float,
             handler=mock.Mock(),

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -260,7 +260,7 @@ class TestUIWrapperHelp(unittest.TestCase):
             handler=mock.Mock(),
         )
         registry2 = TargetRegistry()
-        registry2.register_solver(
+        registry2.register_location(
             target_class=str,
             locator_class=Locator,
             solver=mock.Mock(),
@@ -318,7 +318,7 @@ class TestUIWrapperHelp(unittest.TestCase):
             interaction_class=float,
             handler=mock.Mock(),
         )
-        high_priority_registry.register_solver(
+        high_priority_registry.register_location(
             target_class=str,
             locator_class=str,
             solver=mock.Mock(),
@@ -330,7 +330,7 @@ class TestUIWrapperHelp(unittest.TestCase):
             interaction_class=float,
             handler=mock.Mock(),
         )
-        low_priority_registry.register_solver(
+        low_priority_registry.register_location(
             target_class=str,
             locator_class=str,
             solver=mock.Mock(),


### PR DESCRIPTION
This PR merely does the name change:

- `TargetRegistry.register_solver` -> `TargetRegistry.register_location`
- `TargetRegistry.register_handler` -> `TargetRegistry.register_interaction`

User manual is updated as well.

Closes #1273