### PR TITLE
Release candidate 7.1.0rc2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ MAJOR = 7
 MINOR = 1
 MICRO = 0
 PRERELEASE = "rc2"
-IS_RELEASED = True
+IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ from io import open
 MAJOR = 7
 MINOR = 1
 MICRO = 0
-PRERELEASE = ""
-IS_RELEASED = False
+PRERELEASE = "rc2"
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This Pr contains 2 commits (Dont squash merge!) to set the `PRERELEASE` to rc2 and flip `IS_RELEASED`.