### PR TITLE
Fix key sequence not updating view per keystroke on wx

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
@@ -368,6 +368,7 @@ def key_sequence_text_ctrl(control, interaction, delay):
     for char in interaction.sequence:
         wx.MilliSleep(delay)
         control.WriteText(char)
+        wx.SafeYield()
 
 
 def key_click_slider(control, interaction, delay):


### PR DESCRIPTION
Fix #1200

This fixes the view not updating when KeySequence (on wx TextCtrl) writes each of the key characters. The view is not updated because when the for loop is busy, wx has not got a chance to process pending events. Note that this only affects visuals when one tries to debug a test visually.
