### PR TITLE
Add IsEnabled to the testing api docstring

### DIFF
--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -32,6 +32,7 @@ Interactions (for getting GUI states)
 
 - :class:`~.DisplayedText`
 - :class:`~.IsChecked`
+- :class:`~.IsEnabled`
 - :class:`~.SelectedText`
 
 Locations (for locating GUI elements)


### PR DESCRIPTION
This PR adds a reference to the new `IsEnabled` query in the api module docstring.
