### PR TITLE
Doc: Improve documentation on the UIWrapper._target being protected

### DIFF
--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -380,8 +380,8 @@ The API allows extension such that
    code are not maintained together, tests may be subject to breakages caused
    by internal changes of the UI editors. Certain attributes described in this
    document are classified as protected, to be used for extending the testing
-   API. Developers should evaluate based on context whether using these
-   attributes will introduce unwanted external and/or volatile dependencies.
+   API. Developers should evaluate based on context whether they should be
+   used.
 
 
 Terminology

--- a/docs/source/traitsui_user_manual/testing.rst
+++ b/docs/source/traitsui_user_manual/testing.rst
@@ -378,7 +378,11 @@ The API allows extension such that
    Extending support for testing a UI editor often requires knowledge of the
    implementation details of the editor. If UI editor and the testing support
    code are not maintained together, tests may be subject to breakages caused
-   by internal changes of the UI editors.
+   by internal changes of the UI editors. Certain attributes described in this
+   document are classified as protected, to be used for extending the testing
+   API. Developers should evaluate based on context whether using these
+   attributes will introduce unwanted external and/or volatile dependencies.
+
 
 Terminology
 -----------
@@ -391,7 +395,7 @@ Before we start, we need to define some terminology:
     search for other contained targets (e.g. a table widget that contains
     buttons and text).
 
-    An instance of |UIWrapper| wraps a target under the attribute
+    An instance of |UIWrapper| wraps a target under the protected attribute
     ``_target``.
 
 * Interaction

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -69,11 +69,11 @@ class UIWrapper:
         it is propagated through to created child wrappers. The delay allows
         visual confirmation test code is working as desired.
     _target : any
-        An object on which further UI target can be searched for, or can be
-        a leaf target that can be operated on. Usage of this attribute may
-        require knowledge of the UI target's implementation details.
-        This attribute is expected to be used for implementing extensions to
-        the testing API.
+        The UI target currently wrapped for interactions or locating nested
+        components. This is a protected attribute intended to be used for
+        extending the testing API. Usage of this attribute may expose the
+        software's internal structure to the tests, developers should use this
+        attribute with discretion based on context.
     """
 
     def __init__(self, target, *, registries, delay=0):

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -68,6 +68,12 @@ class UIWrapper:
         Time delay (in ms) in which actions by the wrapper are performed. Note
         it is propagated through to created child wrappers. The delay allows
         visual confirmation test code is working as desired.
+    _target : any
+        An object on which further UI target can be searched for, or can be
+        a leaf target that can be operated on. Usage of this attribute may
+        require knowledge of the UI target's implementation details.
+        This attribute is expected to be used for implementing extensions to
+        the testing API.
     """
 
     def __init__(self, target, *, registries, delay=0):
@@ -246,6 +252,8 @@ class UIWrapper:
         UIWrapper.help
         """
         return self._perform_or_inspect(interaction)
+
+    # Private methods #########################################################
 
     def _perform_or_inspect(self, interaction):
         """ Perform a user interaction or a user inspection.


### PR DESCRIPTION
This PR improves the documentation to clarify that `UIWrapper._target` is a protected (or internal?) attribute that is neither public or private. While it is expected to be used, it should be used with discretion.

The attribute is expected to be used for extending the API (it is mentioned in the "Advanced Testing" section). It deliberately begs the questions "are you sure you want to use it"  / "could you do this differently" / "should you request the support to be implemented upstream". Whether it is appropriate to be used depends on the context, e.g. it may expose the implementation details that do not belong to the same project, or the implementation details may be maintained in the same place such that it is less of a problem.

The documentation here is also useful for developers maintaining the `UIWrapper`: this particular attribute should NOT be renamed lightly once the API is published.