### PR TITLE
Don't import from traitsui.testing.api in internal editor implementations

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/boolean_editor.py
@@ -8,7 +8,8 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.api import DisplayedText, IsChecked, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.query import DisplayedText, IsChecked
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
@@ -8,7 +8,8 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.query import DisplayedText, IsEnabled
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
@@ -10,8 +10,8 @@
 #
 
 from traitsui.qt4.check_list_editor import CustomEditor
-from traitsui.testing.tester.locator import Index
 from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.locator import Index
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/check_list_editor.py
@@ -10,7 +10,8 @@
 #
 
 from traitsui.qt4.check_list_editor import CustomEditor
-from traitsui.testing.api import Index, MouseClick
+from traitsui.testing.tester.locator import Index
+from traitsui.testing.tester.command import MouseClick
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/editor_factory.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/editor_factory.py
@@ -8,7 +8,7 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.api import DisplayedText
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.qt4._registry_helper import (
     register_editable_textbox_handlers,
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/enum_editor.py
@@ -14,14 +14,13 @@ from traitsui.qt4.enum_editor import (
     RadioEditor,
     SimpleEditor,
 )
-from traitsui.testing.api import (
-    DisplayedText,
-    Index,
+from traitsui.testing.tester.command import (
     KeyClick,
     KeySequence,
     MouseClick,
-    SelectedText
 )
+from traitsui.testing.tester.locator import Index
+from traitsui.testing.tester.query import DisplayedText, SelectedText
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/instance_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/instance_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.api import MouseClick
+from traitsui.testing.tester.command import MouseClick
 from traitsui.testing.tester._ui_tester_registry.qt4._interaction_helpers import (  # noqa
     mouse_click_qwidget
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -8,8 +8,8 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.tester.locator import Index
 from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.locator import Index
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/list_editor.py
@@ -8,10 +8,8 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.api import (
-    Index,
-    MouseClick
-)
+from traitsui.testing.tester.locator import Index
+from traitsui.testing.tester.command import MouseClick
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/range_editor.py
@@ -16,11 +16,8 @@ from traitsui.qt4.range_editor import (
     SimpleSliderEditor,
 )
 
-from traitsui.testing.api import (
-    KeyClick,
-    Slider,
-    Textbox
-)
+from traitsui.testing.tester.command import KeyClick
+from traitsui.testing.tester.locator import Slider, Textbox
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers,
     _registry_helper

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/text_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/text_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.api import DisplayedText
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
@@ -9,7 +9,8 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.qt4.ui_base import ButtonEditor
-from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.query import DisplayedText, IsEnabled
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/boolean_editor.py
@@ -9,7 +9,8 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.boolean_editor import ReadonlyEditor, SimpleEditor
-from traitsui.testing.api import DisplayedText, IsChecked, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.query import DisplayedText, IsChecked
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
@@ -11,7 +11,8 @@
 import wx
 
 from traitsui.wx.button_editor import SimpleEditor, CustomEditor
-from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.query import DisplayedText, IsEnabled
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/check_list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/check_list_editor.py
@@ -11,7 +11,8 @@
 import wx
 
 from traitsui.wx.check_list_editor import CustomEditor
-from traitsui.testing.api import Index, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.locator import Index
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/editor_factory.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/editor_factory.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.editor_factory import ReadonlyEditor, TextEditor
-from traitsui.testing.api import DisplayedText
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 from traitsui.testing.tester._ui_tester_registry.wx._registry_helper import (
     register_editable_textbox_handlers,

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/enum_editor.py
@@ -15,14 +15,13 @@ from traitsui.wx.enum_editor import (
     RadioEditor,
     SimpleEditor,
 )
-from traitsui.testing.api import (
-    DisplayedText,
-    Index,
+from traitsui.testing.tester.command import (
     KeyClick,
     KeySequence,
     MouseClick,
-    SelectedText
 )
+from traitsui.testing.tester.locator import Index
+from traitsui.testing.tester.query import DisplayedText, SelectedText
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 
-from traitsui.testing.api import MouseClick
+from traitsui.testing.tester.command import MouseClick
 from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
     register_traitsui_ui_solvers,
 )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/list_editor.py
@@ -8,7 +8,8 @@
 #
 #  Thanks for using Enthought open source!
 #
-from traitsui.testing.api import Index, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.locator import Index
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
 )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/range_editor.py
@@ -15,11 +15,8 @@ from traitsui.wx.range_editor import (
     SimpleSliderEditor,
 )
 
-from traitsui.testing.api import (
-    KeyClick,
-    Slider,
-    Textbox
-)
+from traitsui.testing.tester.command import KeyClick
+from traitsui.testing.tester.locator import Slider, Textbox
 from traitsui.testing.tester._ui_tester_registry.wx import (
     _interaction_helpers,
     _registry_helper

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/text_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/text_editor.py
@@ -9,7 +9,7 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.text_editor import CustomEditor, ReadonlyEditor, SimpleEditor
-from traitsui.testing.api import DisplayedText
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 from traitsui.testing.tester._ui_tester_registry.wx._registry_helper import (
     register_editable_textbox_handlers,

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
@@ -9,7 +9,8 @@
 #  Thanks for using Enthought open source!
 #
 from traitsui.wx.ui_base import ButtonEditor
-from traitsui.testing.api import DisplayedText, IsEnabled, MouseClick
+from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.locator import DisplayedText, IsEnabled
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
@@ -10,7 +10,7 @@
 #
 from traitsui.wx.ui_base import ButtonEditor
 from traitsui.testing.tester.command import MouseClick
-from traitsui.testing.tester.locator import DisplayedText, IsEnabled
+from traitsui.testing.tester.query import DisplayedText, IsEnabled
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 


### PR DESCRIPTION
This PR replaces imports from `traitsui.testing.api` in internal non-test code.  This is to avoid potential circular dependencies.  See comment here: https://github.com/enthought/traitsui/pull/1370#discussion_r506176635