### PR TITLE
Add a test for traitsui.testing.api

### DIFF
--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -57,6 +57,9 @@ Exceptions
 - :class:`~.TesterError`
 """
 
+# Note: Imports are ordered to match the docstring, not in the typical
+# alphabetical order
+
 # Tester
 from .tester.ui_tester import UITester
 

--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -57,19 +57,25 @@ Exceptions
 - :class:`~.TesterError`
 """
 
+# Tester
+from .tester.ui_tester import UITester
+
+# Interactions (for changing GUI states)
 from .tester.command import (
     MouseClick,
     KeyClick,
     KeySequence
 )
 
-from .tester.exceptions import (
-    Disabled,
-    InteractionNotSupported,
-    LocationNotSupported,
-    TesterError
+# Interactions (for getting GUI states)
+from .tester.query import (
+    DisplayedText,
+    IsChecked,
+    IsEnabled,
+    SelectedText
 )
 
+# Locations (for locating GUI elements)
 from .tester.locator import (
     Index,
     TargetById,
@@ -78,13 +84,13 @@ from .tester.locator import (
     Slider
 )
 
+# Advanced usage
 from .tester.target_registry import TargetRegistry
 
-from .tester.query import (
-    DisplayedText,
-    IsChecked,
-    IsEnabled,
-    SelectedText
+# Exceptions
+from .tester.exceptions import (
+    Disabled,
+    InteractionNotSupported,
+    LocationNotSupported,
+    TesterError
 )
-
-from .tester.ui_tester import UITester

--- a/traitsui/testing/tester/_ui_tester_registry/_traitsui_ui.py
+++ b/traitsui/testing/tester/_ui_tester_registry/_traitsui_ui.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.api import TargetById, TargetByName
+from traitsui.testing.tester.locator import TargetById, TargetByName
 
 
 def _get_editor_by_name(ui, name):

--- a/traitsui/testing/tester/_ui_tester_registry/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/default_registry.py
@@ -13,7 +13,7 @@ import importlib
 
 from traits.etsconfig.api import ETSConfig
 
-from traitsui.testing.api import TargetRegistry
+from traitsui.testing.tester.target_registry import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
     register_traitsui_ui_solvers,
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
@@ -14,7 +14,7 @@ from pyface.qt.QtTest import QTest
 from traitsui.testing.tester._ui_tester_registry._compat import (
     check_key_compat
 )
-from traitsui.testing.api import Disabled
+from traitsui.testing.tester.exceptions import Disabled
 from traitsui.qt4.key_event_to_name import key_map as _KEY_MAP
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_registry_helper.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_registry_helper.py
@@ -13,12 +13,12 @@
 and location solvers for common Qt GUI components.
 """
 
-from traitsui.testing.api import (
+from traitsui.testing.tester.command import (
     KeyClick,
     KeySequence,
     MouseClick,
-    DisplayedText
 )
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.api import TargetRegistry
+from traitsui.testing..tester.target_registry import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     boolean_editor,
     button_editor,

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing..tester.target_registry import TargetRegistry
+from traitsui.testing.tester.target_registry import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     boolean_editor,
     button_editor,

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
@@ -14,7 +14,7 @@ import wx
 from traitsui.testing.tester._ui_tester_registry._compat import (
     check_key_compat
 )
-from traitsui.testing.api import Disabled
+from traitsui.testing.tester.exceptions import Disabled
 
 
 def _create_event(event_type, control):

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_registry_helper.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_registry_helper.py
@@ -13,12 +13,12 @@
 and location solvers for common Wx GUI components.
 """
 
-from traitsui.testing.api import (
-    DisplayedText,
+from traitsui.testing.tester.command import (
     KeyClick,
     KeySequence,
     MouseClick
 )
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.api import TargetRegistry
+from traitsui.testing.tester.target_registry import TargetRegistry
 from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
     boolean_editor,
     button_editor,

--- a/traitsui/testing/tests/test_api.py
+++ b/traitsui/testing/tests/test_api.py
@@ -13,20 +13,21 @@
 
 import unittest
 
+
 class TestApi(unittest.TestCase):
 
     def test_tester_import(self):
-        from traitsui.testing.api import UITester
-    
+        from traitsui.testing.api import UITester  # noqa: F401
+
     def test_commands_imports(self):
-        from traitsui.testing.api import (
+        from traitsui.testing.api import (  # noqa: F401
             MouseClick,
             KeyClick,
             KeySequence,
         )
 
     def test_query_imports(self):
-        from traitsui.testing.api import (
+        from traitsui.testing.api import (  # noqa: F401
             DisplayedText,
             IsChecked,
             IsEnabled,
@@ -34,7 +35,7 @@ class TestApi(unittest.TestCase):
         )
 
     def test_locator_imports(self):
-        from traitsui.testing.api import (
+        from traitsui.testing.api import (  # noqa: F401
             Index,
             TargetById,
             TargetByName,
@@ -43,11 +44,10 @@ class TestApi(unittest.TestCase):
         )
 
     def test_advanced_usage_imports(self):
-        #from traitsui.testing.api import TargetRegistry
-        pass
+        from traitsui.testing.api import TargetRegistry  # noqa: F401
 
     def test_exceptions_imports(self):
-        from traitsui.testing.api import (
+        from traitsui.testing.api import (  # noqa: F401
             Disabled,
             InteractionNotSupported,
             LocationNotSupported,

--- a/traitsui/testing/tests/test_api.py
+++ b/traitsui/testing/tests/test_api.py
@@ -1,0 +1,55 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+""" Test the api module. """
+
+import unittest
+
+class TestApi(unittest.TestCase):
+
+    def test_tester_import(self):
+        from traitsui.testing.api import UITester
+    
+    def test_commands_imports(self):
+        from traitsui.testing.api import (
+            MouseClick,
+            KeyClick,
+            KeySequence,
+        )
+
+    def test_query_imports(self):
+        from traitsui.testing.api import (
+            DisplayedText,
+            IsChecked,
+            IsEnabled,
+            SelectedText,
+        )
+
+    def test_locator_imports(self):
+        from traitsui.testing.api import (
+            Index,
+            TargetById,
+            TargetByName,
+            Textbox,
+            Slider,
+        )
+
+    def test_advanced_usage_imports(self):
+        #from traitsui.testing.api import TargetRegistry
+        pass
+
+    def test_exceptions_imports(self):
+        from traitsui.testing.api import (
+            Disabled,
+            InteractionNotSupported,
+            LocationNotSupported,
+            TesterError,
+        )


### PR DESCRIPTION
This PR adds simple import tests for the `traitsui.testing.api`.  I broke the tests up into sections to try to make it easier to ensure the test is up to date with the api moving forward.  

In doing so I also thought it would make sense to reorganize the ordering of the groups of imports in the api module to match the docstring (and have the tests be written in the same order).  In doing so I realized that this actually caused some tests to fail as importing UITester ultimately led to trying to import things from `traitsui.testing.api` whose imports happened after UI Tester.  To avoid this, I simply had those problem cases not import from the api.  (I'm not sure if this was the correct approach, but I thought it made sense).  