### PR TITLE
Misc. clean up of UI Tester (typos, comments, docstring updates)

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/_layout.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_layout.py
@@ -10,7 +10,7 @@
 #
 """ This module contains helper functions for working with layouts inside an
 editor. For example, converting indices so they count through the layout
-appropraitely.
+appropriately.
 """
 
 
@@ -44,7 +44,7 @@ def column_major_to_row_major(index, n, num_rows, num_cols):
     up having at most its last row as incomplete. The general approach for the
     algorithm is to find the coordinates as if we had counted through the
     grid in column major order, and then convert that back to a row major
-    index. The complications come from hte fact that the last row may be
+    index. The complications come from the fact that the last row may be
     missing entries.
     Consider the example (n=17, num_row=4, num_cols=5)
     0  4  8  11  14
@@ -55,7 +55,7 @@ def column_major_to_row_major(index, n, num_rows, num_cols):
 
     If the given index is 7 then we are in a column of the matrix where
     all rows are full.  This corresponds to the else branch below. From here,
-    we simply find the (i,j) coordiantes of the entry 7 above, with the upper
+    we simply find the (i,j) coordinates of the entry 7 above, with the upper
     left corner representing (0,0).  Thus, (i,j) = (3,1).  Now, to convert
     this to a row major index, we can simply take i * num_cols + j.
 
@@ -68,7 +68,7 @@ def column_major_to_row_major(index, n, num_rows, num_cols):
     1  5            9  12  15
     2  6            10 13  16
     3  7
-    we find the (i2,j2) coordiantes of the entry 15 above in grid2, with the
+    we find the (i2,j2) coordinates of the entry 15 above in grid2, with the
     upper left corner of grid2 representing (0,0). Hence, (i2,j2) = (1,2).
     We then find that index if we had counted in row major order for grid2,
     which would be i2 * num_empty_entries_last_row + j2 = 5, and add that to

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
@@ -18,7 +18,7 @@ from traitsui.testing.tester.exceptions import Disabled
 from traitsui.qt4.key_event_to_name import key_map as _KEY_MAP
 
 
-def key_click(widget, key, delay=0):
+def key_click(widget, key, delay):
     """ Performs a key click of the given key on the given widget after
     a delay.
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
@@ -134,6 +134,11 @@ def mouse_click_tab_index(tab_widget, index, delay):
         The index of the tab to be clicked.
     delay : int
         Time delay (in ms) in which click will be performed.
+
+    Raises
+    ------
+    IndexError
+        If the index is out of range.
     """
     if not 0 <= index < tab_widget.count():
         raise IndexError(index)
@@ -157,6 +162,11 @@ def mouse_click_qlayout(layout, index, delay):
         The layout containing the widget to be clicked
     index : int
         The index of the widget in the layout to be clicked
+
+    Raises
+    ------
+    IndexError
+        If the index is out of range.
     """
     if not 0 <= index < layout.count():
         raise IndexError(index)
@@ -235,6 +245,11 @@ def key_sequence_qwidget(control, interaction, delay):
     delay : int
         Time delay (in ms) in which each key click in the sequence will be
         performed.
+
+    Raises
+    ------
+    Disabled
+        If the widget is not enabled.
     """
     if not control.isEnabled():
         raise Disabled("{!r} is disabled.".format(control))
@@ -277,6 +292,11 @@ def key_click_qwidget(control, interaction, delay):
         to be simulated being typed
     delay : int
         Time delay (in ms) in which the key click will be performed.
+
+    Raises
+    ------
+    Disabled
+        If the widget is not enabled.
     """
     if not control.isEnabled():
         raise Disabled("{!r} is disabled.".format(control))
@@ -299,6 +319,11 @@ def key_click_qslider(control, interaction, delay):
         to be simulated being typed
     delay : int
         Time delay (in ms) in which the key click will be performed.
+
+    Raises
+    ------
+    ValueError
+        If the interaction.key is not one of the valid keys.
     """
     valid_keys = {"Left", "Right", "Up", "Down", "Page Up", "Page Down"}
     if interaction.key not in valid_keys:

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
@@ -227,7 +227,7 @@ def mouse_click_combobox(combobox, index, delay):
     )
     # Otherwise the click won't get registered.
     key_click(
-        combobox.view().viewport(), key="Enter",
+        combobox.view().viewport(), key="Enter", delay=delay
     )
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
@@ -428,7 +428,7 @@ def readonly_textbox_displayed_text(control):
     ----------
     control : wx.TextCtrl or wx.StaticText
         the textbox object from which the text of interest is displayed
-    
+
     Raises
     ------
     TypeError

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
@@ -116,6 +116,11 @@ def mouse_click_combobox_or_choice(control, index, delay):
         The index of the item in the combobox/choice to be clicked
     delay: int
         Time delay (in ms) in which click will be performed.
+
+    Raises
+    ------
+    TypeError
+        If the control is not a wxComboBox or wxChoice.
     """
     if isinstance(control, wx.ComboBox):
         click_event = _create_event(
@@ -226,6 +231,11 @@ def mouse_click_checkbox_child_in_panel(control, index, delay):
         The index of the child object in the Panel to be clicked
     delay : int
         Time delay (in ms) in which click will be performed.
+
+    Raises
+    ------
+    IndexError
+        If the index is out of range.
     """
     children_list = control.GetSizer().GetChildren()
     if not 0 <= index <= len(children_list) - 1:
@@ -245,6 +255,11 @@ def mouse_click_radiobutton_child_in_panel(control, index, delay):
         The index of the child object in the Panel to be clicked
     delay : int
         Time delay (in ms) in which click will be performed.
+
+    Raises
+    ------
+    IndexError
+        If the index is out of range.
     """
     children_list = control.GetSizer().GetChildren()
     if not 0 <= index <= len(children_list) - 1:
@@ -335,6 +350,11 @@ def key_sequence_text_ctrl(control, interaction, delay):
     delay : int
         Time delay (in ms) in which each key click in the sequence will be
         performed.
+
+    Raises
+    ------
+    Disabled
+        If the control is either not enabled or not editable.
     """
     # fail early
     for char in interaction.sequence:
@@ -366,6 +386,11 @@ def key_click_slider(control, interaction, delay):
         to be simulated being typed
     delay : int
         Time delay (in ms) in which the key click will be performed.
+
+    Raises
+    ------
+    ValueError
+        If the interaction.key is not one of the valid keys.
     """
     valid_keys = {"Left", "Right", "Up", "Down", "Page Up", "Page Down"}
     if interaction.key not in valid_keys:
@@ -403,6 +428,11 @@ def readonly_textbox_displayed_text(control):
     ----------
     control : wx.TextCtrl or wx.StaticText
         the textbox object from which the text of interest is displayed
+    
+    Raises
+    ------
+    TypeError
+        If the control is not either a wx.TextCtrl or wx.StaticText.
     '''
     if isinstance(control, wx.TextCtrl):
         return control.GetValue()

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -29,7 +29,7 @@ class UITester:
     registries : list of TargetRegistry, optional
         Registries of interaction for different targets, in the order
         of decreasing priority. If provided, a shallow copy will be made.
-        Default registries are always appended to the list to provide
+        A default registry is always appended to the list to provide
         builtin support for TraitsUI UI and editors.
     delay : int, optional
         Time delay (in ms) in which actions by the tester are performed. Note
@@ -50,7 +50,9 @@ class UITester:
         else:
             self._registries = registries.copy()
 
-        # The find_by_name method in this class depends on this registry
+        # This registry contributes the support for TraitsUI UI and editors.
+        # The find_by_name/find_by_id methods in this class also depend on
+        # this registry.
         self._registries.append(get_default_registry())
         self.delay = delay
 


### PR DESCRIPTION
This PR makes some very simply changes to comments and doc strings in the `traitsui.testing` module.  It fixes some typos, updates comments to be more clear/accurate, and adds a 'Raises' section to various doc strings.