### PR TITLE
Maint: Make registries and delay arguments keyword only

### DIFF
--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -44,7 +44,7 @@ class UITester:
         visual confirmation test code is working as desired.
     """
 
-    def __init__(self, registries=None, delay=0):
+    def __init__(self, *, registries=None, delay=0):
         if registries is None:
             self._registries = []
         else:

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -66,7 +66,7 @@ class UIWrapper:
         visual confirmation test code is working as desired.
     """
 
-    def __init__(self, target, registries, *, delay=0):
+    def __init__(self, target, *, registries, delay=0):
         self._target = target
         self._registries = registries
         self.delay = delay

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -66,7 +66,7 @@ class UIWrapper:
         visual confirmation test code is working as desired.
     """
 
-    def __init__(self, target, registries, delay=0):
+    def __init__(self, target, registries, *, delay=0):
         self._target = target
         self._registries = registries
         self.delay = delay

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -154,7 +154,7 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
         )
         LOCAL_REGISTRY = TargetRegistry()
         _register_simple_spin(LOCAL_REGISTRY)
-        tester = UITester([LOCAL_REGISTRY])
+        tester = UITester(registries=[LOCAL_REGISTRY])
         with tester.create_ui(model, dict(view=view)) as ui:
             # sanity check
             self.assertEqual(model.value, 1)
@@ -232,7 +232,7 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
         )
         LOCAL_REGISTRY = TargetRegistry()
         _register_simple_spin(LOCAL_REGISTRY)
-        tester = UITester([LOCAL_REGISTRY])
+        tester = UITester(registries=[LOCAL_REGISTRY])
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field_text = tester.find_by_name(ui, "value")
             number_field_text.perform(command.KeyClick("Right"))


### PR DESCRIPTION
This PR makes a few of the arguments on `UITester` and `UIWrapper` keyword only. When callers are required to set arguments by names, this allows more room for future changes that is backward compatible. This should incur little inconvenience as these arguments are not often set by user code.