### PR TITLE
Explicitly require a minimum version for Traits

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     __version__ = "not-built"
 
-__requires__ = ["traits", "pyface>=6.0.0"]
+__requires__ = ["traits>=6.0.0", "pyface>=6.0.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],


### PR DESCRIPTION
The TraitsUI codebase already implicitly assumes that we're using Traits >= 6.0 (for example, when importing the `Datetime` trait type from traits.api). This PR makes that assumption explicit in the setup file.

(Context: I wanted to remove the try/except for the `AbstractViewElement` import (which I'll do in another PR). That removal is only valid if we insist on Traits >= 6.0, but I realised that we're already implicitly making that assumption.)