### PR TITLE
Fix section name to solve Sphinx warning

### DIFF
--- a/traitsui/testing/tester/command.py
+++ b/traitsui/testing/tester/command.py
@@ -33,8 +33,8 @@ class KeySequence:
 
     Implementations should raise ``Disabled`` if the widget is disabled.
 
-    Attribute
-    ---------
+    Attributes
+    ----------
     sequence : str
         A string that represents a sequence of key inputs.
         e.g. "Hello World"
@@ -49,8 +49,8 @@ class KeyClick:
 
     Implementations should raise ``Disabled`` if the widget is disabled.
 
-    Attribute
-    ---------
+    Attributes
+    ----------
     key : str
         Standardized (pyface) name for a keyboard event.
         e.g. "Enter", "Tab", "Space", "0", "1", "A", ...


### PR DESCRIPTION
Generating the API documentation results in a number of warnings. This PR solves the ones from `traitsui.testing`:
```
/Users/kchoi/Work/ETS/traitsui/traitsui/testing/tester/command.py:docstring of traitsui.testing.tester.command.KeyClick:6: WARNING: Unexpected section title.

Attribute
---------
/Users/kchoi/Work/ETS/traitsui/traitsui/testing/tester/command.py:docstring of traitsui.testing.tester.command.KeySequence:6: WARNING: Unexpected section title.

Attribute
---------
```