### PR TITLE
Assume that AbstractViewElement is available in Traits

### DIFF
--- a/traitsui/view_element.py
+++ b/traitsui/view_element.py
@@ -21,7 +21,7 @@
 
 import re
 
-from traits.api import HasPrivateTraits, Instance, Bool
+from traits.api import AbstractViewElement, Bool, HasPrivateTraits, Instance
 
 from .ui_traits import (
     AnObject,
@@ -31,13 +31,6 @@ from .ui_traits import (
     HelpId,
     Image,
 )
-
-# Is the AbstractViewElement ABC available in traits.api?
-
-try:
-    from traits.api import AbstractViewElement
-except ImportError:
-    AbstractViewElement = None
 
 
 label_pat = re.compile(r"^(.*)\[(.*)\](.*)$", re.MULTILINE | re.DOTALL)
@@ -214,5 +207,4 @@ class ViewSubElement(ViewElement):
 
 # Register ViewElement as implementing AbstractViewElement
 # TODO: eventually have ViewElement inherit directly
-if AbstractViewElement is not None:
-    AbstractViewElement.register(ViewElement)
+AbstractViewElement.register(ViewElement)


### PR DESCRIPTION
This PR removes a try/except around the `AbstractViewElement` import from traits.api. If we're assuming that we're using Traits >= 6.0 (which we're already doing in other parts of the codebase - see #1323), then `AbstractViewElement` will always be available.

This PR represents the final step of the dependency inversion dance started in enthought/traits#610.