### PR TITLE
Bump version for continued development

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 from io import open
 
 MAJOR = 7
-MINOR = 1
+MINOR = 2
 MICRO = 0
 
 IS_RELEASED = False


### PR DESCRIPTION
This PR bumps the version for continued development for 7.2.0.
This should have been done prior to branching off to create the maintenance branch, and then the maintenance branch should branch off from the commit prior to the merge of this PR.
Fortunately the latest commit on master is still the commit we branched off from.