### PR TITLE
Fix QDesktopWidget.availableGeometry deprecation warning

### DIFF
--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -45,7 +45,7 @@ del _palette
 
 # Screen size values:
 
-_geom = QtGui.QApplication.desktop().availableGeometry()
+_geom = QtGui.QApplication.screens()[0].availableGeometry()
 
 screen_dx = _geom.width()
 screen_dy = _geom.height()

--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -15,7 +15,7 @@ editors and text editor factories.
 """
 
 
-from pyface.qt import QtGui
+from pyface.qt import QtCore, QtGui
 
 
 _palette = QtGui.QApplication.palette()
@@ -45,7 +45,10 @@ del _palette
 
 # Screen size values:
 
-_geom = QtGui.QApplication.screens()[0].availableGeometry()
+if QtCore.__version_info__ >= (5, 0):
+    _geom = QtGui.QApplication.screens()[0].availableGeometry()
+else:
+    _geom = QtGui.QApplication.desktop().availableGeometry()
 
 screen_dx = _geom.width()
 screen_dy = _geom.height()

--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -45,6 +45,8 @@ del _palette
 
 # Screen size values:
 
+# QDesktopWidget.availableGeometry(int screen) is deprecated and Qt docs
+# suggest using screens() instead, but screens in not available in qt4
 if QtCore.__version_info__ >= (5, 0):
     _geom = QtGui.QApplication.screens()[0].availableGeometry()
 else:


### PR DESCRIPTION
fixes #1114 

This PR simply replaces `QtGui.QApplication.desktop()` with `QtGui.QApplication.screens()[0]` so that `.availableGeometry` can be called on a QScreen object (where it is not a deprecated method) rather than on a `QDesktopWidget` object.  

My only concern is I do not know how the list of screens obtained by `.screens()` is ordered in the case when multiple screens are being used.  The documentation [here][https://doc.qt.io/qt-5/qguiapplication.html#screens] simply says "Returns a list of all the screens associated with the windowing system the application is connected to."

In the code we actually run 
```
_geom = QtGui.QApplication.screens()[0].availableGeometry()

screen_dx = _geom.width()
screen_dy = _geom.height()
```
and I confirmed that before and after this change the values of `screen_dx` and `screen_dy` remained the same. If however I change the 0 to a 1, the values change (I am using 2 different screens currently).  Thus, I believe the code is correct as it stands (correct in the sense it does what was done before).
