### PR TITLE
Update pyface version being run on CI

### DIFF
--- a/ci-src-requirements.txt
+++ b/ci-src-requirements.txt
@@ -1,1 +1,1 @@
-git+http://github.com/enthought/pyface.git#egg=pyface
+git+http://github.com/enthought/pyface.git@maint/7.1#egg=pyface


### PR DESCRIPTION
[Targeting 7.1 maintenance branch]

This PR updates this CI source requirement such that Pyface maint/7.1 branch is used in tests.