### PR TITLE
Fix Qt button click failing to cause other widgets to update

### DIFF
--- a/traitsui/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
+++ b/traitsui/examples/demo/Advanced/Auto_update_TabularEditor_demo.py
@@ -26,7 +26,7 @@ long lists are used, since enabling this feature adds and removed Traits
 listeners to each item in the list.
 
 """
-# Issues related to the demo warning: enthought/traitsui#913,
+# Issues related to the demo warning:
 # enthought/traitsui#960
 
 from traits.api import HasTraits, Str, Float, List, Instance, Button

--- a/traitsui/examples/demo/Standard_Editors/ButtonEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/ButtonEditor_simple_demo.py
@@ -25,10 +25,6 @@ class ButtonEditorDemo(HasTraits):
     def _my_button_trait_fired(self):
         self.click_counter += 1
 
-    # Currently there is some erroneous behavior with Qt5 and OSX causing
-    # the click_counter to not immediately increment when the button is
-    # clicked. For more deailts, see enthought/traitsui #913.
-
     # Demo view:
     traits_view = View(
         'my_button_trait',

--- a/traitsui/examples/demo/Standard_Editors/CSVListEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/CSVListEditor_demo.py
@@ -1,19 +1,10 @@
 """
-**WARNING**
-
-  This demo might not work as expected and some documented features might be
-  missing.
-
--------------------------------------------------------------------------------
-
 Demonstrate the CSVListEditor class.
 
 This editor allows the user to enter a *single* line of input text, containing
 comma-separated values (or another separator may be specified). Your program
 specifies an element Trait type of Int, Float, Str, Enum, or Range.
 """
-# Issue related to the demo warning: enthought/traitsui#913
-
 
 from traits.api import (
     HasTraits, List, Int, Float, Enum, Range, Str, Button, Property

--- a/traitsui/examples/demo/Standard_Editors/ColorEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/ColorEditor_demo.py
@@ -13,7 +13,7 @@ Implementation of a ColorEditor demo plugin for Traits UI demo program.
 
 This demo shows each of the four styles of the ColorEditor
 """
-# Issues related to the demo warning: enthought/traitsui#913,
+# Issues related to the demo warning:
 # enthought/traitsui#946
 
 

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -69,7 +69,14 @@ class SimpleEditor(Editor):
             self.control.setAutoDefault(False)
 
         self.sync_value(self.factory.label_value, "label", "from")
-        self.control.clicked.connect(self.update_object)
+
+        # The connection type is set to workaround Qt5 + MacOSX issue with
+        # event dispatching. Without the type set to Queue, other widgets
+        # may not repaint properly in response to a button click.
+        # See for example enthought/traitsui#928
+        self.control.clicked.connect(
+            self.update_object, type=QtCore.Qt.QueuedConnection,
+        )
         self.set_tooltip()
 
     def dispose(self):

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -71,9 +71,9 @@ class SimpleEditor(Editor):
         self.sync_value(self.factory.label_value, "label", "from")
 
         # The connection type is set to workaround Qt5 + MacOSX issue with
-        # event dispatching. Without the type set to Queue, other widgets
-        # may not repaint properly in response to a button click.
-        # See for example enthought/traitsui#928
+        # event dispatching. Without the type set to QueuedConnection, other
+        # widgets may not repaint properly in response to a button click.
+        # See enthought/traitsui#1308
         self.control.clicked.connect(
             self.update_object, type=QtCore.Qt.QueuedConnection,
         )


### PR DESCRIPTION
Closes #928 
Closes #1245 (after causing `TabularEditor.update` to fire, from this [comment](https://github.com/enthought/traitsui/issues/1245#issuecomment-696062894)).

The issue affects Mac OSX and Qt only. This [macOSX specific limitation on Qt documentation](https://doc.qt.io/qt-5/macos-issues.html#using-native-cocoa-panels) seems relevant.

This issue is not specific to the textbox, as I can reproduce the same behaviour with a different widget, using just QPushButton and QLabel.

<details>
    <summary> Same strange behaviour using Two QPushButton and QLabel </summary>

```
import sys
from PyQt5 import QtWidgets, QtCore

class MainWindow(QtWidgets.QWidget):
    def __init__(self, ):
        super().__init__()

        self.count = 1
        self.label = QtWidgets.QLabel(self)

        self.button = QtWidgets.QPushButton('button', self)
        self.button.clicked.connect(self.on_click)

        # This second button is important for reproducing the behaviour, and it is important that it is
        # added to the layout _after_ the QLabel
        self.button2 = QtWidgets.QPushButton('do nothing', self)

        vbox = QtWidgets.QVBoxLayout()
        vbox.addWidget(self.button)
        vbox.addWidget(self.label)
        vbox.addWidget(self.button2)
        self.setLayout(vbox)

    def on_click(self):
        self.count += 1
        self.label.setText(str(self.count))

if __name__ == "__main__":
	app = QtWidgets.QApplication(sys.argv)
	window = MainWindow()
	window.show()
	sys.exit(app.exec_())
```
</details>

While this strikes me as a Qt issue rather than a TraitsUI issue, downstream projects using TraitsUI have been working around the issue by adding `GUI.process_events()` in the change handler for their buttons. Manually driving GUI event processing in application code should be avoided whenever possible. This is already causing a lot of inconvenience for developers on OSX, therefore I think it is worth fixing/workaround in TraitsUI.

This PR fixes / workarounds the issue by connecting the QPushButton click signal to its slot as a queued connection, following the approach suggested in the [Qt documentation](https://doc.qt.io/qt-5/macos-issues.html#using-native-cocoa-panels) mentioned above. This should not affect Windows nor Linux in production environment.

However **this does have implications for test code that calls the QPushButton click directly**. If there are test code that does something like this:
```
button_editor = ui.get_editors("trait_name")[0]
with self.assertTraitChange(obj, "trait_name"):
    button_editor.control.click()
```
This PR will cause these test code to break. The invocation to `click` (which is `QPushButton.click`) previously would have caused the click slot to be invoked immediately (see https://doc.qt.io/qt-5/qt.html#ConnectionType-enum), and the expected trait change would have occurred even without manually asking GUI events to be processed in the test. This can be resolved by adding `GUI.process_events` after calling `click()`, or use `GuiTestAssistant.event_loop_until_condition` or, use `UITester` which causes the GUI events to be processed after every interaction by default.

No tests can be written for this PR as this has to do with internal event dispatching between Qt and OSX.

I should file an issue upstream too, but that is going to take me a while... :/ 