### PR TITLE
Remove unnecessary use of f-string.

### DIFF
--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -379,7 +379,7 @@ class TestUIWrapperHelp(unittest.TestCase):
         # then
         self.assertEqual(
             stream.getvalue(),
-            textwrap.dedent(f"""\
+            textwrap.dedent("""\
                 Interactions
                 ------------
                 No interactions are supported.


### PR DESCRIPTION
In this specific case, there was nothing that needed to be formatted in the string so we can just use a normal string.

This was reported as a flake8 failure in the CI job - https://travis-ci.org/github/enthought/traitsui/jobs/738921895, PR #1392 .