### PR TITLE
Doc: Add traitsui.testing.api to the API reference

### DIFF
--- a/docs/source/api/traitsui.testing.api.rst
+++ b/docs/source/api/traitsui.testing.api.rst
@@ -1,0 +1,7 @@
+traitsui\.testing\.api module
+=============================
+
+.. automodule:: traitsui.testing.api
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/api/traitsui.testing.rst
+++ b/docs/source/api/traitsui.testing.rst
@@ -3,6 +3,7 @@ traitsui\.testing package
 
 .. toctree::
 
+   traitsui.testing.api
    traitsui.testing.tester.command
    traitsui.testing.tester.exceptions
    traitsui.testing.tester.locator

--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -4,8 +4,8 @@
 Testing TraitsUI Applications
 =============================
 
-TraitsUI provides the ``traitsui.testing.api`` module which provides test
-functionality that helps developers check the behavior of their application.
+TraitsUI provides an |testing.api| module which provides test
+functionality that helps developers check the behavior of their applications.
 
 Most of the test functionality can be accessed via the |UITester| object.
 
@@ -161,8 +161,7 @@ In this example, ``title_field`` is wrapping a textbox, no further
 nested GUI elements can be located and therefore there are no locations
 supported.
 
-Most of the time these objects can be imported from
-``traitsui.testing.api``.
+Most of the time these objects can be imported from |testing.api|.
 
 Perform a User Interaction to Modify GUI States
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -607,6 +606,8 @@ interaction handler and/or location solver via an instance of
 
 ..
    # substitutions
+
+.. |testing.api| replace:: :mod:`~traitsui.testing.api`
 
 .. |Group| replace:: :class:`~traitsui.group.Group`
 .. |Item| replace:: :class:`~traitsui.item.Item`

--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -8,6 +8,55 @@
 #
 #  Thanks for using Enthought open source!
 #
+"""
+Core API for traitsui.testing
+
+Functionalities exposed via this package are intended to be used by external
+projects and stability is maintained as much as possible. Imports from other
+packages and subpackages do NOT receive the same stability guarantee.
+
+Tester
+------
+
+- :class:`~.UITester`
+
+Interactions (for changing GUI states)
+--------------------------------------
+
+- :class:`~.KeyClick`
+- :class:`~.KeySequence`
+- :class:`~.MouseClick`
+
+Interactions (for getting GUI states)
+-------------------------------------
+
+- :class:`~.DisplayedText`
+- :class:`~.IsChecked`
+- :class:`~.SelectedText`
+
+Locations (for locating GUI elements)
+-------------------------------------
+
+- :class:`~.Index`
+- :class:`~.Slider`
+- :class:`~.TargetById`
+- :class:`~.TargetByName`
+- :class:`~.Textbox`
+
+Advanced usage
+--------------
+
+- :class:`~.TargetRegistry`
+
+Exceptions
+----------
+
+- :class:`~.Disabled`
+- :class:`~.InteractionNotSupported`
+- :class:`~.LocationNotSupported`
+- :class:`~.TesterError`
+"""
+
 from .tester.command import (
     MouseClick,
     KeyClick,


### PR DESCRIPTION
This PR
- Expand docstring for `traitsui.testing.api` so that the API reference provides links to the objects of interest directly.
- Add `traitsui.testing.api` to the TOC
- Minor grammar fix (the cross reference causes the "traitsui.testing.api" to be rendered as "api" with a hyperlink)