### PR TITLE
Accept any Appveyor builds on maintenance branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ matrix:
 branches:
   only:
     - master
-    - maint/6.1
+    - /maint\/.*/
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt


### PR DESCRIPTION
This PR updates the Appveyor config on master to accept builds on any branch matching `maint/*`, this is such that future maintenance branch created from master does not have to update this setting anymore.