### PR TITLE
UI Tester - implement simple list editor

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -24,6 +24,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4 import (
 from traitsui.qt4.list_editor import (
     CustomEditor,
     NotebookEditor,
+    SimpleEditor
 )
 
 
@@ -109,6 +110,14 @@ def register(registry):
     # CustomEditor
     registry.register_location(
         target_class=CustomEditor,
+        locator_class=Index,
+        solver=lambda wrapper, location: (
+            _get_next_target(wrapper._target, location.index)
+        )
+    )
+    # SimpleEditor
+    registry.register_location(
+        target_class=SimpleEditor,
         locator_class=Index,
         solver=lambda wrapper, location: (
             _get_next_target(wrapper._target, location.index)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -19,6 +19,7 @@ from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 from traitsui.wx.list_editor import (
     CustomEditor,
     NotebookEditor,
+    SimpleEditor
 )
 
 
@@ -103,6 +104,14 @@ def register(registry):
     # CustomEditor
     registry.register_location(
         target_class=CustomEditor,
+        locator_class=Index,
+        solver=lambda wrapper, location: (
+            _get_next_target(wrapper._target, location.index)
+        )
+    )
+    # SimpleEditor
+    registry.register_location(
+        target_class=SimpleEditor,
         locator_class=Index,
         solver=lambda wrapper, location: (
             _get_next_target(wrapper._target, location.index)

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -134,6 +134,7 @@ class TestSimpleListEditor(unittest.TestCase):
             self.assertEqual(obj.people[7].name, "Fields")
             people_list = tester.find_by_name(ui, "people")
             item = people_list.locate(Index(7))
+            item.perform(MouseClick())
             name_field = item.find_by_name("name")
             for _ in range(6):
                 name_field.perform(KeyClick("Backspace"))

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -53,6 +53,7 @@ class ListTraitTest(HasStrictTraits):
     # Trait definitions:
     people = List(Instance(Person, ()))
     num_columns = Int(1)
+    style = Str("custom")
 
     # Traits view definitions:
     def default_traits_view(self):
@@ -61,8 +62,8 @@ class ListTraitTest(HasStrictTraits):
                 'people',
                 label='List',
                 id='list',
-                style='custom',
-                editor=ListEditor(style='custom', columns=self.num_columns),
+                style=self.style,
+                editor=ListEditor(style=self.style, columns=self.num_columns),
             ),
             resizable=True
         )
@@ -115,6 +116,43 @@ class TestCustomListEditor(unittest.TestCase):
 
     def test_index_out_of_range(self):
         obj = ListTraitTest(people=get_people())
+        tester = UITester()
+        with tester.create_ui(obj) as ui:
+            people_list = tester.find_by_name(ui, "people")
+            with self.assertRaises(IndexError):
+                people_list.locate(Index(10))
+
+
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
+class TestSimpleListEditor(unittest.TestCase):
+
+    def test_locate_element_and_edit(self):
+        obj = ListTraitTest(people=get_people(), style="simple")
+        tester = UITester()
+        with tester.create_ui(obj) as ui:
+            # sanity check
+            self.assertEqual(obj.people[7].name, "Fields")
+            people_list = tester.find_by_name(ui, "people")
+            item = people_list.locate(Index(7))
+            name_field = item.find_by_name("name")
+            for _ in range(6):
+                name_field.perform(KeyClick("Backspace"))
+            name_field.perform(KeySequence("David"))
+            displayed = name_field.inspect(DisplayedText())
+            self.assertEqual(obj.people[7].name, "David")
+            self.assertEqual(displayed, obj.people[7].name)
+
+    def test_useful_err_message(self):
+        obj = ListTraitTest(people=get_people(), style="simple")
+        tester = UITester()
+        with tester.create_ui(obj) as ui:
+            with self.assertRaises(LocationNotSupported) as exc:
+                people_list = tester.find_by_name(ui, "people")
+                people_list.locate(Textbox())
+            self.assertIn(Index, exc.exception.supported)
+
+    def test_index_out_of_range(self):
+        obj = ListTraitTest(people=get_people(), style="simple")
         tester = UITester()
         with tester.create_ui(obj) as ui:
             people_list = tester.find_by_name(ui, "people")


### PR DESCRIPTION
Fixes #1292 

This PR simply uses the current custom list editor implementation for simple list editor.  The classes are so similar, I believe the implementation did not need to be changed.  This PR also adds tests, (basically just took the Custom tests and made them use a Simple List Editor instead).

One thing to note: when running the tests on wx, the tests all pass but there is an extremely long traceback 
<details>

```
$ python -m unittest test_list_editor.py 
01:22:33 PM: Debug: Adding duplicate image handler for 'Windows bitmap file'
01:22:33 PM: Debug: Adding duplicate animation handler for '1' type
01:22:33 PM: Debug: Adding duplicate animation handler for '2' type
01:22:33 PM: Debug: Adding duplicate image handler for 'Windows bitmap file'
01:22:33 PM: Debug: Adding duplicate animation handler for '1' type
01:22:33 PM: Debug: Adding duplicate animation handler for '2' type
/Users/aayres/.edm/envs/wx-env/lib/python3.6/site-packages/wx/py/buffer.py:6: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
01:22:34 PM: Debug: Adding duplicate image handler for 'Windows bitmap file'
01:22:34 PM: Debug: Adding duplicate animation handler for '1' type
01:22:34 PM: Debug: Adding duplicate animation handler for '2' type
Wx control <wx._core.ScrollBar object at 0x7fd04dad49d8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04dad4af8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04db7b0d8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
.Wx control <wx._core.ScrollBar object at 0x7fd04dbd29d8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04dbd2af8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04dbd2c18> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04dad49d8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04de0c9d8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04de0ca68> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04dbd28b8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04dbd2a68> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04dbd2c18> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04db70948> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04db74168> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04db74288> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
.Wx control <wx._core.ScrollBar object at 0x7fd04db70a68> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04db70798> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04db70948> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
./Users/aayres/Desktop/traits/traits/trait_factory.py:40: DeprecationWarning: 'Color' in 'traits' package has been deprecated. Use 'Color' from 'traitsui' package instead.
  return self.maker_function(*args, **metadata)
/Users/aayres/Desktop/traits/traits/traits.py:330: DeprecationWarning: 'TraitMap' trait handler has been deprecated. Use Map instead.
  other.append(TraitMap(map))
...Wx control <wx._core.ScrollBar object at 0x7fd04dbd2708> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04db7b168> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04db7bd38> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
.Wx control <wx._core.ScrollBar object at 0x7fd04dbd2708> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04ef94798> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04ef94b88> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
.Wx control <wx._core.ScrollBar object at 0x7fd04ef94708> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.ScrollBar object at 0x7fd04ef94048> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
Wx control <wx._core.Window object at 0x7fd04ef945e8> not destroyed cleanly
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/toolkit.py", line 436, in _destroy_control
    control.Destroy()
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
.
----------------------------------------------------------------------
Ran 9 tests in 2.248s

OK

```
</details>