### PR TITLE
Fix ImageEnumEditor button not causing other widget to updates on OSX and Qt

### DIFF
--- a/traitsui/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/ImageEnumEditor_demo.py
@@ -14,7 +14,7 @@ program.
 
 This demo shows each of the four styles of the ImageEnumEditor.
 """
-# Issues related to the demo warning: enthought/traitsui#913,
+# Issues related to the demo warning:
 # enthought/traitsui#947
 
 

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -376,7 +376,11 @@ class RadioEditor(BaseEditor):
 
                     rb.setChecked(name == cur_name)
 
-                    rb.clicked.connect(self._mapper.map)
+                    # The connection type is set to workaround Qt5 + MacOSX
+                    # issue with event dispatching. See enthought/traitsui#1308
+                    rb.clicked.connect(
+                        self._mapper.map, type=QtCore.Qt.QueuedConnection
+                    )
                     self._mapper.setMapping(rb, index)
 
                     self.set_tooltip(rb)


### PR DESCRIPTION
Closes #1304 

The solution is exactly the same as #1303.
I reproduced the issue on OSX 10.15.5 (with both PyQt5 and PySide2) and then verified that this change fixes the issue.

Again, this has implications for tests that don't run the GUI event loop between clicking the button and checking for trait change.

In TraitsUI tests, we have tests using `UITester` for this logic:
https://github.com/enthought/traitsui/blob/a79d7f387bb8d697aff6134e9cdb2a0e81379719/traitsui/tests/editors/test_enum_editor.py#L378-L379
`perform` already does event processing, so the test is happy there.

We also have tests that have yet to be converted to use UITester, and it does the event processing:
https://github.com/enthought/traitsui/blob/964c0110112adc9dc35cf5c6f7f6eedf7ed28fc7/traitsui/tests/editors/test_image_enum_editor.py#L422-L425
So this test also does not require changes. Just to note, if I remove the `process_cascade_events` in this particular test, this PR would break the test.