### PR TITLE
UI Tester - add boolean editor

### DIFF
--- a/traitsui/examples/demo/Standard_Editors/BooleanEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/BooleanEditor_demo.py
@@ -21,13 +21,15 @@ class BooleanEditorDemo(HasTraits):
 
     # Items are used to define the demo display - one Item per editor style
     bool_group = Group(
-        Item('boolean_trait', style='simple', label='Simple'),
+        Item('boolean_trait', style='simple', label='Simple', id='simple'),
         Item('_'),
-        Item('boolean_trait', style='custom', label='Custom'),
+        Item('boolean_trait', style='custom', label='Custom', id='custom'),
         Item('_'),
-        Item('boolean_trait', style='text', label='Text'),
+        Item('boolean_trait', style='text', label='Text', id='text'),
         Item('_'),
-        Item('boolean_trait', style='readonly', label='ReadOnly')
+        Item(
+            'boolean_trait', style='readonly', label='ReadOnly', id='readonly'
+        )
     )
 
     # Demo view

--- a/traitsui/examples/demo/Standard_Editors/BooleanEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/BooleanEditor_simple_demo.py
@@ -33,10 +33,7 @@ class BooleanEditorDemo(HasTraits):
     traits_view = View(
         '10',  # vertical space
 
-        # The trait to be displayed / edited, in default format.
-        # To edit a simple trait, this is the only line needed inside the View.
-        # This is shorthand for Item('my_boolean_trait', style = 'simple')
-        'my_boolean_trait',
+        Item('my_boolean_trait', style='simple', id='simple'),
 
         '10',  # vertical space
 
@@ -49,8 +46,13 @@ class BooleanEditorDemo(HasTraits):
 
         '10',  # vertical space
 
-        Item('my_boolean_trait', style='readonly', label='Read-only style'),
-        Item('my_boolean_trait', style='text', label='Text style'),
+        Item(
+            'my_boolean_trait',
+            style='readonly',
+            label='Read-only style',
+            id='readonly'
+        ),
+        Item('my_boolean_trait', style='text', label='Text style', id='text'),
 
         '10',
         'count_changes',

--- a/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_demo.py
@@ -1,0 +1,56 @@
+"""
+This example demonstrates how to test interacting with a boolean
+using BooleanEditor.
+
+The GUI being tested is written in the demo under the same name (minus the
+preceding 'test') in the outer directory.
+"""
+
+import os
+import runpy
+import unittest
+
+from traitsui.testing.api import (
+    DisplayedText, KeyClick, KeySequence, MouseClick, UITester
+)
+
+#: Filename of the demo script
+FILENAME = "BooleanEditor_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestBooleanEditorDemo(unittest.TestCase):
+
+    def test_boolean_editor_simple_demo(self):
+        demo = runpy.run_path(DEMO_PATH)["demo"]
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            simple = tester.find_by_id(ui, 'simple')
+            custom = tester.find_by_id(ui, 'custom')
+            text = tester.find_by_id(ui, 'text')
+            readonly = tester.find_by_id(ui, 'readonly')
+
+            self.assertEqual(demo.boolean_trait, False)
+            simple.perform(MouseClick())
+            self.assertEqual(demo.boolean_trait, True)
+            custom.perform(MouseClick())
+            self.assertEqual(demo.boolean_trait, False)
+
+            for _ in range(5):
+                text.perform(KeyClick("Backspace"))
+            text.perform(KeySequence("True"))
+            text.perform(KeyClick("Enter"))
+            self.assertEqual(demo.boolean_trait, True)
+
+            demo.boolean_trait = False
+            displayed = readonly.inspect(DisplayedText())
+            self.assertEqual(displayed, "False")
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestBooleanEditorDemo)
+)

--- a/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_demo.py
@@ -33,7 +33,6 @@ class TestBooleanEditorDemo(unittest.TestCase):
             text = tester.find_by_id(ui, 'text')
             readonly = tester.find_by_id(ui, 'readonly')
 
-            self.assertEqual(demo.boolean_trait, False)
             simple.perform(MouseClick())
             self.assertEqual(demo.boolean_trait, True)
             custom.perform(MouseClick())

--- a/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_demo.py
@@ -23,7 +23,7 @@ DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
 
 class TestBooleanEditorDemo(unittest.TestCase):
 
-    def test_boolean_editor_simple_demo(self):
+    def test_boolean_editor_demo(self):
         demo = runpy.run_path(DEMO_PATH)["demo"]
 
         tester = UITester()

--- a/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_simple_demo.py
@@ -11,7 +11,7 @@ import runpy
 import unittest
 
 from traitsui.testing.api import (
-    DisplayedText, KeyClick, KeySequence, MouseClick, UITester
+    DisplayedText, IsChecked, KeyClick, KeySequence, MouseClick, UITester
 )
 
 #: Filename of the demo script
@@ -50,9 +50,8 @@ class TestBooleanEditorSimpleDemo(unittest.TestCase):
             displayed = readonly.inspect(DisplayedText())
             self.assertEqual(displayed, "True")
 
-            displayed_count_changes = count_changes.inspect(DisplayedText())
-            self.assertEqual(displayed_count_changes, '3')
-            self.assertEqual(displayed_count_changes, str(demo.count_changes))
+            simple_is_checked = simple.inspect(IsChecked())
+            self.assertEqual(simple_is_checked, True)
 
 
 # Run the test(s)

--- a/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_simple_demo.py
@@ -1,0 +1,63 @@
+"""
+This example demonstrates how to test interacting with a boolean
+using BooleanEditor.
+
+The GUI being tested is written in the demo under the same name (minus the
+preceding 'test') in the outer directory.
+"""
+
+import os
+import runpy
+import unittest
+
+from traitsui.testing.api import (
+    DisplayedText, KeyClick, KeySequence, MouseClick, UITester
+)
+
+#: Filename of the demo script
+FILENAME = "BooleanEditor_simple_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestBooleanEditorSimpleDemo(unittest.TestCase):
+
+    def test_boolean_editor_simple_demo(self):
+        demo = runpy.run_path(DEMO_PATH)["demo"]
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            simple = tester.find_by_id(ui, 'simple')
+
+            readonly = tester.find_by_id(ui, 'readonly')
+            text = tester.find_by_id(ui, 'text')
+            count_changes = tester.find_by_name(ui, "count_changes")
+
+            self.assertEqual(demo.my_boolean_trait, False)
+            simple.perform(MouseClick())
+            self.assertEqual(demo.my_boolean_trait, True)
+
+            for _ in range(4):
+                text.perform(KeyClick("Backspace"))
+            text.perform(KeySequence("False"))
+            text.perform(KeyClick("Enter"))
+            self.assertEqual(demo.my_boolean_trait, False)
+
+            displayed_count_changes = count_changes.inspect(DisplayedText())
+            self.assertEqual(displayed_count_changes, '2')
+            self.assertEqual(displayed_count_changes, str(demo.count_changes))
+
+            demo.my_boolean_trait = True
+            displayed = readonly.inspect(DisplayedText())
+            self.assertEqual(displayed, "True")
+
+            displayed_count_changes = count_changes.inspect(DisplayedText())
+            self.assertEqual(displayed_count_changes, '3')
+            self.assertEqual(displayed_count_changes, str(demo.count_changes))
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestBooleanEditorSimpleDemo)
+)

--- a/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_BooleanEditor_simple_demo.py
@@ -29,12 +29,10 @@ class TestBooleanEditorSimpleDemo(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(demo) as ui:
             simple = tester.find_by_id(ui, 'simple')
-
             readonly = tester.find_by_id(ui, 'readonly')
             text = tester.find_by_id(ui, 'text')
             count_changes = tester.find_by_name(ui, "count_changes")
 
-            self.assertEqual(demo.my_boolean_trait, False)
             simple.perform(MouseClick())
             self.assertEqual(demo.my_boolean_trait, True)
 

--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -33,6 +33,7 @@ from .tester.registry import TargetRegistry
 
 from .tester.query import (
     DisplayedText,
+    IsChecked,
     SelectedText
 )
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
@@ -1,0 +1,40 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.tester._ui_tester_registry.qt4 import (
+    _interaction_helpers
+)
+from traitsui.qt4.boolean_editor import ReadonlyEditor, SimpleEditor
+
+
+def register(registry):
+    """ Register solvers/handlers specific to qt Boolean Editors
+    for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+    """
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=MouseClick,
+        handler=lambda wrapper, _: _interaction_helpers.mouse_click_qwidget(
+            control=wrapper._target.control, delay=wrapper.delay
+        )
+    )
+
+    registry.register_interaction(
+        target_class=ReadonlyEditor,
+        interaction_class=DisplayedText,
+        handler=lambda wrapper, _: wrapper._target.control.text()
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
@@ -36,5 +36,7 @@ def register(registry):
     registry.register_interaction(
         target_class=ReadonlyEditor,
         interaction_class=DisplayedText,
-        handler=lambda wrapper, _: wrapper._target.control.text()
+        handler=lambda wrapper, _: _interaction_helpers.displayed_text_qobject(
+            widget=wrapper._target.control
+        )
     )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
@@ -8,7 +8,7 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.api import DisplayedText, IsChecked, MouseClick
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -31,6 +31,12 @@ def register(registry):
         handler=lambda wrapper, _: _interaction_helpers.mouse_click_qwidget(
             control=wrapper._target.control, delay=wrapper.delay
         )
+    )
+
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=IsChecked,
+        handler=lambda wrapper, _: wrapper._target.control.isChecked()
     )
 
     registry.register_interaction(

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -11,6 +11,7 @@
 
 from traitsui.testing.tester.registry import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
+    boolean_editor,
     button_editor,
     check_list_editor,
     editor_factory,
@@ -34,6 +35,9 @@ def get_default_registry():
         that is qt specific.
     """
     registry = TargetRegistry()
+
+    # BooleanEditor
+    boolean_editor.register(registry)
 
     # ButtonEditor
     button_editor.register(registry)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
@@ -1,0 +1,43 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+import wx
+
+from traitsui.wx.boolean_editor import ReadonlyEditor, SimpleEditor
+from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
+
+
+def register(registry):
+    """ Register solvers/handlers specific to wx Boolean Editors
+    for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+    """
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=MouseClick,
+        handler=(lambda wrapper, _: _interaction_helpers.mouse_click_checkbox(
+                 control=wrapper._target.control, delay=wrapper.delay))
+    )
+
+    registry.register_interaction(
+        target_class=ReadonlyEditor,
+        interaction_class=DisplayedText,
+        handler=
+            lambda wrapper, _:
+                _interaction_helpers.readonly_textbox_displayed_text(
+                    control=wrapper._target.control
+                )
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
@@ -8,8 +8,6 @@
 #
 #  Thanks for using Enthought open source!
 #
-import wx
-
 from traitsui.wx.boolean_editor import ReadonlyEditor, SimpleEditor
 from traitsui.testing.api import DisplayedText, MouseClick
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
@@ -35,9 +33,8 @@ def register(registry):
     registry.register_interaction(
         target_class=ReadonlyEditor,
         interaction_class=DisplayedText,
-        handler=
-            lambda wrapper, _:
-                _interaction_helpers.readonly_textbox_displayed_text(
-                    control=wrapper._target.control
-                )
+        handler=lambda wrapper, _:
+            _interaction_helpers.readonly_textbox_displayed_text(
+                control=wrapper._target.control
+            )
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.boolean_editor import ReadonlyEditor, SimpleEditor
-from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.api import DisplayedText, IsChecked, MouseClick
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -28,6 +28,12 @@ def register(registry):
         interaction_class=MouseClick,
         handler=(lambda wrapper, _: _interaction_helpers.mouse_click_checkbox(
                  control=wrapper._target.control, delay=wrapper.delay))
+    )
+
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=IsChecked,
+        handler=lambda wrapper, _: wrapper._target.control.GetValue()
     )
 
     registry.register_interaction(

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -11,6 +11,7 @@
 
 from traitsui.testing.tester.registry import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
+    boolean_editor
     button_editor,
     check_list_editor,
     editor_factory,
@@ -34,6 +35,9 @@ def get_default_registry():
         that is wx specific.
     """
     registry = TargetRegistry()
+
+    # BooleanEditor
+    boolean_editor.register(registry)
 
     # ButtonEditor
     button_editor.register(registry)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -11,7 +11,7 @@
 
 from traitsui.testing.tester.registry import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
-    boolean_editor
+    boolean_editor,
     button_editor,
     check_list_editor,
     editor_factory,

--- a/traitsui/testing/tester/query.py
+++ b/traitsui/testing/tester/query.py
@@ -42,10 +42,9 @@ class DisplayedText:
 
 
 class IsChecked:
-    """ An object representing an interaction to obtain whether a checkbox
-    is checked or empty.
+    """ An object representing an interaction to obtain whether a checkable
+    widget (e.g. checkbox) is checked or not.
 
-    Implementations should return something which evaluates to True if checked
-    and False if not.
+    Implementations should return True if checked and False if not.
     """
     pass

--- a/traitsui/testing/tester/query.py
+++ b/traitsui/testing/tester/query.py
@@ -39,3 +39,12 @@ class DisplayedText:
     Implementations should return a ``str``.
     """
     pass
+
+class IsChecked:
+    """ An object representing an interaction to obtain whether a checkbox
+    is checked or empty.
+
+    Implementations should return something which evaluates to True if checked
+    and False if not.
+    """
+    pass

--- a/traitsui/testing/tester/query.py
+++ b/traitsui/testing/tester/query.py
@@ -40,6 +40,7 @@ class DisplayedText:
     """
     pass
 
+
 class IsChecked:
     """ An object representing an interaction to obtain whether a checkbox
     is checked or empty.

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -74,7 +74,7 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(obj.true_or_false, True)
 
     def check_trait_change_shown_in_gui(self, style):
-        view = View(Item( "true_or_false", style=style))
+        view = View(Item("true_or_false", style=style))
         obj = BoolModel()
 
         tester = UITester()
@@ -94,7 +94,7 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
         self.check_trait_change_shown_in_gui('custom')
 
     def test_trait_change_shown_in_gui_readonly(self):
-        view = View(Item( "true_or_false", style='readonly'))
+        view = View(Item("true_or_false", style='readonly'))
         obj = BoolModel()
 
         tester = UITester()
@@ -106,9 +106,9 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
             obj.true_or_false = True
             displayed = readonly.inspect(DisplayedText())
             self.assertEqual(displayed, 'True')
-    
+
     def test_trait_change_shown_in_gui_text(self):
-        view = View(Item( "true_or_false", style='text'))
+        view = View(Item("true_or_false", style='text'))
         obj = BoolModel()
 
         tester = UITester()

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -21,7 +21,7 @@ from traitsui.tests._tools import (
 )
 
 from traitsui.testing.api import (
-    DisplayedText, KeyClick, KeySequence, MouseClick, UITester
+    DisplayedText, IsChecked, KeyClick, KeySequence, MouseClick, UITester
 )
 
 
@@ -73,6 +73,26 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
             text_field.perform(KeyClick("Enter"))
             self.assertEqual(obj.true_or_false, True)
 
+    def check_trait_change_shown_in_gui(self, style):
+        view = View(Item( "true_or_false", style=style))
+        obj = BoolModel()
+
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            checkbox = tester.find_by_name(ui, "true_or_false")
+            checked = checkbox.inspect(IsChecked())
+            # sanity check
+            self.assertEqual(checked, False)
+            obj.true_or_false = True
+            checked = checkbox.inspect(IsChecked())
+            self.assertEqual(checked, True)
+
+    def test_trait_change_shown_in_gui_simple(self):
+        self.check_trait_change_shown_in_gui('simple')
+
+    def test_trait_change_shown_in_gui_custom(self):
+        self.check_trait_change_shown_in_gui('custom')
+
     def test_trait_change_shown_in_gui_readonly(self):
         view = View(Item( "true_or_false", style='readonly'))
         obj = BoolModel()
@@ -83,7 +103,6 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
             displayed = readonly.inspect(DisplayedText())
             # sanity check
             self.assertEqual(displayed, 'False')
-
             obj.true_or_false = True
             displayed = readonly.inspect(DisplayedText())
             self.assertEqual(displayed, 'True')
@@ -94,11 +113,10 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
 
         tester = UITester()
         with tester.create_ui(obj, dict(view=view)) as ui:
-            readonly = tester.find_by_name(ui, "true_or_false")
-            displayed = readonly.inspect(DisplayedText())
+            text_field = tester.find_by_name(ui, "true_or_false")
+            displayed = text_field.inspect(DisplayedText())
             # sanity check
             self.assertEqual(displayed, 'False')
-
             obj.true_or_false = True
-            displayed = readonly.inspect(DisplayedText())
+            displayed = text_field.inspect(DisplayedText())
             self.assertEqual(displayed, 'True')

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -16,11 +16,11 @@ from traits.api import HasTraits, Bool
 from traitsui.api import BooleanEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
-    create_ui,
     requires_toolkit,
-    reraise_exceptions,
     ToolkitName,
 )
+
+from traitsui.testing.api import MouseClick, UITester
 
 
 class BoolModel(HasTraits):
@@ -43,6 +43,19 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
         # Test init and dispose of the editor.
         view = View(Item("true_or_false", editor=BooleanEditor()))
         obj = BoolModel()
-        with reraise_exceptions(), \
-                create_ui(obj, dict(view=view)):
+
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)):
             pass
+
+    def test_click_boolean(self):
+        view = View(Item("true_or_false", editor=BooleanEditor()))
+        obj = BoolModel()
+
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            # sanity check
+            self.assertEqual(obj.true_or_false, False)
+            checkbox = tester.find_by_name(ui, "true_or_false")
+            checkbox.perform(MouseClick())
+            self.assertEqual(obj.true_or_false, True)

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -56,7 +56,7 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
     def test_click_boolean_changes_trait_simple(self):
         self.check_click_boolean_changes_trait('simple')
 
-    def test_click_boolean_changes_trait(self):
+    def test_click_boolean_changes_trait_custom(self):
         self.check_click_boolean_changes_trait('custom')
 
     def test_change_text_boolean_changes_trait(self):

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -20,7 +20,9 @@ from traitsui.tests._tools import (
     ToolkitName,
 )
 
-from traitsui.testing.api import MouseClick, UITester
+from traitsui.testing.api import (
+    DisplayedText, KeyClick, KeySequence, MouseClick, UITester
+)
 
 
 class BoolModel(HasTraits):
@@ -39,8 +41,8 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
     def tearDown(self):
         BaseTestMixin.tearDown(self)
 
-    def test_click_boolean(self):
-        view = View(Item("true_or_false", editor=BooleanEditor()))
+    def check_click_boolean_changes_trait(self, style):
+        view = View(Item("true_or_false", style=style, editor=BooleanEditor()))
         obj = BoolModel()
 
         tester = UITester()
@@ -50,3 +52,53 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
             checkbox = tester.find_by_name(ui, "true_or_false")
             checkbox.perform(MouseClick())
             self.assertEqual(obj.true_or_false, True)
+
+    def test_click_boolean_changes_trait_simple(self):
+        self.check_click_boolean_changes_trait('simple')
+
+    def test_click_boolean_changes_trait(self):
+        self.check_click_boolean_changes_trait('custom')
+
+    def test_change_text_boolean_changes_trait(self):
+        view = View(Item("true_or_false", style='text'))
+        obj = BoolModel()
+
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            self.assertEqual(obj.true_or_false, False)
+            text_field = tester.find_by_name(ui, 'true_or_false')
+            for _ in range(5):
+                text_field.perform(KeyClick("Backspace"))
+            text_field.perform(KeySequence("True"))
+            text_field.perform(KeyClick("Enter"))
+            self.assertEqual(obj.true_or_false, True)
+
+    def test_trait_change_shown_in_gui_readonly(self):
+        view = View(Item( "true_or_false", style='readonly'))
+        obj = BoolModel()
+
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            readonly = tester.find_by_name(ui, "true_or_false")
+            displayed = readonly.inspect(DisplayedText())
+            # sanity check
+            self.assertEqual(displayed, 'False')
+
+            obj.true_or_false = True
+            displayed = readonly.inspect(DisplayedText())
+            self.assertEqual(displayed, 'True')
+    
+    def test_trait_change_shown_in_gui_text(self):
+        view = View(Item( "true_or_false", style='text'))
+        obj = BoolModel()
+
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            readonly = tester.find_by_name(ui, "true_or_false")
+            displayed = readonly.inspect(DisplayedText())
+            # sanity check
+            self.assertEqual(displayed, 'False')
+
+            obj.true_or_false = True
+            displayed = readonly.inspect(DisplayedText())
+            self.assertEqual(displayed, 'True')

--- a/traitsui/tests/editors/test_boolean_editor.py
+++ b/traitsui/tests/editors/test_boolean_editor.py
@@ -30,7 +30,7 @@ class BoolModel(HasTraits):
 
 # Run this against wx once enthought/traitsui#752 is also fixed for
 # BooleanEditor
-@requires_toolkit([ToolkitName.qt])
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
 
     def setUp(self):
@@ -38,15 +38,6 @@ class TestBooleanEditor(BaseTestMixin, unittest.TestCase):
 
     def tearDown(self):
         BaseTestMixin.tearDown(self)
-
-    def test_init_dispose(self):
-        # Test init and dispose of the editor.
-        view = View(Item("true_or_false", editor=BooleanEditor()))
-        obj = BoolModel()
-
-        tester = UITester()
-        with tester.create_ui(obj, dict(view=view)):
-            pass
 
     def test_click_boolean(self):
         view = View(Item("true_or_false", editor=BooleanEditor()))


### PR DESCRIPTION
This PR adds an implementation for BooleanEditor to UI Tester.  It also modifies the current `test_boolean_editor.py` file by modifying it to use UI Tester, and adding another simple test.  Lastly, it adds tests for the examples `BooleanEditor_demo` and `BooleanEditor_simple_demo`. The previously list changes are made in roughly 1 change per commit.  