### PR TITLE
Doc: Add links two more demo GUI tests to the user manual

### DIFF
--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -284,12 +284,13 @@ Several test examples can be found for testing
 
 Editors
 -------
-- :github-demo:`ButtonEditor <Standard_Editors/tests/test_ButtonEditor_demo.py>`
+- :github-demo:`BooleanEditor <Standard_Editors/tests/test_BooleanEditor_simple_demo.py>`
 - :github-demo:`ButtonEditor <Standard_Editors/tests/test_ButtonEditor_simple_demo.py>`
 - :github-demo:`CheckListEditor <Standard_Editors/tests/test_CheckListEditor_simple_demo.py>`
 - :github-demo:`EnumEditor <Standard_Editors/tests/test_EnumEditor_demo.py>`
 - :github-demo:`InstanceEditor <Standard_Editors/tests/test_InstanceEditor_demo.py>`
 - :github-demo:`ListEditor <Advanced/tests/test_List_editor_notebook_selection_demo.py>`
+- :github-demo:`RangeEditor <Standard_Editors/tests/test_RangeEditor_demo.py>`
 - :github-demo:`TextEditor <Standard_Editors/tests/test_TextEditor_demo.py>`
 
 Applications


### PR DESCRIPTION
This PR adds links in the user manual to the recently added demo tests for BooleanEditor and RangeEditor.

I removed one of the links to the ButtonEditor demo test as it has so much in common with the other example that there is little value in referencing both. 