### PR TITLE
Dont install pyface from git source

### DIFF
--- a/ci-src-requirements.txt
+++ b/ci-src-requirements.txt
@@ -1,1 +1,0 @@
-git+http://github.com/enthought/pyface.git#egg=pyface

--- a/etstool.py
+++ b/etstool.py
@@ -117,6 +117,7 @@ dependencies = {
 
 # NOTE : pyface is always installed from source
 source_dependencies = {
+    "pyface": "git+http://github.com/enthought/pyface.git#egg=pyface",
     "traits": "git+http://github.com/enthought/traits.git#egg=traits",
 }
 

--- a/etstool.py
+++ b/etstool.py
@@ -111,8 +111,8 @@ TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
 
 # Required runtime dependencies. Should match install_requires in setup.py
 dependencies = {
+    "pyface",
     "traits" + TRAITS_VERSION_REQUIRES,
-    # pyface is installed from source via ci-src-requirements.txt
 }
 
 # NOTE : pyface is always installed from source


### PR DESCRIPTION
fixes #1382 

This PR updates CI/etstool to install pyface using edm instead of installing it from git source.