### PR TITLE
Replace screen metrics code with Pyface implementation

### DIFF
--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -16,8 +16,6 @@ editors and text editor factories.
 
 
 from pyface.qt import QtGui
-from pyface.api import SystemMetrics
-
 
 _palette = QtGui.QApplication.palette()
 

--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -43,8 +43,3 @@ EditableColor = _palette.color(QtGui.QPalette.Base)
 WindowColor = _palette.color(QtGui.QPalette.Window)
 
 del _palette
-
-# Screen size values:
-
-screen_dx = SystemMetrics()._get_screen_width()
-screen_dy = SystemMetrics()._get_screen_height()

--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -15,7 +15,8 @@ editors and text editor factories.
 """
 
 
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtGui
+from pyface.api import SystemMetrics
 
 
 _palette = QtGui.QApplication.palette()
@@ -45,14 +46,5 @@ del _palette
 
 # Screen size values:
 
-# QDesktopWidget.availableGeometry(int screen) is deprecated and Qt docs
-# suggest using screens() instead, but screens in not available in qt4
-if QtCore.__version_info__ >= (5, 0):
-    _geom = QtGui.QApplication.screens()[0].availableGeometry()
-else:
-    _geom = QtGui.QApplication.desktop().availableGeometry()
-
-screen_dx = _geom.width()
-screen_dy = _geom.height()
-
-del _geom
+screen_dx = SystemMetrics()._get_screen_width()
+screen_dy = SystemMetrics()._get_screen_height()

--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -17,6 +17,8 @@ editors and text editor factories.
 
 from pyface.qt import QtGui
 
+from pyface.api import SystemMetrics
+
 _palette = QtGui.QApplication.palette()
 
 # Default dialog title
@@ -41,3 +43,9 @@ EditableColor = _palette.color(QtGui.QPalette.Base)
 WindowColor = _palette.color(QtGui.QPalette.Window)
 
 del _palette
+
+#: Screen width
+screen_dx = SystemMetrics().screen_width
+
+#: Screen height
+screen_dy = SystemMetrics().screen_height

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -32,12 +32,6 @@ from pyface.qt import QtCore, QtGui, qt_api
 from traitsui.toolkit import Toolkit
 
 
-#: Screen width
-screen_dx = SystemMetrics().screen_width
-
-#: Screen height
-screen_dy = SystemMetrics().screen_height
-
 # -------------------------------------------------------------------------
 #  Handles UI notification handler requests that occur on a thread other than
 #  the UI thread:
@@ -250,8 +244,8 @@ class GUIToolkit(Toolkit):
         if parent is None:
             px = 0
             py = 0
-            pdx = screen_dx
-            pdy = screen_dy
+            pdx = SystemMetrics().screen_width
+            pdy = SystemMetrics().screen_height
         else:
             pos = parent.pos()
             if int(parent.windowFlags()) & QtCore.Qt.Window == 0:
@@ -273,14 +267,14 @@ class GUIToolkit(Toolkit):
         if width < 0.0:
             width = cur_width
         elif width <= 1.0:
-            width = int(width * screen_dx)
+            width = int(width * SystemMetrics().screen_width)
         else:
             width = int(width)
 
         if height < 0.0:
             height = cur_height
         elif height <= 1.0:
-            height = int(height * screen_dy)
+            height = int(height * SystemMetrics().screen_height)
         else:
             height = int(height)
 

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -33,10 +33,10 @@ from traitsui.toolkit import Toolkit
 
 
 #: Screen width
-screen_dx = SystemMetrics()._get_screen_width()
+screen_dx = SystemMetrics().screen_width
 
 #: Screen height
-screen_dy = SystemMetrics()._get_screen_height()
+screen_dy = SystemMetrics().screen_height
 
 # -------------------------------------------------------------------------
 #  Handles UI notification handler requests that occur on a thread other than

--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -26,10 +26,17 @@ from pyface.toolkit import toolkit_object as pyface_toolkit
 _app = pyface_toolkit("init:_app")
 
 from traits.trait_notifiers import set_ui_handler
+from pyface.api import SystemMetrics
 from pyface.qt import QtCore, QtGui, qt_api
 
 from traitsui.toolkit import Toolkit
-from .constants import screen_dx, screen_dy
+
+
+#: Screen width
+screen_dx = SystemMetrics()._get_screen_width()
+
+#: Screen height
+screen_dy = SystemMetrics()._get_screen_height()
 
 # -------------------------------------------------------------------------
 #  Handles UI notification handler requests that occur on a thread other than

--- a/traitsui/wx/constants.py
+++ b/traitsui/wx/constants.py
@@ -23,8 +23,6 @@ import sys
 
 import wx
 
-from pyface.api import SystemMetrics
-
 #: Define platform and wx version constants:
 is_mac = sys.platform == "darwin"
 

--- a/traitsui/wx/constants.py
+++ b/traitsui/wx/constants.py
@@ -23,6 +23,8 @@ import sys
 
 import wx
 
+from pyface.api import SystemMetrics
+
 #: Define platform and wx version constants:
 is_mac = sys.platform == "darwin"
 
@@ -77,3 +79,9 @@ standard_bitmap_width = 120
 
 #: Width of a scrollbar
 scrollbar_dx = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
+
+#: Screen width
+screen_dx = SystemMetrics().screen_width
+
+#: Screen height
+screen_dy = SystemMetrics().screen_height

--- a/traitsui/wx/constants.py
+++ b/traitsui/wx/constants.py
@@ -23,6 +23,8 @@ import sys
 
 import wx
 
+from pyface.api import SystemMetrics
+
 #: Define platform and wx version constants:
 is_mac = sys.platform == "darwin"
 
@@ -79,7 +81,7 @@ standard_bitmap_width = 120
 scrollbar_dx = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
 
 #: Screen width
-screen_dx = wx.SystemSettings.GetMetric(wx.SYS_SCREEN_X)
+screen_dx = SystemMetrics()._get_screen_width()
 
 #: Screen height
-screen_dy = wx.SystemSettings.GetMetric(wx.SYS_SCREEN_Y)
+screen_dy = SystemMetrics()._get_screen_height()

--- a/traitsui/wx/constants.py
+++ b/traitsui/wx/constants.py
@@ -79,9 +79,3 @@ standard_bitmap_width = 120
 
 #: Width of a scrollbar
 scrollbar_dx = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
-
-#: Screen width
-screen_dx = SystemMetrics()._get_screen_width()
-
-#: Screen height
-screen_dy = SystemMetrics()._get_screen_height()

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -53,12 +53,6 @@ from .constants import standard_bitmap_width
 from .editor import Editor
 
 
-#: Screen width
-screen_dx = SystemMetrics().screen_width
-
-#: Screen height
-screen_dy = SystemMetrics().screen_height
-
 # -------------------------------------------------------------------------
 #  Trait definitions:
 # -------------------------------------------------------------------------
@@ -235,7 +229,10 @@ def position_window(window, width=None, height=None, parent=None):
     if parent is None:
         # Center the popup on the screen:
         window.SetSize(
-            (screen_dx - width) // 2, (screen_dy - height) // 2, width, height
+            (SystemMetrics().screen_width - width) // 2,
+            (SystemMetrics().screen_height - height) // 2,
+            width,
+            height
         )
         return
 
@@ -249,8 +246,8 @@ def position_window(window, width=None, height=None, parent=None):
         x, y, parent_dx, parent_dy = parent
 
     adjacent = getattr(window, "_kind", "popup") == "popup"
-    width = min(max(parent_dx, width), screen_dx)
-    height = min(height, screen_dy)
+    width = min(max(parent_dx, width), SystemMetrics().screen_width)
+    height = min(height, SystemMetrics().screen_height)
 
     closest = find_closest_display(x, y)
 
@@ -580,9 +577,9 @@ class PopupControl(HasPrivateTraits):
 
         # Calculate the best position and size for the pop-up:
         py = cy + cdy
-        if (py + pdy) > screen_dy:
+        if (py + pdy) > SystemMetrics().screen_height:
             if (cy - pdy) < 0:
-                bottom = screen_dy - py
+                bottom = SystemMetrics().screen_height - py
                 if cy > bottom:
                     py, pdy = 0, cy
                 else:

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -44,13 +44,20 @@ from traits.api import (
 
 from traitsui.ui_traits import convert_image, SequenceTypes
 
+from pyface.api import SystemMetrics
+
 from pyface.timer.api import do_later
 
-from .constants import standard_bitmap_width, screen_dx, screen_dy
+from .constants import standard_bitmap_width
 
 from .editor import Editor
 
 
+#: Screen width
+screen_dx = SystemMetrics()._get_screen_width()
+
+#: Screen height
+screen_dy = SystemMetrics()._get_screen_height()
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -54,10 +54,10 @@ from .editor import Editor
 
 
 #: Screen width
-screen_dx = SystemMetrics()._get_screen_width()
+screen_dx = SystemMetrics().screen_width
 
 #: Screen height
-screen_dy = SystemMetrics()._get_screen_height()
+screen_dy = SystemMetrics().screen_height
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -46,10 +46,10 @@ from .helper import position_window
 
 
 #: Screen width
-screen_dx = SystemMetrics()._get_screen_width()
+screen_dx = SystemMetrics().screen_width
 
 #: Screen height
-screen_dy = SystemMetrics()._get_screen_height()
+screen_dy = SystemMetrics().screen_height
 
 logger = logging.getLogger(__name__)
 

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -35,17 +35,23 @@ _app = pyface_toolkit("init:_app")
 
 from traits.api import HasPrivateTraits, Instance
 from traits.trait_notifiers import set_ui_handler
+from pyface.api import SystemMetrics
 from pyface.wx.drag_and_drop import PythonDropTarget
 
 from traitsui.theme import Theme
 from traitsui.ui import UI
 from traitsui.toolkit import Toolkit
-from .constants import WindowColor, screen_dx, screen_dy
+from .constants import WindowColor
 from .helper import position_window
 
 
-logger = logging.getLogger(__name__)
+#: Screen width
+screen_dx = SystemMetrics()._get_screen_width()
 
+#: Screen height
+screen_dy = SystemMetrics()._get_screen_height()
+
+logger = logging.getLogger(__name__)
 
 #: Mapping from wx events to method suffixes.
 EventSuffix = {

--- a/traitsui/wx/toolkit.py
+++ b/traitsui/wx/toolkit.py
@@ -44,13 +44,6 @@ from traitsui.toolkit import Toolkit
 from .constants import WindowColor
 from .helper import position_window
 
-
-#: Screen width
-screen_dx = SystemMetrics().screen_width
-
-#: Screen height
-screen_dy = SystemMetrics().screen_height
-
 logger = logging.getLogger(__name__)
 
 #: Mapping from wx events to method suffixes.
@@ -235,7 +228,8 @@ class GUIToolkit(Toolkit):
         parent = window.GetParent()
         if parent is None:
             px, py = 0, 0
-            pdx, pdy = screen_dx, screen_dy
+            pdx = SystemMetrics().screen_width
+            pdy = SystemMetrics().screen_height
         else:
             px, py = parent.GetPosition()
             pdx, pdy = parent.GetSize()
@@ -248,14 +242,14 @@ class GUIToolkit(Toolkit):
         if width < 0.0:
             width = cur_width
         elif width <= 1.0:
-            width = int(width * screen_dx)
+            width = int(width * SystemMetrics().screen_width)
         else:
             width = int(width)
 
         if height < 0.0:
             height = cur_height
         elif height <= 1.0:
-            height = int(height * screen_dy)
+            height = int(height * SystemMetrics().screen_height)
         else:
             height = int(height)
 

--- a/traitsui/wx/ui_live.py
+++ b/traitsui/wx/ui_live.py
@@ -43,7 +43,7 @@ from traitsui.menu import (
 
 
 #: Screen height
-screen_dy = SystemMetrics()._get_screen_height()
+screen_dy = SystemMetrics().screen_height
 
 
 # -------------------------------------------------------------------------

--- a/traitsui/wx/ui_live.py
+++ b/traitsui/wx/ui_live.py
@@ -42,10 +42,6 @@ from traitsui.menu import (
 )
 
 
-#: Screen height
-screen_dy = SystemMetrics().screen_height
-
-
 # -------------------------------------------------------------------------
 #  Creates a 'live update' wxPython user interface for a specified UI object:
 # -------------------------------------------------------------------------
@@ -198,7 +194,7 @@ class LiveWindow(BaseDialog):
             sizer.Add(trait_sheet, 1, wx.EXPAND)
             tsdx, tsdy = trait_sheet.GetSize()
             sw.SetScrollRate(16, 16)
-            max_dy = (2 * screen_dy) // 3
+            max_dy = (2 * SystemMetrics().screen_height) // 3
             sw.SetSizer(sizer)
             sw.SetSize(
                 wx.Size(

--- a/traitsui/wx/ui_live.py
+++ b/traitsui/wx/ui_live.py
@@ -22,13 +22,15 @@
 
 import wx
 
+from pyface.api import SystemMetrics
+
 from .helper import save_window, TraitsUIScrolledPanel
 
 from .ui_base import BaseDialog
 
 from .ui_panel import panel
 
-from .constants import DefaultTitle, WindowColor, screen_dy, scrollbar_dx
+from .constants import DefaultTitle, WindowColor, scrollbar_dx
 from traitsui.undo import UndoHistory
 
 from traitsui.menu import (
@@ -38,6 +40,10 @@ from traitsui.menu import (
     CancelButton,
     HelpButton,
 )
+
+
+#: Screen height
+screen_dy = SystemMetrics()._get_screen_height()
 
 
 # -------------------------------------------------------------------------

--- a/traitsui/wx/ui_modal.py
+++ b/traitsui/wx/ui_modal.py
@@ -39,9 +39,6 @@ from traitsui.menu import (
     HelpButton,
 )
 
-#: Screen height
-screen_dy = SystemMetrics().screen_height
-
 
 def ui_modal(ui, parent):
     """ Creates a modal wxPython user interface for a specified UI object.
@@ -131,7 +128,7 @@ class ModalDialog(BaseDialog):
             tsdx += 8
             tsdy += 8
             sw.SetScrollRate(16, 16)
-            max_dy = (2 * screen_dy) // 3
+            max_dy = (2 * SystemMetrics().screen_height) // 3
             sw.SetSizer(sizer)
             sw.SetSize(
                 wx.Size(

--- a/traitsui/wx/ui_modal.py
+++ b/traitsui/wx/ui_modal.py
@@ -40,7 +40,7 @@ from traitsui.menu import (
 )
 
 #: Screen height
-screen_dy = SystemMetrics()._get_screen_height()
+screen_dy = SystemMetrics().screen_height
 
 
 def ui_modal(ui, parent):

--- a/traitsui/wx/ui_modal.py
+++ b/traitsui/wx/ui_modal.py
@@ -21,13 +21,15 @@
 
 import wx
 
+from pyface.api import SystemMetrics
+
 from .helper import save_window, TraitsUIScrolledPanel
 
 from .ui_base import BaseDialog
 
 from .ui_panel import panel
 
-from .constants import DefaultTitle, WindowColor, screen_dy, scrollbar_dx
+from .constants import DefaultTitle, WindowColor, scrollbar_dx
 
 from traitsui.menu import (
     ApplyButton,
@@ -36,6 +38,9 @@ from traitsui.menu import (
     CancelButton,
     HelpButton,
 )
+
+#: Screen height
+screen_dy = SystemMetrics()._get_screen_height()
 
 
 def ui_modal(ui, parent):

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -37,6 +37,8 @@ from traitsui.help_template import help_template
 
 from traitsui.menu import UndoButton, RevertButton, HelpButton
 
+from pyface.api import SystemMetrics
+
 from pyface.dock.api import (
     DockWindow,
     DockSizer,
@@ -54,10 +56,16 @@ from .helper import (
     GroupEditor,
 )
 
-from .constants import screen_dx, screen_dy, WindowColor
+from .constants import WindowColor
 
 from .ui_base import BaseDialog
 
+
+#: Screen width
+screen_dx = SystemMetrics()._get_screen_width()
+
+#: Screen height
+screen_dy = SystemMetrics()._get_screen_height()
 
 # Pattern of all digits
 all_digits = re.compile(r"\d+")
@@ -1170,7 +1178,7 @@ class HTMLHelpWindow(wx.Frame):
         sizer.Add(b_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
         self.SetSizer(sizer)
         self.SetSize(
-            wx.Size(int(scale_dx * screen_dx), int(scale_dy * screen_dy))
+            wx.Size(int(scale_dx * screen_dx, int(scale_dy * screen_dy))
         )
 
         # Position and show the dialog:

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -62,10 +62,10 @@ from .ui_base import BaseDialog
 
 
 #: Screen width
-screen_dx = SystemMetrics()._get_screen_width()
+screen_dx = SystemMetrics().screen_width
 
 #: Screen height
-screen_dy = SystemMetrics()._get_screen_height()
+screen_dy = SystemMetrics().screen_height
 
 # Pattern of all digits
 all_digits = re.compile(r"\d+")

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -1178,7 +1178,7 @@ class HTMLHelpWindow(wx.Frame):
         sizer.Add(b_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
         self.SetSizer(sizer)
         self.SetSize(
-            wx.Size(int(scale_dx * screen_dx, int(scale_dy * screen_dy))
+            wx.Size(int(scale_dx * screen_dx), int(scale_dy * screen_dy))
         )
 
         # Position and show the dialog:

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -61,12 +61,6 @@ from .constants import WindowColor
 from .ui_base import BaseDialog
 
 
-#: Screen width
-screen_dx = SystemMetrics().screen_width
-
-#: Screen height
-screen_dy = SystemMetrics().screen_height
-
 # Pattern of all digits
 all_digits = re.compile(r"\d+")
 
@@ -1178,7 +1172,8 @@ class HTMLHelpWindow(wx.Frame):
         sizer.Add(b_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
         self.SetSizer(sizer)
         self.SetSize(
-            wx.Size(int(scale_dx * screen_dx), int(scale_dy * screen_dy))
+            wx.Size(int(scale_dx * SystemMetrics().screen_width),
+            int(scale_dy * SystemMetrics().screen_height))
         )
 
         # Position and show the dialog:


### PR DESCRIPTION
fixes #1316 

~~This PR removes the screen size from the `traitsui.qt4.constants.py` and `traitsui.wx.constants.py` files~~ (Edit: they have been added back in and use pyface's `SystemMetrics`.  They were added back as they had been public and it is possible they may be used elsewhere). Note pyface's `SystemMetrics`  is now used to get these values whenever they are needed (only a few places) within traitsui, rather than getting them from `constants.py`.  I.e. the constants which remain in the `constants.py` files are not used in traitsui itself, but could still potentially be being used elsewhere.   

Note that this will reintroduce deprecation warnings which were resolved by #1311 ~~until https://github.com/enthought/pyface/pull/719 is merged on pyface~~ (Edit: it is now merged) and a release is made so those changes are accessible in traitsui.

Additionally, see this comment: https://github.com/enthought/traitsui/pull/1311#issuecomment-705206248 for why this PR may very slightly change behavior.  If this change is something we wish to avoid I am more than happy to modify this PR as needed.  

