### PR TITLE
Update __init__.py to depend on Pyface >= 7.1.0 

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     __version__ = "not-built"
 
-__requires__ = ["traits>=6.0.0", "pyface>=6.0.0"]
+__requires__ = ["traits>=6.0.0", "pyface>=7.1.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],


### PR DESCRIPTION
fixes #1355 

Note that pyface 7.1.0 is not yet released, but I opened this PR in anticipation of that.  (It may be too early to do this in which case I will simply close this PR and open a new PR at the appropriate time)  

This PR simply bumps the version number for pyface in `__requires__` in `__init__.py` to 7.1.0.