### PR TITLE
Improve changelog for release 7.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -78,10 +78,10 @@ Fixes
 * Fix ImageEnumEditor button not causing other updates on OSX (#1326)
 * Fix SetEditor on Qt and OSX not updating view after button clicks (#1325)
 * Fix deprecation warnings from Traits 6.1 due to the use of PrefixList (#1053)
-* Fix deprecation warning about trait_get (#1062)
-* Fix QDesktopWidget.availableGeometry deprecation warning (#1311)
-* Replace logger.warn with logger.warning (#1165)
-* Use collections.abc instead of collections (#1103, #1129)
+* Fix deprecation warnings from using HasTraits.trait_get (#1062)
+* Fix deprecation warnings from using QDesktopWidget.availableGeometry (#1311)
+* Fix deprecation warnings from using logging.warn (#1165)
+* Fix deprecation warnings from using ABC in collections (#1103, #1129)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -94,20 +94,20 @@ Build and continuous integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Add a CI job for testing against traits 6.0 (#1108)
-* Update appveyor config to also build on macos (#1160)
-* Add flake8 task to CI with excludes (#1222)
-* Mention additional dependencies for demo examples (#1147)
+* Move MacOS CI build from Travis to Appveyor (#1160)
+* Add flake8 task to CI with exclusions (#1222)
+* Explicitly declare additional dependencies for demo examples (#1147)
 * Explicitly require a minimum version for Traits (#1323)
 
 Maintenance and code organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Relax constrain on PySide2 version (#1146)
+* Relax constraint on PySide2 version (#1146)
 * Update edm version in travis and appveyor config files (#1049)
 * Resolve warnings in tests from QItemSelectionModel with Qt5 (#1041)
 * Improve how we capture and re-raise errors in GUI tests (#1099)
 * Replace screen metrics code with Pyface implementation (#1322)
-* Fix QDateTime deprecation warning (#1310)
+* Fix deprecation warnings from certain usage of QDateTime in tests (#1310)
 * Add a new shell command to etstool.py (#1244)
 
 Release 7.0.1

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,10 @@ and a number of significant fixes. Demo examples are also distributed as
 package data such that they are visible via the "etsdemo" GUI application (to
 be installed separately).
 
+This release should be compatible with Traits 6.0+. Users are encouraged to
+upgrade to Traits 6.1+ to stay current as future releases of TraitsUI will
+stop supporting Traits 6.0.
+
 Highlights of this release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,15 +72,16 @@ Features
 Fixes
 ~~~~~
 
-* Fix deprecation warnings from Traits 6.1 due to the use of PrefixList (#1053)
-* Fix deprecation warning about trait_get (#1062)
+* Fix AttributeError when a nested UI is disposed (#1286)
 * Fix wx error due to use of alignment flag wxEXPAND (#1095)
 * Fix ButtonEditor not causing other widgets to update on OSX and Qt (#1303)
 * Fix ImageEnumEditor button not causing other updates on OSX (#1326)
 * Fix SetEditor on Qt and OSX not updating view after button clicks (#1325)
+* Fix deprecation warnings from Traits 6.1 due to the use of PrefixList (#1053)
+* Fix deprecation warning about trait_get (#1062)
 * Fix QDesktopWidget.availableGeometry deprecation warning (#1311)
-* Fix QDateTime deprecation warning (#1310)
-* Fix AttributeError when a nested UI is disposed (#1286)
+* Replace logger.warn with logger.warning (#1165)
+* Use collections.abc instead of collections (#1103, #1129)
 
 Documentation
 ~~~~~~~~~~~~~
@@ -95,21 +96,20 @@ Build and continuous integration
 * Add a CI job for testing against traits 6.0 (#1108)
 * Update appveyor config to also build on macos (#1160)
 * Add flake8 task to CI with excludes (#1222)
-* Add a new shell command to etstool.py (#1244)
 * Add unittest for ui_traits (#1057)
 * Mention additional dependencies for demo examples (#1147)
+* Explicitly require a minimum version for Traits (#1323)
 
 Maintenance and code organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Use collections.abc instead of collections (#1103, #1129)
-* Explicitly require a minimum version for Traits (#1323)
 * Relax constrain on PySide2 version (#1146)
 * Update edm version in travis and appveyor config files (#1049)
 * Resolve warnings in tests from QItemSelectionModel with Qt5 (#1041)
 * Improve how we capture and re-raise errors in GUI tests (#1099)
-* Replace logger.warn with logger.warning (#1165)
 * Replace screen metrics code with Pyface implementation (#1322)
+* Fix QDateTime deprecation warning (#1310)
+* Add a new shell command to etstool.py (#1244)
 
 Release 7.0.1
 -------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -96,7 +96,6 @@ Build and continuous integration
 * Add a CI job for testing against traits 6.0 (#1108)
 * Update appveyor config to also build on macos (#1160)
 * Add flake8 task to CI with excludes (#1222)
-* Add unittest for ui_traits (#1057)
 * Mention additional dependencies for demo examples (#1147)
 * Explicitly require a minimum version for Traits (#1323)
 


### PR DESCRIPTION
[Targeting maint/7.1]

On second pass of the changelog, there are some minor improvements we can make.

- Add a mention to encourage users to upgrade to Traits 6.1
- Move behaviourial fixes to the top of the "Fixes" section.
- Move fixes to deprecation warning that users can see together.

This PR may be easier to review commits by commits.