### PR TITLE
Process GUI events before resolving location

### DIFF
--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -151,6 +151,8 @@ class TestUIWrapperInteractionRegistries(unittest.TestCase):
         )
 
 
+# Use of locate requires the GUI event loop
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestUIWrapperLocationRegistry(unittest.TestCase):
     """ Test the use of registries with locate. """
 

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -414,6 +414,22 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
         with self.assertTraitChanges(model, "number"):
             wrapper.perform(None)
 
+    def test_event_processed_prior_to_resolving_location(self):
+        # Test GUI events are processed prior to resolving location
+        gui = GUI()
+        model = NumberHasTraits()
+        gui.set_trait_later(model, "number", 2)
+
+        def solver(wrapper, action):
+            return model.number
+
+        wrapper = example_ui_wrapper(
+            registries=[StubRegistry(solver=solver)],
+        )
+
+        new_wrapper = wrapper.locate(None)
+        self.assertEqual(new_wrapper._target, 2)
+
     def test_event_processed_with_exception_captured(self):
         # Test exceptions in the GUI event loop are captured and then cause
         # the test to error.

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -310,6 +310,8 @@ class UIWrapper:
             except LocationNotSupported as e:
                 supported |= set(e.supported)
             else:
+                with _reraise_exceptions():
+                    _process_cascade_events()
                 return handler(self, location)
 
         raise LocationNotSupported(


### PR DESCRIPTION
This PR causes `UIWrapper.locate` (testing tool) to process the GUI events prior to resolving locations on the GUI.

Use case:
- When a trait is changed to cause GUI elements to change (e.g. the available values in the enum is dynamically computed), those updates may have been deferred for the GUI event loop to process (using dispatch="ui" in on_trait_change or observe). In that case, we should locate a GUI element only after those events are processed such that the GUI state is consistent.

Locating a GUI element is similar in concept compared to `UIWrapper.inspect`. `inspect` also needs to process GUI events in order to ensure the GUI is in a consistent state prior to getting the GUI state for testing.

We should only need to process events prior to locating the GUI element. Locate should have no side effect to require processing events before `locate` returns.

This is motivated by attempts to solve #1145 (will be in a separate PR). But the change here is needed regardless of the solution to #1145.