### PR TITLE
Doc: Improve docstrings on UIWrapper

### DIFF
--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -132,14 +132,19 @@ class UIWrapper:
         Parameters
         ----------
         location : any
-            Any location type supported by the current target.
+            An instance of a location type supported by the current target.
+
+        Returns
+        -------
+        wrapper : UIWrapper
+            A new UIWrapper for the given location.
 
         Raises
         ------
         LocationNotSupported
             If the given location is not supported.
 
-        See also
+        See Also
         --------
         UIWrapper.help
         """
@@ -169,7 +174,7 @@ class UIWrapper:
             If the current target does not support locating another target
             by a name.
 
-        See also
+        See Also
         --------
         traitsui.testing.tester.locator.TargetByName
         """
@@ -195,7 +200,7 @@ class UIWrapper:
             If the current target does not support locating another target
             by a unique identifier.
 
-        See also
+        See Also
         --------
         traitsui.testing.tester.locator.TargetById
         """
@@ -207,10 +212,8 @@ class UIWrapper:
         Parameters
         ----------
         interaction : object
-            An interaction instance that defines the user interaction.
-            See ``traitsui.testing.tester.command`` module for builtin
-            query objects.
-            e.g. ``traitsui.testing.tester.command.MouseClick``
+            An instance of an interaction type supported by the current target.
+            e.g. ``traitsui.testing.api.MouseClick()``
 
         Raises
         ------
@@ -218,7 +221,7 @@ class UIWrapper:
             If the interaction given is not supported for the current UI
             target.
 
-        See also
+        See Also
         --------
         UIWrapper.help
         """
@@ -230,10 +233,14 @@ class UIWrapper:
         Parameters
         ----------
         interaction : object
-            An interaction instance that defines the inspection.
-            See ``traitsui.testing.tester.query`` module for builtin
-            query objects.
-            e.g. ``traitsui.testing.tester.query.DisplayedText``
+            An instance of an interaction type supported by the current target.
+            e.g. ``traitsui.testing.api.DisplayedText()``
+
+        Returns
+        -------
+        values : any
+            Any values returned for the given inspection. The type should be
+            documented by the interaction type object.
 
         Raises
         ------
@@ -241,7 +248,7 @@ class UIWrapper:
             If the interaction given is not supported for the current UI
             target.
 
-        See also
+        See Also
         --------
         UIWrapper.help
         """

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -133,6 +133,7 @@ class UIWrapper:
         ----------
         location : any
             An instance of a location type supported by the current target.
+            e.g. ``traitsui.testing.api.Index(1)``
 
         Returns
         -------


### PR DESCRIPTION
This PR fixes a few missing "Returns" block in the `UIWrapper` docstrings (part of the public API) and some drive-by language improvements.
Purely documentation change, i.e. no behavioural change.