### PR TITLE
Make event processing optional in UITester

### DIFF
--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -352,7 +352,9 @@ Example::
     modal_dialog_tester = ModalDialogTester(callable_to_open_dialog)
     modal_dialog_tester.open_and_run(when_opened)
 
-Note that you can instantiate as many |UITester| objects as you need.
+In the above example, ``ui`` is an instance of |UI| that has been obtained
+elsewhere in the test. Note that you can instantiate as many |UITester| objects
+as you need.
 
 .. rubric:: Is UITester compatible with PyFace GuiTestAssistant?
 

--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -333,8 +333,26 @@ it with any testing framework (e.g. unittest, pytest).
 
 .. rubric:: Is UITester compatible with PyFace ModalDialogTester?
 
-Yes. For example, you can use |UITester| to launch a modal dialog, and use
+Yes, with some care.
+
+For example, you can use |UITester| to launch a modal dialog, and use
 ModelDialogTester to close it.
+
+But if you are attempting to modify or inspect GUI states using |UITester|
+while the dialog is opened, you should set the ``process_events`` attribute to
+false for those operations. Otherwise the ModalDialogTester and UITester
+will enter a race condition that blocks forever.
+
+Example::
+
+    def when_opened(modal_dialog_tester):
+        ui_tester = UITester(process_events=False)
+        ui_tester.find_by_id(ui, "button").perform(MouseClick())
+
+    modal_dialog_tester = ModalDialogTester(callable_to_open_dialog)
+    modal_dialog_tester.open_and_run(when_opened)
+
+Note that you can instantiate as many |UITester| objects as you need.
 
 .. rubric:: Is UITester compatible with PyFace GuiTestAssistant?
 

--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -341,7 +341,7 @@ ModelDialogTester to close it.
 But if you are attempting to modify or inspect GUI states using |UITester|
 while the dialog is opened, you should set the ``process_events`` attribute to
 false for those operations. Otherwise the ModalDialogTester and UITester
-will enter a race condition that blocks forever.
+will enter a deadlock that blocks forever.
 
 Example::
 

--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -339,14 +339,14 @@ For example, you can use |UITester| to launch a modal dialog, and use
 ModelDialogTester to close it.
 
 But if you are attempting to modify or inspect GUI states using |UITester|
-while the dialog is opened, you should set the ``process_events`` attribute to
-false for those operations. Otherwise the ModalDialogTester and UITester
-will enter a deadlock that blocks forever.
+while the dialog is opened, you should set the ``auto_process_events``
+attribute to false for those operations. Otherwise the ModalDialogTester and
+UITester will enter a deadlock that blocks forever.
 
 Example::
 
     def when_opened(modal_dialog_tester):
-        ui_tester = UITester(process_events=False)
+        ui_tester = UITester(auto_process_events=False)
         ui_tester.find_by_id(ui, "button").perform(MouseClick())
 
     modal_dialog_tester = ModalDialogTester(callable_to_open_dialog)

--- a/traitsui/testing/tester/tests/test_ui_tester.py
+++ b/traitsui/testing/tester/tests/test_ui_tester.py
@@ -79,8 +79,8 @@ class TestUITesterCreateUI(unittest.TestCase):
 
         self.assertIsNone(ui.control)
 
-    def test_create_ui_respect_process_events_flag(self):
-        tester = UITester(process_events=False)
+    def test_create_ui_respect_auto_process_events_flag(self):
+        tester = UITester(auto_process_events=False)
         order = Order()
         view = View(Item("_"))
         side_effect = mock.Mock()
@@ -198,9 +198,9 @@ class TestUITesterFindEditor(unittest.TestCase):
             wrapper = tester.find_by_id(ui, "item2")
             self.assertIs(wrapper._target.item, item2)
 
-    def test_process_events_skipped(self):
+    def test_auto_process_events_skipped(self):
         # Event processing can be skipped.
-        tester = UITester(process_events=False)
+        tester = UITester(auto_process_events=False)
         side_effect = mock.Mock()
         gui = GUI()
         gui.invoke_later(side_effect)

--- a/traitsui/testing/tester/tests/test_ui_tester.py
+++ b/traitsui/testing/tester/tests/test_ui_tester.py
@@ -86,10 +86,11 @@ class TestUITesterCreateUI(unittest.TestCase):
         side_effect = mock.Mock()
         gui = GUI()
         gui.invoke_later(side_effect)
+        # Make sure all pending events are processed at the end of the test.
+        self.addCleanup(process_cascade_events)
+
         with tester.create_ui(order, dict(view=view)) as ui:
-            # We still want the events (if any) to be processed at the end of
-            # the test.
-            self.addCleanup(process_cascade_events)
+            pass
 
         # dispose is called.
         self.assertIsNone(ui.control)
@@ -203,6 +204,8 @@ class TestUITesterFindEditor(unittest.TestCase):
         side_effect = mock.Mock()
         gui = GUI()
         gui.invoke_later(side_effect)
+        # Make sure all pending events are processed at the end of the test.
+        self.addCleanup(process_cascade_events)
 
         view = View(Item("submit_button", id="item"))
         with tester.create_ui(Order(), dict(view=view)) as ui:

--- a/traitsui/testing/tester/tests/test_ui_tester.py
+++ b/traitsui/testing/tester/tests/test_ui_tester.py
@@ -10,6 +10,7 @@
 #
 
 import unittest
+from unittest import mock
 
 from pyface.api import GUI
 from traits.api import (
@@ -177,3 +178,15 @@ class TestUITesterFindEditor(unittest.TestCase):
         with tester.create_ui(Order(), dict(view=view)) as ui:
             wrapper = tester.find_by_id(ui, "item2")
             self.assertIs(wrapper._target.item, item2)
+
+    def test_process_events_skipped(self):
+        # Event processing can be skipped.
+        tester = UITester(process_events=False)
+        side_effect = mock.Mock()
+        gui = GUI()
+        gui.invoke_later(side_effect)
+
+        view = View(Item("submit_button", id="item"))
+        with tester.create_ui(Order(), dict(view=view)) as ui:
+            tester.find_by_id(ui, "item")
+            self.assertEqual(side_effect.call_count, 0)

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -475,10 +475,10 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
 
         wrapper = example_ui_wrapper(
             registries=[StubRegistry(handler=handler)],
-            process_events=False,
+            auto_process_events=False,
         )
 
-        # With process_events set to False, events are not automatically
+        # With auto_process_events set to False, events are not automatically
         # processed.
         wrapper.perform(None)
         self.addCleanup(process_cascade_events)
@@ -497,12 +497,12 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
 
         wrapper = example_ui_wrapper(
             registries=[StubRegistry(solver=solver)],
-            process_events=False,
+            auto_process_events=False,
         )
 
-        # With process_events set to False, events are not automatically
+        # With auto_process_events set to False, events are not automatically
         # processed.
         new_wrapper = wrapper.locate(None)
 
         self.assertEqual(side_effect.call_count, 0)
-        self.assertFalse(new_wrapper._process_events)
+        self.assertFalse(new_wrapper._auto_process_events)

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -18,6 +18,7 @@ from pyface.api import GUI
 from traits.api import HasTraits, Int
 from traits.testing.api import UnittestTools
 from traitsui.tests._tools import (
+    process_cascade_events,
     requires_toolkit,
     ToolkitName,
 )
@@ -480,6 +481,7 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
         # With process_events set to False, events are not automatically
         # processed.
         wrapper.perform(None)
+        self.addCleanup(process_cascade_events)
 
         self.assertEqual(side_effect.call_count, 0)
 
@@ -488,6 +490,7 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
         gui = GUI()
         side_effect = mock.Mock()
         gui.invoke_later(side_effect)
+        self.addCleanup(process_cascade_events)
 
         def solver(wrapper, location):
             return 1

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -18,7 +18,6 @@ from pyface.api import GUI
 from traits.api import HasTraits, Int
 from traits.testing.api import UnittestTools
 from traitsui.tests._tools import (
-    process_cascade_events,
     requires_toolkit,
     ToolkitName,
 )
@@ -468,10 +467,10 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
     def test_perform_event_processed_optional(self):
         # Allow event processing to be switched off.
         gui = GUI()
-        callable_ = mock.Mock()
+        side_effect = mock.Mock()
 
         def handler(wrapper, action):
-            gui.invoke_later(callable_)
+            gui.invoke_later(side_effect)
 
         wrapper = example_ui_wrapper(
             registries=[StubRegistry(handler=handler)],
@@ -481,16 +480,14 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
         # With process_events set to False, events are not automatically
         # processed.
         wrapper.perform(None)
-        # In case test fails, still flush the events.
-        self.addCleanup(process_cascade_events)
 
-        self.assertEqual(callable_.call_count, 0)
+        self.assertEqual(side_effect.call_count, 0)
 
     def test_locate_event_processed_optional(self):
         # Allow event processing to be switched off.
         gui = GUI()
-        callable_ = mock.Mock()
-        gui.invoke_later(callable_)
+        side_effect = mock.Mock()
+        gui.invoke_later(side_effect)
 
         def solver(wrapper, location):
             return 1
@@ -502,9 +499,7 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
 
         # With process_events set to False, events are not automatically
         # processed.
-        wrapper.locate(None)
+        new_wrapper = wrapper.locate(None)
 
-        # In case test fails, still flush the events.
-        self.addCleanup(process_cascade_events)
-
-        self.assertEqual(callable_.call_count, 0)
+        self.assertEqual(side_effect.call_count, 0)
+        self.assertFalse(new_wrapper._process_events)

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -38,7 +38,7 @@ class UITester:
         Time delay (in ms) in which actions by the tester are performed. Note
         it is propagated through to created child wrappers. The delay allows
         visual confirmation test code is working as desired. Defaults to 0.
-    process_events : bool, optional
+    auto_process_events : bool, optional
         Whether to process (cascade) GUI events automatically. Default is True.
         For tests that launch a modal dialog and rely on a recurring timer to
         poll if the dialog is closed, it may be necessary to set this flag to
@@ -53,7 +53,7 @@ class UITester:
         visual confirmation test code is working as desired.
     """
 
-    def __init__(self, *, registries=None, delay=0, process_events=True):
+    def __init__(self, *, registries=None, delay=0, auto_process_events=True):
         if registries is None:
             self._registries = []
         else:
@@ -64,7 +64,7 @@ class UITester:
         # this registry.
         self._registries.append(get_default_registry())
         self.delay = delay
-        self._process_events = process_events
+        self._auto_process_events = auto_process_events
 
     @contextlib.contextmanager
     def create_ui(self, object, ui_kwargs=None):
@@ -90,7 +90,7 @@ class UITester:
             yield ui
         finally:
             with reraise_exceptions():
-                if self._process_events:
+                if self._auto_process_events:
                     # At the end of a test, there may be events to be
                     # processed. If dispose happens first, those events will be
                     # processed after various editor states are removed,
@@ -102,7 +102,7 @@ class UITester:
                 finally:
                     # dispose is not atomic and may push more events to the
                     # event queue. Flush those too unless we are asked not to.
-                    if self._process_events:
+                    if self._auto_process_events:
                         process_cascade_events()
 
     def find_by_name(self, ui, name):
@@ -155,5 +155,5 @@ class UITester:
             target=ui,
             registries=self._registries,
             delay=self.delay,
-            process_events=self._process_events,
+            auto_process_events=self._auto_process_events,
         )

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -40,10 +40,10 @@ class UITester:
         visual confirmation test code is working as desired. Defaults to 0.
     process_events : bool, optional
         Whether to process (cascade) GUI events automatically. Default is True.
-        For tests that run the GUI event loop separately with a polling model
-        (e.g. checking for a condition periodically), it may be necessary to
-        set this flag to false in order to avoid processing GUI events
-        indefinitely. This is propagated through to created child wrappers.
+        For tests that launch a modal dialog and rely on a timer that polls if
+        the dialog is closed, it may be necessary to set this flag to false in
+        order to avoid race conditions. Note that this is propagated through
+        to created child wrappers.
 
     Attributes
     ----------

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -40,10 +40,10 @@ class UITester:
         visual confirmation test code is working as desired. Defaults to 0.
     process_events : bool, optional
         Whether to process (cascade) GUI events automatically. Default is True.
-        For tests that launch a modal dialog and rely on a timer that polls if
-        the dialog is closed, it may be necessary to set this flag to false in
-        order to avoid race conditions. Note that this is propagated through
-        to created child wrappers.
+        For tests that launch a modal dialog and rely on a recurring timer to
+        poll if the dialog is closed, it may be necessary to set this flag to
+        false in order to avoid race conditions. Note that this is propagated
+        through to created child wrappers.
 
     Attributes
     ----------

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -42,7 +42,7 @@ class UITester:
         Whether to process (cascade) GUI events automatically. Default is True.
         For tests that launch a modal dialog and rely on a recurring timer to
         poll if the dialog is closed, it may be necessary to set this flag to
-        false in order to avoid race conditions. Note that this is propagated
+        false in order to avoid deadlocks. Note that this is propagated
         through to created child wrappers.
 
     Attributes

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -65,7 +65,7 @@ class UIWrapper:
         Whether to process (cascade) GUI events automatically. Default is True.
         For tests that launch a modal dialog and rely on a recurring timer to
         poll if the dialog is closed, it may be necessary to set this flag to
-        false in order to avoid race conditions. Note that this is propagated
+        false in order to avoid deadlocks. Note that this is propagated
         through to created child wrappers.
 
     Attributes

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -66,7 +66,7 @@ class UIWrapper:
         For tests that run the GUI event loop separately with a polling model
         (e.g. checking for a condition periodically), it may be necessary to
         set this flag to false in order to avoid processing GUI events
-        indefinitely.
+        indefinitely. This is propagated through to created child wrappers.
 
     Attributes
     ----------
@@ -154,6 +154,7 @@ class UIWrapper:
             target=self._get_next_target(location),
             registries=self._registries,
             delay=self.delay,
+            process_events=self._process_events,
         )
 
     def find_by_name(self, name):
@@ -347,6 +348,7 @@ def _event_processed():
             yield
         finally:
             _process_cascade_events()
+
 
 @contextmanager
 def _nullcontext():

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -63,10 +63,10 @@ class UIWrapper:
         visual confirmation test code is working as desired. Defaults to 0.
     process_events : bool, optional
         Whether to process (cascade) GUI events automatically. Default is True.
-        For tests that run the GUI event loop separately with a polling model
-        (e.g. checking for a condition periodically), it may be necessary to
-        set this flag to false in order to avoid processing GUI events
-        indefinitely. This is propagated through to created child wrappers.
+        For tests that launch a modal dialog and rely on a timer that polls if
+        the dialog is closed, it may be necessary to set this flag to false in
+        order to avoid race conditions. Note that this is propagated through
+        to created child wrappers.
 
     Attributes
     ----------

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -61,7 +61,7 @@ class UIWrapper:
         Time delay (in ms) in which actions by the wrapper are performed. Note
         it is propagated through to created child wrappers. The delay allows
         visual confirmation test code is working as desired. Defaults to 0.
-    process_events : bool, optional
+    auto_process_events : bool, optional
         Whether to process (cascade) GUI events automatically. Default is True.
         For tests that launch a modal dialog and rely on a recurring timer to
         poll if the dialog is closed, it may be necessary to set this flag to
@@ -76,10 +76,11 @@ class UIWrapper:
         visual confirmation test code is working as desired.
     """
 
-    def __init__(self, target, *, registries, delay=0, process_events=True):
+    def __init__(
+            self, target, *, registries, delay=0, auto_process_events=True):
         self._target = target
         self._registries = registries
-        self._process_events = process_events
+        self._auto_process_events = auto_process_events
         self.delay = delay
 
     def help(self):
@@ -154,7 +155,7 @@ class UIWrapper:
             target=self._get_next_target(location),
             registries=self._registries,
             delay=self.delay,
-            process_events=self._process_events,
+            auto_process_events=self._auto_process_events,
         )
 
     def find_by_name(self, name):
@@ -286,7 +287,8 @@ class UIWrapper:
                 continue
             else:
                 context = (
-                    _event_processed if self._process_events else _nullcontext
+                    _event_processed if self._auto_process_events
+                    else _nullcontext
                 )
                 with context():
                     return handler(self, interaction)
@@ -325,7 +327,7 @@ class UIWrapper:
             except LocationNotSupported as e:
                 supported |= set(e.supported)
             else:
-                if self._process_events:
+                if self._auto_process_events:
                     with _reraise_exceptions():
                         _process_cascade_events()
                 return handler(self, location)

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -63,10 +63,10 @@ class UIWrapper:
         visual confirmation test code is working as desired. Defaults to 0.
     process_events : bool, optional
         Whether to process (cascade) GUI events automatically. Default is True.
-        For tests that launch a modal dialog and rely on a timer that polls if
-        the dialog is closed, it may be necessary to set this flag to false in
-        order to avoid race conditions. Note that this is propagated through
-        to created child wrappers.
+        For tests that launch a modal dialog and rely on a recurring timer to
+        poll if the dialog is closed, it may be necessary to set this flag to
+        false in order to avoid race conditions. Note that this is propagated
+        through to created child wrappers.
 
     Attributes
     ----------

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -114,10 +114,9 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
                 with tester.capture_error():
                     try:
                         dialog_ui = tester.get_dialog_widget()._ui
-                        # If process_events was not set to false, ``perform``
-                        # will block due to race condition with
-                        # ModalDialogTester.
-                        ui_tester = UITester(process_events=False)
+                        # If auto_process_events was not set to false, this
+                        # will block due to deadlocks with ModalDialogTester.
+                        ui_tester = UITester(auto_process_events=False)
                         value = ui_tester.find_by_name(dialog_ui, "value")
                         value.perform(KeySequence("Hello"))
                         self.assertEqual(obj.inst.value, "")

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -1,8 +1,8 @@
 import unittest
 
+from pyface.toolkit import toolkit_object
 from traits.api import HasTraits, Instance, Str
-from traitsui.item import Item
-from traitsui.view import View
+from traitsui.api import InstanceEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
     requires_toolkit,
@@ -16,13 +16,18 @@ from traitsui.testing.api import (
     UITester
 )
 
+ModalDialogTester = toolkit_object(
+    "util.modal_dialog_tester:ModalDialogTester"
+)
+no_modal_dialog_tester = ModalDialogTester.__name__ == "Unimplemented"
+
 
 class EditedInstance(HasTraits):
     value = Str()
     traits_view = View(Item("value"), buttons=["OK"])
 
 
-class NonmodalInstanceEditor(HasTraits):
+class ObjectWithInstance(HasTraits):
     inst = Instance(EditedInstance, ())
 
 
@@ -40,7 +45,7 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
         BaseTestMixin.tearDown(self)
 
     def test_simple_editor(self):
-        obj = NonmodalInstanceEditor()
+        obj = ObjectWithInstance()
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("simple"))) as ui:
             instance = tester.find_by_name(ui, "inst")
@@ -50,7 +55,7 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(obj.inst.value, "abc")
 
     def test_custom_editor(self):
-        obj = NonmodalInstanceEditor()
+        obj = ObjectWithInstance()
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("custom"))) as ui:
             value_txt = tester.find_by_name(ui, "inst").find_by_name("value")
@@ -59,7 +64,7 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
 
     def test_custom_editor_resynch_editor(self):
         edited_inst = EditedInstance(value='hello')
-        obj = NonmodalInstanceEditor(inst=edited_inst)
+        obj = ObjectWithInstance(inst=edited_inst)
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("custom"))) as ui:
             value_txt = tester.find_by_name(ui, "inst").find_by_name("value")
@@ -71,7 +76,7 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
 
     def test_simple_editor_resynch_editor(self):
         edited_inst = EditedInstance(value='hello')
-        obj = NonmodalInstanceEditor(inst=edited_inst)
+        obj = ObjectWithInstance(inst=edited_inst)
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view("simple"))) as ui:
             instance = tester.find_by_name(ui, "inst")
@@ -85,8 +90,46 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(displayed, "bye")
 
     def test_simple_editor_parent_closed(self):
-        obj = NonmodalInstanceEditor()
+        obj = ObjectWithInstance()
         tester = UITester()
         with tester.create_ui(obj, dict(view=get_view('simple'))) as ui:
             instance = tester.find_by_name(ui, "inst")
             instance.perform(MouseClick())
+
+    @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
+    def test_simple_editor_modal(self):
+        # Test launching the instance editor with kind set to 'modal'
+        obj = ObjectWithInstance()
+        ui_tester = UITester()
+        view = View(
+            Item("inst", style="simple", editor=InstanceEditor(kind="modal"))
+        )
+
+        with ui_tester.create_ui(obj, dict(view=view)) as ui:
+
+            def click_button():
+                ui_tester.find_by_name(ui, "inst").perform(MouseClick())
+
+            def when_opened(tester):
+                with tester.capture_error():
+                    try:
+                        dialog_ui = tester.get_dialog_widget()._ui
+                        # If process_events was not set to false, ``perform``
+                        # will block due to race condition with
+                        # ModalDialogTester.
+                        ui_tester = UITester(process_events=False)
+                        value = ui_tester.find_by_name(dialog_ui, "value")
+                        value.perform(KeySequence("Hello"))
+                        self.assertEqual(obj.inst.value, "")
+                        ok_button = ui_tester.find_by_id(dialog_ui, "OK")
+                        ok_button.perform(MouseClick())
+                    finally:
+                        # If the block above fails, the dialog will block
+                        # forever. Close it regardless.
+                        if tester.get_dialog_widget() is not None:
+                            tester.close(accept=True)
+
+            mdtester = ModalDialogTester(click_button)
+            mdtester.open_and_run(when_opened=when_opened)
+            self.assertTrue(mdtester.dialog_was_opened)
+            self.assertEqual(obj.inst.value, "Hello")


### PR DESCRIPTION
Closes #1297

This PR adds a ~"process_events"~ `auto_process_events` flag on `UITester` (propagated to `UIWrapper`) to skip GUI event processing if the users request so.

- User manual is updated to highlight the specific care required when using UITester with ModalDialogTester.  
- Add a test against InstanceEditor that launches a UI as a modal dialog. ModalDialogTester and UITester are used in that test, which demonstrate the issue in #1297 if the flag is set to true.
- The flag is set while instantiating `UITester`, because it is convenient to be able to set it once.
- For correctness, `UITester.create_ui` will also respect this flag.

*Alternative*
- Instead of setting the flag in the object constructor, we can instead pass it through `perform`, `inspect` and `locate`. However I find that a little laborious.

*Question*:
- ~`process_events` here is a boolean, and its name does clash with `pyface.api.GUI.process_events`. The latter is a callable. A different naming suggestion would be very welcome.~ Edited: New name is.... `auto_process_events`!

Note: I have checked compatibility between `UITester` and `GuiTestAssistant.event_loop_until_condition`. This pairing isn't affected. The modal dialog is a special one here because the function that launches the modal dialog typically blocks until the dialog is closed.