### PR TITLE
Install PySide2 using edm instead of pip

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -112,8 +112,8 @@ source_dependencies = {
 # The following should match extras_require in setup.py but with package
 # names compatible with EDM
 extra_dependencies = {
-    # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': {
+        'pyside2',
         'pygments',
     },
     'pyqt': {
@@ -220,12 +220,7 @@ def install(runtime, toolkit, environment, editable, source):
         install_traitsui,
     ])
 
-    # pip install pyqt5 and pyside2, because we don't have them in EDM yet
-    if toolkit == 'pyside2':
-        commands.append(
-            "edm run -e {environment} -- pip install pyside2"
-        )
-    elif toolkit == 'wx':
+    if toolkit == 'wx':
         if sys.platform != 'linux':
             commands.append(
                 "edm run -e {environment} -- pip install wxPython"

--- a/etstool.py
+++ b/etstool.py
@@ -213,8 +213,13 @@ def install(runtime, toolkit, environment, editable, source):
     else:
         commands = ["edm environments create {environment} --force --version={runtime}"]
 
+    if toolkit == "pyside2":
+        additional_repositories = "--add-repository enthought/lgpl"
+    else:
+        additional_repositories = ""
+
     commands.extend([
-        "edm install -y -e {environment} " + " ".join(packages),
+        "edm install -y -e {environment} " + " ".join(packages) + " " + additional_repositories,
         "edm run -e {environment} -- pip install --force-reinstall -r ci-src-requirements.txt --no-dependencies",
         "edm run -e {environment} -- python setup.py clean --all",
         install_traitsui,


### PR DESCRIPTION
This PR updates etstool.py to install pyside2 using edm instead of pip - this is possible now because pyside2 v 5.14.1 is available via edm.

See similar pyface PR https://github.com/enthought/pyface/pull/765