### PR TITLE
Fix Qt IconButton with a clickable area too small

### DIFF
--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -179,6 +179,13 @@ class IconButton(QtGui.QPushButton):
         self.clicked.connect(slot)
 
     def sizeHint(self):
+        """ Reimplement sizeHint to return a recommended button size based on
+        the size of the icon.
+
+        Returns
+        -------
+        size : QtCore.QSize
+        """
         # We want the button to have a size similar to the icon.
         # Using the size computed for a tool button gives a desirable size.
         option = QtGui.QStyleOptionButton()

--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -173,12 +173,20 @@ class IconButton(QtGui.QPushButton):
 
         # Configure the button.
         self.setIcon(ico)
-        self.setMaximumSize(ico_sz, ico_sz)
         self.setFlat(True)
         self.setFocusPolicy(QtCore.Qt.NoFocus)
 
         self.clicked.connect(slot)
 
+    def sizeHint(self):
+        # We want the button to have a size similar to the icon.
+        # Using the size computed for a tool button gives a desirable size.
+        option = QtGui.QStyleOptionButton()
+        self.initStyleOption(option)
+        size = self.style().sizeFromContents(
+            QtGui.QStyle.CT_ToolButton, option, option.iconSize
+        )
+        return size
 
 # ------------------------------------------------------------------------
 # Text Rendering helpers

--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -186,6 +186,8 @@ class IconButton(QtGui.QPushButton):
         -------
         size : QtCore.QSize
         """
+        self.ensurePolished()
+
         # We want the button to have a size similar to the icon.
         # Using the size computed for a tool button gives a desirable size.
         option = QtGui.QStyleOptionButton()


### PR DESCRIPTION
Closes https://github.com/enthought/traitsui/issues/1364

On OSX, the clickable area of the icon button is too small: you have to click dead center with a few pixel accuracy to actually click the button. This explains why sometimes the dialog can be launched and sometimes it cannot.

This issue affects the simple FileEditor, RangeEditor (the buttons for incrementing and decrementing the value), and the ListEditor (the button for opening a menu for adding or removing an item).

This PR fixes the issue by reimplementing the sizeHint of the `IconButton` (inheriting QPushButton) to return a larger size and remove the `setMaximumSize` line which set the button size to be too small.  The sizeHint implemented here follows a logic similar to that of `QToolButton` (see source [here](https://code.woboq.org/qt5/qtbase/src/widgets/widgets/qtoolbutton.cpp.html)). 

On master, see the little grey area when I click the button:
![Oct-19-2020 12-19-00](https://user-images.githubusercontent.com/3673984/96444008-672beb00-1205-11eb-827f-51f8b3031e99.gif)

On this branch, the clickable area is bigger (as shown by the larger grey area when I press the button):
![Oct-19-2020 12-19-27](https://user-images.githubusercontent.com/3673984/96444046-74e17080-1205-11eb-8239-01a91342ff47.gif)
