### PR TITLE
Rename _BaseSourceWithLocation to BaseSourceWithLocation

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_common_ui_targets.py
@@ -16,7 +16,7 @@ any necessary traits, and then call the register method.
 """
 
 
-class _BaseSourceWithLocation:
+class BaseSourceWithLocation:
     """ Wrapper base class to hold locator information together with a source
     (typically an editor).  This is useful for cases in which the location
     information is still necessary when performing actions such as a mouse

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
@@ -12,7 +12,7 @@
 from traitsui.qt4.check_list_editor import CustomEditor
 from traitsui.testing.tester import command, locator
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
-    _BaseSourceWithLocation
+    BaseSourceWithLocation
 )
 from traitsui.testing.tester._ui_tester_registry._layout import (
     column_major_to_row_major
@@ -22,7 +22,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4 import (
 )
 
 
-class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
+class _IndexedCustomCheckListEditor(BaseSourceWithLocation):
     """ Wrapper for CheckListEditor + locator.Index """
     source_class = CustomEditor
     locator_class = locator.Index

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
@@ -16,7 +16,7 @@ from traitsui.qt4.enum_editor import (
 )
 from traitsui.testing.tester import command, locator, query
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
-    _BaseSourceWithLocation
+    BaseSourceWithLocation
 )
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
@@ -26,7 +26,7 @@ from traitsui.testing.tester._ui_tester_registry._layout import (
 )
 
 
-class _IndexedListEditor(_BaseSourceWithLocation):
+class _IndexedListEditor(BaseSourceWithLocation):
     """ Wrapper class for EnumListEditor and Index.
     """
     source_class = ListEditor
@@ -42,7 +42,7 @@ class _IndexedListEditor(_BaseSourceWithLocation):
     ]
 
 
-class _IndexedRadioEditor(_BaseSourceWithLocation):
+class _IndexedRadioEditor(BaseSourceWithLocation):
     """ Wrapper class for EnumRadioEditor and Index.
     """
     source_class = RadioEditor
@@ -88,7 +88,7 @@ def convert_index(layout, index, row_major):
         return column_major_to_row_major(index, n, num_rows, num_cols)
 
 
-class _IndexedSimpleEditor(_BaseSourceWithLocation):
+class _IndexedSimpleEditor(BaseSourceWithLocation):
     """ Wrapper class for Simple EnumEditor and Index.
     """
     source_class = SimpleEditor

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -10,7 +10,7 @@
 #
 from traitsui.testing.tester import command, locator
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
-    _BaseSourceWithLocation
+    BaseSourceWithLocation
 )
 from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
     register_traitsui_ui_solvers,
@@ -24,7 +24,7 @@ from traitsui.qt4.list_editor import (
 )
 
 
-class _IndexedNotebookEditor(_BaseSourceWithLocation):
+class _IndexedNotebookEditor(BaseSourceWithLocation):
     """ Wrapper for a ListEditor (Notebook) with an index.
     """
     source_class = NotebookEditor

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/check_list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/check_list_editor.py
@@ -13,7 +13,7 @@ import wx
 from traitsui.wx.check_list_editor import CustomEditor
 from traitsui.testing.tester import command, locator
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
-    _BaseSourceWithLocation
+    BaseSourceWithLocation
 )
 from traitsui.testing.tester._ui_tester_registry._layout import (
     column_major_to_row_major
@@ -21,7 +21,7 @@ from traitsui.testing.tester._ui_tester_registry._layout import (
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
-class _IndexedCustomCheckListEditor(_BaseSourceWithLocation):
+class _IndexedCustomCheckListEditor(BaseSourceWithLocation):
     """ Wrapper for CheckListEditor + locator.Index
     """
     source_class = CustomEditor

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
@@ -17,7 +17,7 @@ from traitsui.wx.enum_editor import (
 )
 from traitsui.testing.tester import command, locator, query
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
-    _BaseSourceWithLocation
+    BaseSourceWithLocation
 )
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 from traitsui.testing.tester._ui_tester_registry._layout import (
@@ -25,7 +25,7 @@ from traitsui.testing.tester._ui_tester_registry._layout import (
 )
 
 
-class _IndexedListEditor(_BaseSourceWithLocation):
+class _IndexedListEditor(BaseSourceWithLocation):
     """ Wrapper class for EnumListEditor and Index.
     """
     source_class = ListEditor
@@ -40,7 +40,7 @@ class _IndexedListEditor(_BaseSourceWithLocation):
     ]
 
 
-class _IndexedRadioEditor(_BaseSourceWithLocation):
+class _IndexedRadioEditor(BaseSourceWithLocation):
     """ Wrapper class for EnumRadioEditor and Index.
     """
     source_class = RadioEditor
@@ -85,7 +85,7 @@ def convert_index(source, index):
     return column_major_to_row_major(index, n, num_rows, num_cols)
 
 
-class _IndexedSimpleEditor(_BaseSourceWithLocation):
+class _IndexedSimpleEditor(BaseSourceWithLocation):
     """ Wrapper class for Simple EnumEditor and Index.
     """
     source_class = SimpleEditor

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -10,7 +10,7 @@
 #
 from traitsui.testing.tester import command, locator
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
-    _BaseSourceWithLocation
+    BaseSourceWithLocation
 )
 from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
     register_traitsui_ui_solvers,
@@ -22,7 +22,7 @@ from traitsui.wx.list_editor import (
 )
 
 
-class _IndexedNotebookEditor(_BaseSourceWithLocation):
+class _IndexedNotebookEditor(BaseSourceWithLocation):
     """ Wrapper for a ListEditor (Notebook) with an index.
     """
     source_class = NotebookEditor


### PR DESCRIPTION
This PR renames a class in a private module to have a public name, as the class is imported by other modules in the same package. Since the module itself is privately named (so is its container package), the class is still considered private from the end user.