### PR TITLE
Skip load_tests in API documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,7 +189,7 @@ except ImportError as exc:
 # #html_style = 'default.css'
 # #html_theme = 'classic'
 
-# Useful aliases to avoid repeating long URLs. 
+# Useful aliases to avoid repeating long URLs.
 extlinks = {'github-demo': (
     'https://github.com/enthought/traitsui/tree/master/traitsui/examples/demo/%s',
     'github-demo')
@@ -238,3 +238,13 @@ intersphinx_mapping = {
     'traits': ('http://docs.enthought.com/traits', None),
     'pyface': ('http://docs.enthought.com/pyface', None),
 }
+
+
+def autodoc_skip_member(app, what, name, obj, skip, options):
+    # Skip load_tests targeting unittest discover
+    is_load_tests = what == "module" and name == "load_tests"
+    return skip or is_load_tests
+
+
+def setup(app):
+    app.connect('autodoc-skip-member', autodoc_skip_member)


### PR DESCRIPTION
Closes #1375 

Similar to https://github.com/enthought/pyface/pull/762, this PR adds a skip logic in autodoc so that `load_tests` does not appear in the API documentation.

Maybe a more scalable and explicit solution is to have a decorator purely for documentation purpose, and the decorator adds a private attribute that autodoc-skip-member will use to skip the member. So one does something like this:
```
@skip_api_doc
def load_tests(...):
    ...
```

With the current PR, if one actually wants to document a function called `load_tests`, they are going to have a harder time figuring out why it is not visible on the API documentation...
On the other hand, this might well be an overkill. Just an idea.