### PR TITLE
Fix QDateTime deprecation warning

### DIFF
--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -252,7 +252,7 @@ class TestDatetimeEditorQt(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
             # the user set the datetime on the Qt widget to a value
             # too large for Python
             from pyface.qt.QtCore import QDateTime, QDate, QTime
-            q_datetime = QDateTime(QDate(datetime.MAXYEAR + 1, 1, 1), QTime())
+            q_datetime = QDateTime(QDate(datetime.MAXYEAR + 1, 1, 1), QTime(0,0))
             editor.control.setDateTime(q_datetime)
 
             # Get the displayed value back.

--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -252,7 +252,9 @@ class TestDatetimeEditorQt(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
             # the user set the datetime on the Qt widget to a value
             # too large for Python
             from pyface.qt.QtCore import QDateTime, QDate, QTime
-            q_datetime = QDateTime(QDate(datetime.MAXYEAR + 1, 1, 1), QTime(0,0))
+            q_datetime = QDateTime(
+                QDate(datetime.MAXYEAR + 1, 1, 1), QTime(0, 0)
+            )
             editor.control.setDateTime(q_datetime)
 
             # Get the displayed value back.

--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -251,8 +251,8 @@ class TestDatetimeEditorQt(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
                 self.launch_editor(instance, view) as editor:
             # the user set the datetime on the Qt widget to a value
             # too large for Python
-            from pyface.qt.QtCore import QDateTime, QDate
-            q_datetime = QDateTime(QDate(datetime.MAXYEAR + 1, 1, 1))
+            from pyface.qt.QtCore import QDateTime, QDate, QTime
+            q_datetime = QDateTime(QDate(datetime.MAXYEAR + 1, 1, 1), QTime())
             editor.control.setDateTime(q_datetime)
 
             # Get the displayed value back.


### PR DESCRIPTION
fixes #1096 

This PR is simply a one line change to pass a null `QTime` object as the second argument to the `QDateTime` constructor, so that it is using a non-deprecated signature.  