### PR TITLE
Use traitsui.testing.api imports where possible

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/_traitsui_ui.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_traitsui_ui.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.tester import locator
+from traitsui.testing.api import TargetById, TargetByName
 
 
 def _get_editor_by_name(ui, name):
@@ -92,7 +92,7 @@ def register_traitsui_ui_solvers(registry, target_class, traitsui_ui_getter):
 
     registry.register_location(
         target_class=target_class,
-        locator_class=locator.TargetByName,
+        locator_class=TargetByName,
         solver=lambda wrapper, location: (
             _get_editor_by_name(
                 ui=traitsui_ui_getter(wrapper._target),
@@ -102,7 +102,7 @@ def register_traitsui_ui_solvers(registry, target_class, traitsui_ui_getter):
     )
     registry.register_location(
         target_class=target_class,
-        locator_class=locator.TargetById,
+        locator_class=TargetById,
         solver=lambda wrapper, location: (
             _get_editor_by_id(
                 ui=traitsui_ui_getter(wrapper._target),

--- a/traitsui/testing/tester/_ui_tester_registry/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/default_registry.py
@@ -13,7 +13,7 @@ import importlib
 
 from traits.etsconfig.api import ETSConfig
 
-from traitsui.testing.tester.registry import TargetRegistry
+from traitsui.testing.api import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
     register_traitsui_ui_solvers,
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
@@ -14,7 +14,7 @@ from pyface.qt.QtTest import QTest
 from traitsui.testing.tester._ui_tester_registry._compat import (
     check_key_compat
 )
-from traitsui.testing.tester.exceptions import Disabled
+from traitsui.testing.api import Disabled
 from traitsui.qt4.key_event_to_name import key_map as _KEY_MAP
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_registry_helper.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_registry_helper.py
@@ -13,7 +13,12 @@
 and location solvers for common Qt GUI components.
 """
 
-from traitsui.testing.tester import command, query
+from traitsui.testing.api import (
+    KeyClick,
+    KeySequence,
+    MouseClick,
+    DisplayedText
+)
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -34,18 +39,18 @@ def register_editable_textbox_handlers(registry, target_class, widget_getter):
         or QTextEdit.
     """
     handlers = [
-        (command.KeySequence,
+        (KeySequence,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_sequence_textbox(
                     widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.KeyClick,
+        (KeyClick,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_click_qwidget(
                     widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_qwidget(
                 widget_getter(wrapper), wrapper.delay))),
-        (query.DisplayedText,
+        (DisplayedText,
             lambda wrapper, _: _interaction_helpers.displayed_text_qobject(
                 widget_getter(wrapper))),
     ]

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
@@ -8,7 +8,7 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.tester import command, query
+from traitsui.testing.api import DisplayedText, MouseClick
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -27,10 +27,10 @@ def register(registry):
     """
 
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             lambda wrapper, _: _interaction_helpers.mouse_click_qwidget(
                 wrapper._target.control, wrapper.delay)),
-        (query.DisplayedText,
+        (DisplayedText,
             lambda wrapper, _: wrapper._target.control.text())
     ]
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
@@ -10,7 +10,7 @@
 #
 
 from traitsui.qt4.check_list_editor import CustomEditor
-from traitsui.testing.tester import command, locator
+from traitsui.testing.api import Index, MouseClick
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     _BaseSourceWithLocation
 )
@@ -25,9 +25,9 @@ from traitsui.testing.tester._ui_tester_registry.qt4 import (
 class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
     """ Wrapper for CheckListEditor + locator.Index """
     source_class = CustomEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_qlayout(
                 layout=wrapper._target.source.control.layout(),
                 index=convert_index(

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/editor_factory.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/editor_factory.py
@@ -8,7 +8,7 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.tester import query
+from traitsui.testing.api import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.qt4._registry_helper import (
     register_editable_textbox_handlers,
 )
@@ -33,6 +33,6 @@ def register(registry):
     )
     registry.register_interaction(
         target_class=ReadonlyEditor,
-        interaction_class=query.DisplayedText,
+        interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.text()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
@@ -14,7 +14,14 @@ from traitsui.qt4.enum_editor import (
     RadioEditor,
     SimpleEditor,
 )
-from traitsui.testing.tester import command, locator, query
+from traitsui.testing.api import (
+    DisplayedText,
+    Index,
+    KeyClick,
+    KeySequence,
+    MouseClick,
+    SelectedText
+)
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     _BaseSourceWithLocation
 )
@@ -30,9 +37,9 @@ class _IndexedListEditor(_BaseSourceWithLocation):
     """ Wrapper class for EnumListEditor and Index.
     """
     source_class = ListEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_item_view(
                 model=wrapper._target.source.control.model(),
                 view=wrapper._target.source.control,
@@ -46,9 +53,9 @@ class _IndexedRadioEditor(_BaseSourceWithLocation):
     """ Wrapper class for EnumRadioEditor and Index.
     """
     source_class = RadioEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_qlayout(
                 layout=wrapper._target.source.control.layout(),
                 index=convert_index(
@@ -92,9 +99,9 @@ class _IndexedSimpleEditor(_BaseSourceWithLocation):
     """ Wrapper class for Simple EnumEditor and Index.
     """
     source_class = SimpleEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_combobox(
                 combobox=wrapper._target.source.control,
                 index=wrapper._target.location.index,
@@ -109,9 +116,9 @@ def radio_selected_text_handler(wrapper, interaction):
     ----------
     wrapper : UIWrapper
         The UIWrapper containing that object with text to be displayed.
-    interaction : query.SelectedText
+    interaction : SelectedText
         Unused in this function but included to match the expected format of a
-        handler.  Should only be query.SelectedText
+        handler.  Should only be SelectedText
     """
     control = wrapper._target.control
     for index in range(control.layout().count()):
@@ -132,21 +139,21 @@ def register(registry):
     _IndexedSimpleEditor.register(registry)
 
     simple_editor_text_handlers = [
-        (command.KeyClick,
+        (KeyClick,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_click_qwidget(
                     control=wrapper._target.control,
                     interaction=interaction,
                     delay=wrapper.delay))),
-        (command.KeySequence,
+        (KeySequence,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_sequence_qwidget(
                     control=wrapper._target.control,
                     interaction=interaction,
                     delay=wrapper.delay))),
-        (query.DisplayedText,
+        (DisplayedText,
             lambda wrapper, _: wrapper._target.control.currentText()),
-        (query.SelectedText,
+        (SelectedText,
             lambda wrapper, _: wrapper._target.control.currentText())
     ]
 
@@ -159,13 +166,13 @@ def register(registry):
 
     registry.register_interaction(
         target_class=RadioEditor,
-        interaction_class=query.SelectedText,
+        interaction_class=SelectedText,
         handler=radio_selected_text_handler,
     )
 
     registry.register_interaction(
         target_class=ListEditor,
-        interaction_class=query.SelectedText,
+        interaction_class=SelectedText,
         handler=lambda wrapper, _:
             wrapper._target.control.currentItem().text(),
     )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/instance_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/instance_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.tester import command
+from traitsui.testing.api import MouseClick
 from traitsui.testing.tester._ui_tester_registry.qt4._interaction_helpers import (  # noqa
     mouse_click_qwidget
 )
@@ -54,7 +54,7 @@ def register(registry):
     """
     registry.register_interaction(
         target_class=SimpleEditor,
-        interaction_class=command.MouseClick,
+        interaction_class=MouseClick,
         handler=lambda wrapper, _: (
             mouse_click_qwidget(wrapper._target._button, delay=wrapper.delay)
         )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -8,7 +8,10 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.tester import command, locator
+from traitsui.testing.api import (
+    Index,
+    MouseClick
+)
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     _BaseSourceWithLocation
 )
@@ -28,9 +31,9 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
     """ Wrapper for a ListEditor (Notebook) with an index.
     """
     source_class = NotebookEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_tab_index(
                 tab_widget=wrapper._target.source.control,
                 index=wrapper._target.location.index,
@@ -106,7 +109,7 @@ def register(registry):
     # CustomEditor
     registry.register_location(
         target_class=CustomEditor,
-        locator_class=locator.Index,
+        locator_class=Index,
         solver=lambda wrapper, location: (
             _get_next_target(wrapper._target, location.index)
         )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
@@ -16,7 +16,11 @@ from traitsui.qt4.range_editor import (
     SimpleSliderEditor,
 )
 
-from traitsui.testing.tester import command, locator
+from traitsui.testing.api import (
+    KeyClick,
+    Slider,
+    Textbox
+)
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers,
     _registry_helper
@@ -78,7 +82,7 @@ class LocatedSlider:
         """
         registry.register_interaction(
             target_class=cls,
-            interaction_class=command.KeyClick,
+            interaction_class=KeyClick,
             handler=lambda wrapper, interaction:
                 _interaction_helpers.key_click_qslider(
                     wrapper._target.slider, interaction, wrapper.delay)
@@ -102,13 +106,13 @@ def register(registry):
     for target_class in targets:
         registry.register_location(
             target_class=target_class,
-            locator_class=locator.Textbox,
+            locator_class=Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
                 textbox=wrapper._target.control.text),
         )
         registry.register_location(
             target_class=target_class,
-            locator_class=locator.Slider,
+            locator_class=Slider,
             solver=lambda wrapper, _: LocatedSlider(
                 slider=wrapper._target.control.slider),
         )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/text_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/text_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.tester import query
+from traitsui.testing.api import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -39,7 +39,7 @@ def register(registry):
 
     registry.register_interaction(
         target_class=ReadonlyEditor,
-        interaction_class=query.DisplayedText,
+        interaction_class=DisplayedText,
         handler=lambda wrapper, _: _interaction_helpers.displayed_text_qobject(
             wrapper._target.control),
     )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.qt4.ui_base import ButtonEditor
-from traitsui.testing.tester import command, query
+from traitsui.testing.api import DisplayedText, MouseClick
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -26,10 +26,10 @@ def register(registry):
     registry : TargetRegistry
     """
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_qwidget(
                 wrapper._target.control, wrapper.delay))),
-        (query.DisplayedText,
+        (DisplayedText,
             lambda wrapper, _: wrapper._target.control.text())
     ]
     for interaction_class, handler in handlers:

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.tester.registry import TargetRegistry
+from traitsui.testing.api import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     boolean_editor,
     button_editor,

--- a/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
@@ -14,7 +14,7 @@ import unittest
 from traitsui.testing.tester._ui_tester_registry.default_registry import (
     get_default_registry
 )
-from traitsui.testing.tester.registry import TargetRegistry
+from traitsui.testing.api import TargetRegistry
 from traitsui.tests._tools import is_null
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
@@ -14,7 +14,7 @@ import wx
 from traitsui.testing.tester._ui_tester_registry._compat import (
     check_key_compat
 )
-from traitsui.testing.tester.exceptions import Disabled
+from traitsui.testing.api import Disabled
 
 
 def _create_event(event_type, control):

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_registry_helper.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_registry_helper.py
@@ -13,7 +13,12 @@
 and location solvers for common Wx GUI components.
 """
 
-from traitsui.testing.tester import command, query
+from traitsui.testing.api import (
+    DisplayedText,
+    KeyClick,
+    KeySequence,
+    MouseClick
+)
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -31,18 +36,18 @@ def register_editable_textbox_handlers(registry, target_class, widget_getter):
         A callable to return a wx.TextCtrl
     """
     handlers = [
-        (command.KeySequence,
+        (KeySequence,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_sequence_text_ctrl(
                     widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.KeyClick,
+        (KeyClick,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_click_text_entry(
                     widget_getter(wrapper), interaction, wrapper.delay))),
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _: _interaction_helpers.mouse_click_object(
                 control=widget_getter(wrapper), delay=wrapper.delay))),
-        (query.DisplayedText,
+        (DisplayedText,
             lambda wrapper, _: widget_getter(wrapper).GetValue()),
     ]
     for interaction_class, handler in handlers:

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
@@ -11,7 +11,7 @@
 import wx
 
 from traitsui.wx.button_editor import SimpleEditor, CustomEditor
-from traitsui.testing.tester import command, query
+from traitsui.testing.api import DisplayedText, MouseClick
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -57,25 +57,25 @@ def register(registry):
 
     registry.register_interaction(
         target_class=SimpleEditor,
-        interaction_class=command.MouseClick,
+        interaction_class=MouseClick,
         handler=(lambda wrapper, _: _interaction_helpers.mouse_click_button(
                  control=wrapper._target.control, delay=wrapper.delay))
     )
 
     registry.register_interaction(
         target_class=SimpleEditor,
-        interaction_class=query.DisplayedText,
+        interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
     )
 
     registry.register_interaction(
         target_class=CustomEditor,
-        interaction_class=command.MouseClick,
+        interaction_class=MouseClick,
         handler=mouse_click_ImageButton
     )
 
     registry.register_interaction(
         target_class=CustomEditor,
-        interaction_class=query.DisplayedText,
+        interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/check_list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/check_list_editor.py
@@ -11,7 +11,7 @@
 import wx
 
 from traitsui.wx.check_list_editor import CustomEditor
-from traitsui.testing.tester import command, locator
+from traitsui.testing.api import Index, MouseClick
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     _BaseSourceWithLocation
 )
@@ -22,12 +22,12 @@ from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
 class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
-    """ Wrapper for CheckListEditor + locator.Index
+    """ Wrapper for CheckListEditor + Index
     """
     source_class = CustomEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _:
                 _interaction_helpers.mouse_click_checkbox_child_in_panel(
                     control=wrapper._target.source.control,

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/editor_factory.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/editor_factory.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.editor_factory import ReadonlyEditor, TextEditor
-from traitsui.testing.tester import query
+from traitsui.testing.api import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 from traitsui.testing.tester._ui_tester_registry.wx._registry_helper import (
     register_editable_textbox_handlers,
@@ -33,7 +33,7 @@ def register(registry):
     )
     registry.register_interaction(
         target_class=ReadonlyEditor,
-        interaction_class=query.DisplayedText,
+        interaction_class=DisplayedText,
         handler=lambda wrapper, _:
             _interaction_helpers.readonly_textbox_displayed_text(
                 wrapper._target.control),

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
@@ -15,7 +15,14 @@ from traitsui.wx.enum_editor import (
     RadioEditor,
     SimpleEditor,
 )
-from traitsui.testing.tester import command, locator, query
+from traitsui.testing.api import (
+    DisplayedText,
+    Index,
+    KeyClick,
+    KeySequence,
+    MouseClick,
+    SelectedText
+)
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     _BaseSourceWithLocation
 )
@@ -29,9 +36,9 @@ class _IndexedListEditor(_BaseSourceWithLocation):
     """ Wrapper class for EnumListEditor and Index.
     """
     source_class = ListEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _:
                 _interaction_helpers.mouse_click_listbox(
                     control=wrapper._target.source.control,
@@ -44,9 +51,9 @@ class _IndexedRadioEditor(_BaseSourceWithLocation):
     """ Wrapper class for EnumRadioEditor and Index.
     """
     source_class = RadioEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _:
                 _interaction_helpers.mouse_click_radiobutton_child_in_panel(
                     control=wrapper._target.source.control,
@@ -89,9 +96,9 @@ class _IndexedSimpleEditor(_BaseSourceWithLocation):
     """ Wrapper class for Simple EnumEditor and Index.
     """
     source_class = SimpleEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _:
                 _interaction_helpers.mouse_click_combobox_or_choice(
                     control=wrapper._target.source.control,
@@ -109,9 +116,9 @@ def simple_displayed_selected_text_handler(wrapper, interaction):
     ----------
     wrapper : UIWrapper
         The UIWrapper containing that object with text to be displayed.
-    interaction : query.DisplayedText
+    interaction : DisplayedText
         Unused in this function but included to match the expected format of a
-        handler.  Should only be query.DisplayedText
+        handler.  Should only be DisplayedText
     """
     control = wrapper._target.control
     if isinstance(control, wx.ComboBox):
@@ -127,9 +134,9 @@ def radio_selected_text_handler(wrapper, interaction):
     ----------
     wrapper : UIWrapper
         The UIWrapper containing that object with text that is selected.
-    interaction : query.SelectedText
+    interaction : SelectedText
         Unused in this function but included to match the expected format of a
-        handler.  Should only be query.SelectedText
+        handler.  Should only be SelectedText
     """
     children_list = wrapper._target.control.GetSizer().GetChildren()
     for child in children_list:
@@ -150,20 +157,20 @@ def register(registry):
     _IndexedSimpleEditor.register(registry)
 
     simple_editor_text_handlers = [
-        (command.KeyClick,
+        (KeyClick,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_click_combobox(
                     control=wrapper._target.control,
                     interaction=interaction,
                     delay=wrapper.delay))),
-        (command.KeySequence,
+        (KeySequence,
             (lambda wrapper, interaction:
                 _interaction_helpers.key_sequence_text_ctrl(
                     control=wrapper._target.control,
                     interaction=interaction,
                     delay=wrapper.delay))),
-        (query.DisplayedText, simple_displayed_selected_text_handler),
-        (query.SelectedText, simple_displayed_selected_text_handler)
+        (DisplayedText, simple_displayed_selected_text_handler),
+        (SelectedText, simple_displayed_selected_text_handler)
     ]
 
     for interaction_class, handler in simple_editor_text_handlers:
@@ -175,12 +182,12 @@ def register(registry):
 
     registry.register_interaction(
         target_class=RadioEditor,
-        interaction_class=query.SelectedText,
+        interaction_class=SelectedText,
         handler=radio_selected_text_handler,
     )
     registry.register_interaction(
         target_class=ListEditor,
-        interaction_class=query.SelectedText,
+        interaction_class=SelectedText,
         handler=lambda wrapper, _: wrapper._target.control.GetString(
             wrapper._target.control.GetSelection()),
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.tester import command
+from traitsui.testing.api import MouseClick
 from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
     register_traitsui_ui_solvers,
 )
@@ -52,7 +52,7 @@ def register(registry):
     """
     registry.register_interaction(
         target_class=SimpleEditor,
-        interaction_class=command.MouseClick,
+        interaction_class=MouseClick,
         handler=lambda wrapper, _: mouse_click_button(
             control=wrapper._target._button, delay=wrapper.delay,
         )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -8,7 +8,7 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.tester import command, locator
+from traitsui.testing.api import Index, MouseClick
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     _BaseSourceWithLocation
 )
@@ -26,9 +26,9 @@ class _IndexedNotebookEditor(_BaseSourceWithLocation):
     """ Wrapper for a ListEditor (Notebook) with an index.
     """
     source_class = NotebookEditor
-    locator_class = locator.Index
+    locator_class = Index
     handlers = [
-        (command.MouseClick,
+        (MouseClick,
             (lambda wrapper, _:
                 _interaction_helpers.mouse_click_notebook_tab_index(
                     control=wrapper._target.source.control,
@@ -103,7 +103,7 @@ def register(registry):
     # CustomEditor
     registry.register_location(
         target_class=CustomEditor,
-        locator_class=locator.Index,
+        locator_class=Index,
         solver=lambda wrapper, location: (
             _get_next_target(wrapper._target, location.index)
         )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
@@ -15,7 +15,11 @@ from traitsui.wx.range_editor import (
     SimpleSliderEditor,
 )
 
-from traitsui.testing.tester import command, locator
+from traitsui.testing.api import (
+    KeyClick,
+    Slider,
+    Textbox
+)
 from traitsui.testing.tester._ui_tester_registry.wx import (
     _interaction_helpers,
     _registry_helper
@@ -77,7 +81,7 @@ class LocatedSlider:
         """
         registry.register_interaction(
             target_class=cls,
-            interaction_class=command.KeyClick,
+            interaction_class=KeyClick,
             handler=lambda wrapper, interaction:
                 _interaction_helpers.key_click_slider(
                     wrapper._target.slider, interaction, wrapper.delay)
@@ -101,13 +105,13 @@ def register(registry):
     for target_class in targets:
         registry.register_location(
             target_class=target_class,
-            locator_class=locator.Textbox,
+            locator_class=Textbox,
             solver=lambda wrapper, _: LocatedTextbox(
                 textbox=wrapper._target.control.text),
         )
         registry.register_location(
             target_class=target_class,
-            locator_class=locator.Slider,
+            locator_class=Slider,
             solver=lambda wrapper, _: LocatedSlider(
                 slider=wrapper._target.control.slider),
         )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/text_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/text_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.text_editor import CustomEditor, ReadonlyEditor, SimpleEditor
-from traitsui.testing.tester import query
+from traitsui.testing.api import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 from traitsui.testing.tester._ui_tester_registry.wx._registry_helper import (
     register_editable_textbox_handlers,
@@ -35,7 +35,7 @@ def register(registry):
 
     registry.register_interaction(
         target_class=ReadonlyEditor,
-        interaction_class=query.DisplayedText,
+        interaction_class=DisplayedText,
         handler=lambda wrapper, _:
             _interaction_helpers.readonly_textbox_displayed_text(
                 wrapper._target.control),

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.ui_base import ButtonEditor
-from traitsui.testing.tester import command, query
+from traitsui.testing.api import DisplayedText, MouseClick
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -26,13 +26,13 @@ def register(registry):
 
     registry.register_interaction(
         target_class=ButtonEditor,
-        interaction_class=command.MouseClick,
+        interaction_class=MouseClick,
         handler=(lambda wrapper, _: _interaction_helpers.mouse_click_button(
                  control=wrapper._target.control, delay=wrapper.delay))
     )
 
     registry.register_interaction(
         target_class=ButtonEditor,
-        interaction_class=query.DisplayedText,
+        interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.tester.registry import TargetRegistry
+from traitsui.testing.api import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
     boolean_editor,
     button_editor,

--- a/traitsui/tests/_tools.py
+++ b/traitsui/tests/_tools.py
@@ -29,7 +29,7 @@ from traits.etsconfig.api import ETSConfig
 # to traitsui.testing and then these aliases can be removed.
 from traitsui.testing._exception_handling import reraise_exceptions  # noqa
 from traitsui.testing._gui import process_cascade_events  # noqa: F401
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import UITester
 
 # ######### Testing tools
 

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -9,8 +9,11 @@ from traitsui.tests._tools import (
     reraise_exceptions,
     ToolkitName,
 )
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText,
+    MouseClick,
+    UITester
+)
 
 
 class ButtonTextEdit(HasTraits):
@@ -61,11 +64,11 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         tester = UITester()
         with tester.create_ui(button_text_edit, dict(view=view)) as ui:
             button = tester.find_by_name(ui, "play_button")
-            actual = button.inspect(query.DisplayedText())
+            actual = button.inspect(DisplayedText())
             self.assertEqual(actual, "I'm a play button")
 
             button_text_edit.play_button_label = "New Label"
-            actual = button.inspect(query.DisplayedText())
+            actual = button.inspect(DisplayedText())
             self.assertEqual(actual, "New Label")
 
     def test_styles(self):
@@ -89,7 +92,7 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
 
             with self.assertTraitChanges(
                     button_text_edit, "play_button", count=1):
-                button.perform(command.MouseClick())
+                button.perform(MouseClick())
 
     def test_simple_button_editor_clicked(self):
         self.check_button_fired_event(simple_view)
@@ -116,12 +119,12 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
 
             with self.assertTraitDoesNotChange(
                     button_text_edit, "play_button"):
-                button.perform(command.MouseClick())
+                button.perform(MouseClick())
 
             button_text_edit.button_enabled = True
             with self.assertTraitChanges(
                     button_text_edit, "play_button", count=1):
-                button.perform(command.MouseClick())
+                button.perform(MouseClick())
 
     def test_simple_button_editor_disabled(self):
         self.check_button_disabled("simple")

--- a/traitsui/tests/editors/test_check_list_editor.py
+++ b/traitsui/tests/editors/test_check_list_editor.py
@@ -14,8 +14,11 @@ from traitsui.tests._tools import (
     reraise_exceptions,
     ToolkitName,
 )
-from traitsui.testing.tester.ui_tester import UITester
-from traitsui.testing.tester import command, locator
+from traitsui.testing.api import (
+    Index,
+    MouseClick,
+    UITester
+)
 
 
 class ListModel(HasTraits):
@@ -461,10 +464,10 @@ class TestCustomCheckListEditor(BaseTestMixin, unittest.TestCase):
         with tester.create_ui(list_edit, dict(view=get_view("custom"))) as ui:
             self.assertEqual(list_edit.value, [])
             check_list = tester.find_by_name(ui, "value")
-            item_1 = check_list.locate(locator.Index(1))
-            item_1.perform(command.MouseClick())
+            item_1 = check_list.locate(Index(1))
+            item_1.perform(MouseClick())
             self.assertEqual(list_edit.value, ["two"])
-            item_1.perform(command.MouseClick())
+            item_1.perform(MouseClick())
             self.assertEqual(list_edit.value, [])
 
     def test_custom_check_list_editor_click_initial_value(self):
@@ -475,8 +478,8 @@ class TestCustomCheckListEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(list_edit.value, ["two"])
 
             check_list = tester.find_by_name(ui, "value")
-            item_1 = check_list.locate(locator.Index(1))
-            item_1.perform(command.MouseClick())
+            item_1 = check_list.locate(Index(1))
+            item_1.perform(MouseClick())
 
             self.assertEqual(list_edit.value, [])
 
@@ -492,8 +495,8 @@ class TestCustomCheckListEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(str_edit.value, "two,three,one")
 
             check_list = tester.find_by_name(ui, "value")
-            item_1 = check_list.locate(locator.Index(1))
-            item_1.perform(command.MouseClick())
+            item_1 = check_list.locate(Index(1))
+            item_1.perform(MouseClick())
 
             self.assertEqual(str_edit.value, "three,one")
 
@@ -505,10 +508,10 @@ class TestCustomCheckListEditor(BaseTestMixin, unittest.TestCase):
             with tester.create_ui(list_edit, dict(view=view)) as ui:
                 self.assertEqual(list_edit.value, [])
                 check_list = tester.find_by_name(ui, "value")
-                item = check_list.locate(locator.Index(6))
-                item.perform(command.MouseClick())
+                item = check_list.locate(Index(6))
+                item.perform(MouseClick())
                 self.assertEqual(list_edit.value, ["seven"])
-                item.perform(command.MouseClick())
+                item.perform(MouseClick())
                 self.assertEqual(list_edit.value, [])
 
 

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -13,9 +13,16 @@ from traitsui.tests._tools import (
     reraise_exceptions,
     ToolkitName,
 )
-from traitsui.testing.tester import command, locator, query
-from traitsui.testing.tester.exceptions import Disabled
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    Disabled,
+    DisplayedText,
+    Index,
+    KeyClick,
+    KeySequence,
+    MouseClick,
+    SelectedText,
+    UITester
+)
 
 is_windows = platform.system() == "Windows"
 
@@ -196,11 +203,11 @@ class TestSimpleEnumEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(enum_edit, dict(view=view)) as ui:
             combobox = tester.find_by_name(ui, "value")
-            displayed = combobox.inspect(query.DisplayedText())
+            displayed = combobox.inspect(DisplayedText())
             self.assertEqual(displayed, "one")
 
-            combobox.locate(locator.Index(1)).perform(command.MouseClick())
-            displayed = combobox.inspect(query.DisplayedText())
+            combobox.locate(Index(1)).perform(MouseClick())
+            displayed = combobox.inspect(DisplayedText())
             self.assertEqual(displayed, "two")
 
     def check_enum_object_update(self, view):
@@ -213,9 +220,9 @@ class TestSimpleEnumEditor(BaseTestMixin, unittest.TestCase):
 
             combobox = tester.find_by_name(ui, "value")
             for _ in range(3):
-                combobox.perform(command.KeyClick("Backspace"))
-            combobox.perform(command.KeySequence("two"))
-            combobox.perform(command.KeyClick("Enter"))
+                combobox.perform(KeyClick("Backspace"))
+            combobox.perform(KeySequence("two"))
+            combobox.perform(KeyClick("Enter"))
 
             self.assertEqual(enum_edit.value, "two")
 
@@ -227,7 +234,7 @@ class TestSimpleEnumEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(enum_edit.value, "one")
 
             combobox = tester.find_by_name(ui, "value")
-            combobox.locate(locator.Index(1)).perform(command.MouseClick())
+            combobox.locate(Index(1)).perform(MouseClick())
 
             self.assertEqual(enum_edit.value, "two")
 
@@ -241,9 +248,9 @@ class TestSimpleEnumEditor(BaseTestMixin, unittest.TestCase):
 
             combobox = tester.find_by_name(ui, "value")
             for _ in range(3):
-                combobox.perform(command.KeyClick("Backspace"))
-            combobox.perform(command.KeyClick("H"))
-            combobox.perform(command.KeyClick("Enter"))
+                combobox.perform(KeyClick("Backspace"))
+            combobox.perform(KeyClick("H"))
+            combobox.perform(KeyClick("Enter"))
 
             self.assertEqual(enum_edit.value, "one")
 
@@ -278,11 +285,11 @@ class TestSimpleEnumEditor(BaseTestMixin, unittest.TestCase):
 
             combobox = tester.find_by_name(ui, "value")
             for _ in range(3):
-                combobox.perform(command.KeyClick("Backspace"))
-            combobox.perform(command.KeySequence("two"))
+                combobox.perform(KeyClick("Backspace"))
+            combobox.perform(KeySequence("two"))
 
             self.assertEqual(enum_edit.value, "one")
-            combobox.perform(command.KeyClick("Enter"))
+            combobox.perform(KeyClick("Enter"))
             self.assertEqual(enum_edit.value, "two")
 
     def test_simple_editor_resizable(self):
@@ -320,9 +327,9 @@ class TestSimpleEnumEditor(BaseTestMixin, unittest.TestCase):
         with tester.create_ui(enum_edit, dict(view=view)) as ui:
             combobox = tester.find_by_name(ui, "value")
             with self.assertRaises(Disabled):
-                combobox.perform(command.KeyClick("Enter"))
+                combobox.perform(KeyClick("Enter"))
             with self.assertRaises(Disabled):
-                combobox.perform(command.KeySequence("two"))
+                combobox.perform(KeySequence("two"))
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
@@ -343,14 +350,14 @@ class TestRadioEnumEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(enum_edit.value, "one")
             radio_editor = tester.find_by_name(ui, "value")
             self.assertEqual(
-                radio_editor.inspect(query.SelectedText()),
+                radio_editor.inspect(SelectedText()),
                 "One",
             )
 
             enum_edit.value = "two"
 
             self.assertEqual(
-                radio_editor.inspect(query.SelectedText()),
+                radio_editor.inspect(SelectedText()),
                 "Two",
             )
 
@@ -367,8 +374,8 @@ class TestRadioEnumEditor(BaseTestMixin, unittest.TestCase):
                     if is_qt():
                         radio_editor._target.row_major = row_major
                         radio_editor._target.rebuild_editor()
-                    item = radio_editor.locate(locator.Index(3))
-                    item.perform(command.MouseClick())
+                    item = radio_editor.locate(Index(3))
+                    item.perform(MouseClick())
                     self.assertEqual(enum_edit.value, "four")
 
     # it appears that on windows the behavior is different - it forces
@@ -380,7 +387,7 @@ class TestRadioEnumEditor(BaseTestMixin, unittest.TestCase):
         with tester.create_ui(enum_edit, dict(view=get_radio_view())) as ui:
             self.assertEqual(enum_edit.value, None)
             radio_editor = tester.find_by_name(ui, "value")
-            displayed = radio_editor.inspect(query.SelectedText())
+            displayed = radio_editor.inspect(SelectedText())
             self.assertEqual(displayed, None)
 
 
@@ -400,12 +407,12 @@ class TestListEnumEditor(BaseTestMixin, unittest.TestCase):
         with tester.create_ui(enum_edit, dict(view=view)) as ui:
 
             list_editor = tester.find_by_name(ui, "value")
-            displayed = list_editor.inspect(query.SelectedText())
+            displayed = list_editor.inspect(SelectedText())
 
             self.assertEqual(displayed, "one")
 
-            list_editor.locate(locator.Index(1)).perform(command.MouseClick())
-            displayed = list_editor.inspect(query.SelectedText())
+            list_editor.locate(Index(1)).perform(MouseClick())
+            displayed = list_editor.inspect(SelectedText())
             self.assertEqual(displayed, "two")
 
     def check_enum_index_update(self, view):
@@ -416,7 +423,7 @@ class TestListEnumEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(enum_edit.value, "one")
 
             list_editor = tester.find_by_name(ui, "value")
-            list_editor.locate(locator.Index(1)).perform(command.MouseClick())
+            list_editor.locate(Index(1)).perform(MouseClick())
 
             self.assertEqual(enum_edit.value, "two")
 
@@ -474,5 +481,5 @@ class TestListEnumEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(enum_edit.value, None)
             list_editor = tester.find_by_name(ui, "value")
             # As a result the displayed text is actually the string 'None'
-            displayed = list_editor.inspect(query.SelectedText())
+            displayed = list_editor.inspect(SelectedText())
             self.assertEqual(displayed, 'None')

--- a/traitsui/tests/editors/test_font_editor.py
+++ b/traitsui/tests/editors/test_font_editor.py
@@ -18,8 +18,10 @@ from traitsui.tests._tools import (
     requires_toolkit,
     ToolkitName,
 )
-from traitsui.testing.tester import command
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    MouseClick,
+    UITester
+)
 
 
 class ObjectWithFont(HasTraits):
@@ -36,4 +38,4 @@ class TestFontEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(ObjectWithFont(), dict(view=view)) as ui:
             wrapper = tester.find_by_name(ui, "font_trait")
-            wrapper.perform(command.MouseClick())
+            wrapper.perform(MouseClick())

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -9,8 +9,12 @@ from traitsui.tests._tools import (
     ToolkitName,
 )
 
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText,
+    KeySequence,
+    MouseClick,
+    UITester
+)
 
 
 class EditedInstance(HasTraits):
@@ -40,9 +44,9 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("simple"))) as ui:
             instance = tester.find_by_name(ui, "inst")
-            instance.perform(command.MouseClick())
+            instance.perform(MouseClick())
             value_txt = instance.find_by_name("value")
-            value_txt.perform(command.KeySequence("abc"))
+            value_txt.perform(KeySequence("abc"))
             self.assertEqual(obj.inst.value, "abc")
 
     def test_custom_editor(self):
@@ -50,7 +54,7 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("custom"))) as ui:
             value_txt = tester.find_by_name(ui, "inst").find_by_name("value")
-            value_txt.perform(command.KeySequence("abc"))
+            value_txt.perform(KeySequence("abc"))
             self.assertEqual(obj.inst.value, "abc")
 
     def test_custom_editor_resynch_editor(self):
@@ -59,10 +63,10 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("custom"))) as ui:
             value_txt = tester.find_by_name(ui, "inst").find_by_name("value")
-            displayed = value_txt.inspect(query.DisplayedText())
+            displayed = value_txt.inspect(DisplayedText())
             self.assertEqual(displayed, "hello")
             edited_inst.value = "bye"
-            displayed = value_txt.inspect(query.DisplayedText())
+            displayed = value_txt.inspect(DisplayedText())
             self.assertEqual(displayed, "bye")
 
     def test_simple_editor_resynch_editor(self):
@@ -71,13 +75,13 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("simple"))) as ui:
             instance = tester.find_by_name(ui, "inst")
-            instance.perform(command.MouseClick())
+            instance.perform(MouseClick())
 
             value_txt = instance.find_by_name("value")
-            displayed = value_txt.inspect(query.DisplayedText())
+            displayed = value_txt.inspect(DisplayedText())
             self.assertEqual(displayed, "hello")
             edited_inst.value = "bye"
-            displayed = value_txt.inspect(query.DisplayedText())
+            displayed = value_txt.inspect(DisplayedText())
             self.assertEqual(displayed, "bye")
 
     def test_simple_editor_parent_closed(self):
@@ -85,4 +89,4 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view('simple'))) as ui:
             instance = tester.find_by_name(ui, "inst")
-            instance.perform(command.MouseClick())
+            instance.perform(MouseClick())

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -2,9 +2,16 @@ import unittest
 
 from traits.api import HasStrictTraits, Instance, Int, List, Str
 from traitsui.api import Item, ListEditor, View
-from traitsui.testing.tester import command, locator, query
-from traitsui.testing.tester.exceptions import LocationNotSupported
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText,
+    Index,
+    KeyClick,
+    KeySequence,
+    LocationNotSupported,
+    MouseClick,
+    Textbox,
+    UITester
+)
 from traitsui.tests._tools import (
     requires_toolkit,
     ToolkitName,
@@ -88,12 +95,12 @@ class TestCustomListEditor(unittest.TestCase):
                 # sanity check
                 self.assertEqual(obj.people[7].name, "Fields")
                 people_list = tester.find_by_name(ui, "people")
-                item = people_list.locate(locator.Index(7))
+                item = people_list.locate(Index(7))
                 name_field = item.find_by_name("name")
                 for _ in range(6):
-                    name_field.perform(command.KeyClick("Backspace"))
-                name_field.perform(command.KeySequence("David"))
-                displayed = name_field.inspect(query.DisplayedText())
+                    name_field.perform(KeyClick("Backspace"))
+                name_field.perform(KeySequence("David"))
+                displayed = name_field.inspect(DisplayedText())
                 self.assertEqual(obj.people[7].name, "David")
                 self.assertEqual(displayed, obj.people[7].name)
 
@@ -103,8 +110,8 @@ class TestCustomListEditor(unittest.TestCase):
         with tester.create_ui(obj) as ui:
             with self.assertRaises(LocationNotSupported) as exc:
                 people_list = tester.find_by_name(ui, "people")
-                people_list.locate(locator.Textbox())
-            self.assertIn(locator.Index, exc.exception.supported)
+                people_list.locate(Textbox())
+            self.assertIn(Index, exc.exception.supported)
 
     def test_index_out_of_range(self):
         obj = ListTraitTest(people=get_people())
@@ -112,7 +119,7 @@ class TestCustomListEditor(unittest.TestCase):
         with tester.create_ui(obj) as ui:
             people_list = tester.find_by_name(ui, "people")
             with self.assertRaises(IndexError):
-                people_list.locate(locator.Index(10))
+                people_list.locate(Index(10))
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
@@ -125,11 +132,11 @@ class TestNotebookListEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(phonebook, dict(view=notebook_view)) as ui:
             list_ = tester.find_by_name(ui, "people")
-            list_.locate(locator.Index(1)).perform(command.MouseClick())
-            name_field = list_.locate(locator.Index(1)).find_by_name("name")
+            list_.locate(Index(1)).perform(MouseClick())
+            name_field = list_.locate(Index(1)).find_by_name("name")
             for _ in range(4):
-                name_field.perform(command.KeyClick("Backspace"))
-            name_field.perform(command.KeySequence("Pete"))
+                name_field.perform(KeyClick("Backspace"))
+            name_field.perform(KeySequence("Pete"))
 
             self.assertEqual(phonebook.people[1].name, "Pete")
 
@@ -142,9 +149,9 @@ class TestNotebookListEditor(unittest.TestCase):
         tester = UITester()
         with tester.create_ui(phonebook, dict(view=notebook_view)) as ui:
             list_ = tester.find_by_name(ui, "people")
-            list_.locate(locator.Index(1)).perform(command.MouseClick())
-            name_field = list_.locate(locator.Index(1)).find_by_name("name")
-            actual = name_field.inspect(query.DisplayedText())
+            list_.locate(Index(1)).perform(MouseClick())
+            name_field = list_.locate(Index(1)).find_by_name("name")
+            actual = name_field.inspect(DisplayedText())
             self.assertEqual(actual, "Mary")
 
     def test_index_out_of_bound(self):
@@ -155,5 +162,5 @@ class TestNotebookListEditor(unittest.TestCase):
         with tester.create_ui(phonebook, dict(view=notebook_view)) as ui:
             with self.assertRaises(IndexError):
                 tester.find_by_name(ui, "people").\
-                    locate(locator.Index(0)).\
-                    perform(command.MouseClick())
+                    locate(Index(0)).\
+                    perform(MouseClick())

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -3,9 +3,15 @@ import unittest
 
 from traits.api import HasTraits, Float, Int
 from traitsui.api import Item, RangeEditor, UItem, View
-from traitsui.testing.tester import command, locator, query
-from traitsui.testing.tester.registry import TargetRegistry
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import (
+    DisplayedText,
+    KeyClick,
+    KeySequence,
+    Slider,
+    TargetRegistry,
+    Textbox,
+    UITester
+)
 from traitsui.tests._tools import (
     BaseTestMixin,
     is_wx,
@@ -102,10 +108,10 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             # sanity check
             self.assertEqual(model.value, 1)
             number_field = tester.find_by_name(ui, "value")
-            text = number_field.locate(locator.Textbox())
-            text.perform(command.KeyClick("0"))
-            text.perform(command.KeyClick("Enter"))
-            displayed = text.inspect(query.DisplayedText())
+            text = number_field.locate(Textbox())
+            text.perform(KeyClick("0"))
+            text.perform(KeyClick("Enter"))
+            displayed = text.inspect(DisplayedText())
             self.assertEqual(model.value, 10)
             self.assertEqual(displayed, str(model.value))
 
@@ -135,10 +141,10 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
                 # For RangeTextEditor on wx and windows, the textbox
                 # automatically gets focus and the full content is selected.
                 # Insertion point is moved to keep the test consistent
-                number_field_text.perform(command.KeyClick("End"))
-            number_field_text.perform(command.KeyClick("0"))
-            number_field_text.perform(command.KeyClick("Enter"))
-            displayed = number_field_text.inspect(query.DisplayedText())
+                number_field_text.perform(KeyClick("End"))
+            number_field_text.perform(KeyClick("0"))
+            number_field_text.perform(KeyClick("Enter"))
+            displayed = number_field_text.inspect(DisplayedText())
             self.assertEqual(model.value, 10)
             self.assertEqual(displayed, str(model.value))
 
@@ -160,10 +166,10 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(model.value, 1)
             number_field = tester.find_by_name(ui, "value")
             # For whatever reason, "End" was not working here
-            number_field.perform(command.KeyClick("Right"))
-            number_field.perform(command.KeyClick("0"))
-            number_field.perform(command.KeyClick("Enter"))
-            displayed = number_field.inspect(query.DisplayedText())
+            number_field.perform(KeyClick("Right"))
+            number_field.perform(KeyClick("0"))
+            number_field.perform(KeyClick("Enter"))
+            displayed = number_field.inspect(DisplayedText())
             self.assertEqual(model.value, 10)
             self.assertEqual(displayed, str(model.value))
 
@@ -178,13 +184,13 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
-            text = number_field.locate(locator.Textbox())
+            text = number_field.locate(Textbox())
             # Delete all contents of textbox
             for _ in range(5):
-                text.perform(command.KeyClick("Backspace"))
-            text.perform(command.KeySequence("11"))
-            text.perform(command.KeyClick("Enter"))
-            displayed = text.inspect(query.DisplayedText())
+                text.perform(KeyClick("Backspace"))
+            text.perform(KeySequence("11"))
+            text.perform(KeyClick("Enter"))
+            displayed = text.inspect(DisplayedText())
             self.assertEqual(model.value, 11)
             self.assertEqual(displayed, str(model.value))
 
@@ -213,10 +219,10 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             number_field_text = tester.find_by_name(ui, "value")
             # Delete all contents of textbox
             for _ in range(5):
-                number_field_text.perform(command.KeyClick("Backspace"))
-            number_field_text.perform(command.KeySequence("11"))
-            number_field_text.perform(command.KeyClick("Enter"))
-            displayed = number_field_text.inspect(query.DisplayedText())
+                number_field_text.perform(KeyClick("Backspace"))
+            number_field_text.perform(KeySequence("11"))
+            number_field_text.perform(KeyClick("Enter"))
+            displayed = number_field_text.inspect(DisplayedText())
             self.assertEqual(model.value, 11)
             self.assertEqual(displayed, str(model.value))
 
@@ -235,13 +241,13 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester(registries=[LOCAL_REGISTRY])
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field_text = tester.find_by_name(ui, "value")
-            number_field_text.perform(command.KeyClick("Right"))
+            number_field_text.perform(KeyClick("Right"))
             # Delete all contents of textbox
             for _ in range(5):
-                number_field_text.perform(command.KeyClick("Backspace"))
-            number_field_text.perform(command.KeySequence("11"))
-            number_field_text.perform(command.KeyClick("Enter"))
-            displayed = number_field_text.inspect(query.DisplayedText())
+                number_field_text.perform(KeyClick("Backspace"))
+            number_field_text.perform(KeySequence("11"))
+            number_field_text.perform(KeyClick("Enter"))
+            displayed = number_field_text.inspect(DisplayedText())
             self.assertEqual(model.value, 11)
             self.assertEqual(displayed, str(model.value))
 
@@ -256,20 +262,20 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "value")
-            slider = number_field.locate(locator.Slider())
-            text = number_field.locate(locator.Textbox())
+            slider = number_field.locate(Slider())
+            text = number_field.locate(Textbox())
             # slider values are converted to a [0, 10000] scale.  A single
             # step is a change of 100 on that scale and a page step is 1000.
             # Our range in [0, 10] so these correspond to changes of .1 and 1.
             # Note: when tested manually, the step size seen on OSX and Wx is
             # different.
             for _ in range(10):
-                slider.perform(command.KeyClick("Right"))
-            displayed = text.inspect(query.DisplayedText())
+                slider.perform(KeyClick("Right"))
+            displayed = text.inspect(DisplayedText())
             self.assertEqual(model.value, 1)
             self.assertEqual(displayed, str(model.value))
-            slider.perform(command.KeyClick("Page Up"))
-            displayed = text.inspect(query.DisplayedText())
+            slider.perform(KeyClick("Page Up"))
+            displayed = text.inspect(DisplayedText())
             self.assertEqual(model.value, 2)
             self.assertEqual(displayed, str(model.value))
 
@@ -290,17 +296,17 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             number_field = tester.find_by_name(ui, "float_value")
-            slider = number_field.locate(locator.Slider())
-            text = number_field.locate(locator.Textbox())
+            slider = number_field.locate(Slider())
+            text = number_field.locate(Textbox())
             # 10 steps is equivalent to 1 page step
             # on this scale either of those is equivalent to increasing the
             # trait's value from 10^n to 10^(n+1)
             for _ in range(10):
-                slider.perform(command.KeyClick("Right"))
-            displayed = text.inspect(query.DisplayedText())
+                slider.perform(KeyClick("Right"))
+            displayed = text.inspect(DisplayedText())
             self.assertEqual(model.float_value, 1.0)
             self.assertEqual(displayed, str(model.float_value))
-            slider.perform(command.KeyClick("Page Up"))
-            displayed = text.inspect(query.DisplayedText())
+            slider.perform(KeyClick("Page Up"))
+            displayed = text.inspect(DisplayedText())
             self.assertEqual(model.float_value, 10.0)
             self.assertEqual(displayed, str(model.float_value))

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -325,7 +325,7 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
                 tester.find_by_name(ui, "name").inspect(DisplayedText())
             )
             display_nickname = (
-                tester.find_by_name(ui, "nickname").inspect(DisplayedText())  # noqa E501
+                tester.find_by_name(ui, "nickname").inspect(DisplayedText())
             )
             self.assertEqual(display_name, "WILLIAM")
             self.assertEqual(display_nickname, "bill")

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -21,9 +21,14 @@ from traits.api import (
 )
 from traits.testing.api import UnittestTools
 from traitsui.api import TextEditor, View, Item
-from traitsui.testing.tester.ui_tester import UITester
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.exceptions import InteractionNotSupported
+from traitsui.testing.api import (
+    DisplayedText,
+    KeyClick,
+    KeySequence,
+    MouseClick,
+    InteractionNotSupported,
+    UITester
+)
 from traitsui.tests._tools import (
     BaseTestMixin,
     GuiTestAssistant,
@@ -178,9 +183,9 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         with tester.create_ui(foo, dict(view=view)) as ui:
             with self.assertTraitChanges(foo, "name", count=3):
                 name_field = tester.find_by_name(ui, "name")
-                name_field.perform(command.KeySequence("NEW"))
+                name_field.perform(KeySequence("NEW"))
                 # with auto-set the displayed name should match the name trait
-            display_name = name_field.inspect(query.DisplayedText())
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "NEW")
             self.assertEqual(display_name, foo.name)
 
@@ -194,15 +199,15 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
             name_field = tester.find_by_name(ui, "name")
-            name_field.perform(command.KeySequence("NEW"))
+            name_field.perform(KeySequence("NEW"))
             # with auto-set as False the displayed name should match what has
             # been typed not the trait itself, After "Enter" is pressed it
             # should match the name trait
-            display_name = name_field.inspect(query.DisplayedText())
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "")
             self.assertEqual(display_name, "NEW")
-            name_field.perform(command.KeyClick("Enter"))
-            display_name = name_field.inspect(query.DisplayedText())
+            name_field.perform(KeyClick("Enter"))
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "NEW")
             self.assertEqual(display_name, foo.name)
 
@@ -222,15 +227,15 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
             name_field = tester.find_by_name(ui, "name")
-            name_field.perform(command.KeySequence("NEW"))
+            name_field.perform(KeySequence("NEW"))
             # with auto-set as False the displayed name should match what has
             # been typed not the trait itself, After moving to another textbox
             # it should match the name trait
-            display_name = name_field.inspect(query.DisplayedText())
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "")
             self.assertEqual(display_name, "NEW")
-            tester.find_by_name(ui, "nickname").perform(command.MouseClick())
-            display_name = name_field.inspect(query.DisplayedText())
+            tester.find_by_name(ui, "nickname").perform(MouseClick())
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "NEW")
             self.assertEqual(display_name, foo.name)
 
@@ -242,9 +247,9 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         with tester.create_ui(foo, dict(view=view)) as ui:
             with self.assertTraitChanges(foo, "name", count=3):
                 name_field = tester.find_by_name(ui, "name")
-                name_field.perform(command.KeySequence("NEW"))
+                name_field.perform(KeySequence("NEW"))
             # with auto-set the displayed name should match the name trait
-            display_name = name_field.inspect(query.DisplayedText())
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "NEW")
             self.assertEqual(display_name, foo.name)
 
@@ -256,9 +261,9 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
             name_field = tester.find_by_name(ui, "name")
-            name_field.perform(command.KeySequence("NEW"))
-            name_field.perform(command.KeyClick("Enter"))
-            display_name = name_field.inspect(query.DisplayedText())
+            name_field.perform(KeySequence("NEW"))
+            name_field.perform(KeyClick("Enter"))
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "NEW\n")
             self.assertEqual(display_name, foo.name)
 
@@ -278,15 +283,15 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
             name_field = tester.find_by_name(ui, "name")
-            name_field.perform(command.KeySequence("NEW"))
+            name_field.perform(KeySequence("NEW"))
             # with auto-set as False the displayed name should match what has
             # been typed not the trait itself, After moving to another textbox
             # it should match the name trait
-            display_name = name_field.inspect(query.DisplayedText())
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "")
             self.assertEqual(display_name, "NEW")
-            tester.find_by_name(ui, "nickname").perform(command.MouseClick())
-            display_name = name_field.inspect(query.DisplayedText())
+            tester.find_by_name(ui, "nickname").perform(MouseClick())
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(foo.name, "NEW")
             self.assertEqual(display_name, foo.name)
 
@@ -297,11 +302,11 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         with tester.create_ui(foo, dict(view=view)) as ui:
             name_field = tester.find_by_name(ui, "name")
             with self.assertRaises(InteractionNotSupported):
-                name_field.perform(command.KeySequence("NEW"))
+                name_field.perform(KeySequence("NEW"))
             # Trying to type should do nothing
             with self.assertRaises(InteractionNotSupported):
-                name_field.perform(command.KeyClick("Space"))
-            display_name = name_field.inspect(query.DisplayedText())
+                name_field.perform(KeyClick("Space"))
+            display_name = name_field.inspect(DisplayedText())
             self.assertEqual(display_name, "A name")
 
     def check_format_func_used(self, style):
@@ -317,10 +322,10 @@ class TestTextEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
             display_name = (
-                tester.find_by_name(ui, "name").inspect(query.DisplayedText())
+                tester.find_by_name(ui, "name").inspect(DisplayedText())
             )
             display_nickname = (
-                tester.find_by_name(ui, "nickname").inspect(query.DisplayedText())  # noqa E501
+                tester.find_by_name(ui, "nickname").inspect(DisplayedText())  # noqa E501
             )
             self.assertEqual(display_name, "WILLIAM")
             self.assertEqual(display_nickname, "bill")


### PR DESCRIPTION
In much of the `traitsui.testing` internal code, the `traitsui.testing.api` was not currently being used for imports.  Likewise for tests using the tester in `traitsui/tests/editors`.  This PR simply updates import statements to use the recently populate api module.  