### PR TITLE
UI Tester - add IsEnabled query class and implementations for Button Editors

### DIFF
--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -83,6 +83,7 @@ from .tester.registry import TargetRegistry
 from .tester.query import (
     DisplayedText,
     IsChecked,
+    IsEnabled,
     SelectedText
 )
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
@@ -32,7 +32,7 @@ def register(registry):
                 wrapper._target.control, wrapper.delay)),
         (DisplayedText,
             lambda wrapper, _: wrapper._target.control.text()),
-        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled())
+        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled()),
     ]
 
     for target_class in [SimpleEditor, CustomEditor]:

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
@@ -8,7 +8,7 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -31,7 +31,8 @@ def register(registry):
             lambda wrapper, _: _interaction_helpers.mouse_click_qwidget(
                 wrapper._target.control, wrapper.delay)),
         (DisplayedText,
-            lambda wrapper, _: wrapper._target.control.text())
+            lambda wrapper, _: wrapper._target.control.text()),
+        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled())
     ]
 
     for target_class in [SimpleEditor, CustomEditor]:

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.qt4.ui_base import ButtonEditor
-from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -30,7 +30,8 @@ def register(registry):
             (lambda wrapper, _: _interaction_helpers.mouse_click_qwidget(
                 wrapper._target.control, wrapper.delay))),
         (DisplayedText,
-            lambda wrapper, _: wrapper._target.control.text())
+            lambda wrapper, _: wrapper._target.control.text()),
+        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled())
     ]
     for interaction_class, handler in handlers:
         registry.register_interaction(

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
@@ -31,7 +31,7 @@ def register(registry):
                 wrapper._target.control, wrapper.delay))),
         (DisplayedText,
             lambda wrapper, _: wrapper._target.control.text()),
-        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled())
+        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled()),
     ]
     for interaction_class, handler in handlers:
         registry.register_interaction(

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
@@ -11,7 +11,7 @@
 import wx
 
 from traitsui.wx.button_editor import SimpleEditor, CustomEditor
-from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -69,6 +69,12 @@ def register(registry):
     )
 
     registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=IsEnabled,
+        handler=lambda wrapper, _: wrapper._target.control.isEnabled()
+    )
+
+    registry.register_interaction(
         target_class=CustomEditor,
         interaction_class=MouseClick,
         handler=mouse_click_ImageButton
@@ -78,4 +84,10 @@ def register(registry):
         target_class=CustomEditor,
         interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
+    )
+
+    registry.register_interaction(
+        target_class=CustomEditor,
+        interaction_class=IsEnabled,
+        handler=lambda wrapper, _: wrapper._target.control.isEnabled()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
@@ -71,7 +71,7 @@ def register(registry):
     registry.register_interaction(
         target_class=SimpleEditor,
         interaction_class=IsEnabled,
-        handler=lambda wrapper, _: wrapper._target.control.isEnabled()
+        handler=lambda wrapper, _: wrapper._target.control.IsEnabled()
     )
 
     registry.register_interaction(
@@ -89,5 +89,5 @@ def register(registry):
     registry.register_interaction(
         target_class=CustomEditor,
         interaction_class=IsEnabled,
-        handler=lambda wrapper, _: wrapper._target.control.isEnabled()
+        handler=lambda wrapper, _: wrapper._target.control.IsEnabled()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.ui_base import ButtonEditor
-from traitsui.testing.api import DisplayedText, MouseClick
+from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -35,4 +35,10 @@ def register(registry):
         target_class=ButtonEditor,
         interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
+    )
+
+    registry.register_interaction(
+        target_class=ButtonEditor,
+        interaction_class=IsEnabled,
+        handler=lambda wrapper, _: wrapper._target.control.isEnabled()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
@@ -40,5 +40,5 @@ def register(registry):
     registry.register_interaction(
         target_class=ButtonEditor,
         interaction_class=IsEnabled,
-        handler=lambda wrapper, _: wrapper._target.control.isEnabled()
+        handler=lambda wrapper, _: wrapper._target.control.IsEnabled()
     )

--- a/traitsui/testing/tester/query.py
+++ b/traitsui/testing/tester/query.py
@@ -48,3 +48,12 @@ class IsChecked:
     Implementations should return True if checked and False if not.
     """
     pass
+
+
+class IsEnabled:
+    """ An object representing an interaction to obtain whether a widget is
+    enabled or not.
+
+    Implementations should return True if enabled and False if not.
+    """
+    pass

--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -11,6 +11,7 @@ from traitsui.tests._tools import (
 )
 from traitsui.testing.api import (
     DisplayedText,
+    IsEnabled,
     MouseClick,
     UITester
 )
@@ -116,12 +117,14 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
         tester = UITester()
         with tester.create_ui(button_text_edit, dict(view=view)) as ui:
             button = tester.find_by_name(ui, "play_button")
+            self.assertFalse(button.inspect(IsEnabled()))
 
             with self.assertTraitDoesNotChange(
                     button_text_edit, "play_button"):
                 button.perform(MouseClick())
 
             button_text_edit.button_enabled = True
+            self.assertTrue(button.inspect(IsEnabled()))
             with self.assertTraitChanges(
                     button_text_edit, "play_button", count=1):
                 button.perform(MouseClick())

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -28,8 +28,7 @@ from traits.trait_types import Str, Int
 import traitsui
 from traitsui.basic_editor_factory import BasicEditorFactory
 from traitsui.api import Group, Item, spring, View
-from traitsui.testing.tester import command, query
-from traitsui.testing.tester.ui_tester import UITester
+from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick, UITester
 from traitsui.tests._tools import (
     BaseTestMixin,
     count_calls,
@@ -203,8 +202,9 @@ class TestUI(BaseTestMixin, unittest.TestCase):
 
             # press the OK button and close the dialog
             ok_button = tester.find_by_id(ui, "OK")
-            self.assertEqual(ok_button.inspect(query.DisplayedText()), "OK")
-            ok_button.perform(command.MouseClick())
+            self.assertEqual(ok_button.inspect(DisplayedText()), "OK")
+            self.assertTrue(ok_button.inspect(IsEnabled()))
+            ok_button.perform(MouseClick())
 
             self.assertIsNone(ui.control)
             self.assertEqual(control.Destroy._n_calls, 1)
@@ -226,8 +226,9 @@ class TestUI(BaseTestMixin, unittest.TestCase):
 
             # press the OK button and close the dialog
             ok_button = tester.find_by_id(ui, "OK")
-            self.assertEqual(ok_button.inspect(query.DisplayedText()), "OK")
-            ok_button.perform(command.MouseClick())
+            self.assertEqual(ok_button.inspect(DisplayedText()), "OK")
+            self.assertTrue(ok_button.inspect(IsEnabled()))
+            ok_button.perform(MouseClick())
 
             self.assertIsNone(ui.control)
             self.assertEqual(control.deleteLater._n_calls, 1)


### PR DESCRIPTION
Closes #1294 

This PR adds a new `IsEditable` query class for UI Tester, along with implementations for the standard traitsui `ButtonEditor` and the `ui_base` `ButtonEditor`.  It also adds very simple check to the currently existing tests for these editors using the new query class.  