### PR TITLE
Fix SetEditor on Qt and OSX not updating view after button clicks

### DIFF
--- a/traitsui/examples/demo/Standard_Editors/SetEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/SetEditor_demo.py
@@ -2,13 +2,6 @@
 #  License: BSD Style.
 
 """
-**WARNING**
-
-  This demo might not work as expected and some documented features might be
-  missing.
-
--------------------------------------------------------------------------------
-
 Implementation of a SetEditor demo plugin for the Traits UI demo program.
 
 The four tabs of this demo show variations on the interface as follows:
@@ -18,8 +11,6 @@ The four tabs of this demo show variations on the interface as follows:
    Ord I:    Creates a set whose order is specified by the user, no "move all"
    Ord II:   Creates a set whose order is specifed by the user, has "move all"
 """
-# Issue related to the demo warning: enthought/traitsui#913
-
 
 from traits.api import HasTraits, List
 

--- a/traitsui/qt4/set_editor.py
+++ b/traitsui/qt4/set_editor.py
@@ -161,7 +161,7 @@ class SimpleEditor(Editor):
         button = QtGui.QPushButton(label)
         # The connection type is set to workaround Qt5 + MacOSX issue with
         # event dispatching. See enthought/traitsui#1308
-        button.clicked.connect(handler , type=QtCore.Qt.QueuedConnection)
+        button.clicked.connect(handler, type=QtCore.Qt.QueuedConnection)
         layout.addWidget(button)
         return button
 

--- a/traitsui/qt4/set_editor.py
+++ b/traitsui/qt4/set_editor.py
@@ -159,7 +159,9 @@ class SimpleEditor(Editor):
         """ Creates a button.
         """
         button = QtGui.QPushButton(label)
-        button.clicked.connect(handler)
+        # The connection type is set to workaround Qt5 + MacOSX issue with
+        # event dispatching. See enthought/traitsui#1308
+        button.clicked.connect(handler , type=QtCore.Qt.QueuedConnection)
         layout.addWidget(button)
         return button
 


### PR DESCRIPTION
Closes #1305

The solution is exactly the same as #1303. Again, no tests can be written for this. 
I reproduced the issue on OSX 10.15.5 (with both PyQt5 and PySide2) and then verified that this change fixes the issue.

Like in #1303, this change has implications for tests that try to call `click` directly without causing the event loop to process pending events before checking for state change. Currently tests in TraitsUI are either using UITester that handles this automatically, or have already been driving the event loop processing manually. Therefore the tests here do not require changes.