### PR TITLE
Allow docs command to be run on Windows

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -376,12 +376,15 @@ def docs(runtime, toolkit, environment):
     click.echo('Done installing documentation tools')
 
     os.chdir('docs')
-    commands = [
-        "edm run -e {environment} -- make html",
-    ]
+    command = (
+        "edm run -e {environment} -- sphinx-build -b html "
+        "-d build/doctrees "
+        "source "
+        "build/html"
+    )
     click.echo("Building documentation in  '{environment}'".format(**parameters))
     try:
-        execute(commands, parameters)
+        execute([command], parameters)
     finally:
         os.chdir('..')
     click.echo('Done building documentation')


### PR DESCRIPTION
The current `docs` command in `etstool.py` cannot be reliably run on Windows as reported by @rahulporuri 
While I could not reproduce, we can avoid the issue by using the sphinx command directly.

The make files are kept, I believe some developers still prefer to use them(?). It does risk the two going out-of-sync though.

Closes #997
