### PR TITLE
Run pip install with no deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - env: RUNTIME=3.6 TOOLKITS="null"
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt5" TRAITS_REQUIRES="^=6.0"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt5"
   allow_failures:
     - env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - env: RUNTIME=3.6 TOOLKITS="null"
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt5"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt5" TRAITS_REQUIRES="^=6.0"
   allow_failures:
     - env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true

--- a/etstool.py
+++ b/etstool.py
@@ -221,10 +221,13 @@ def install(runtime, toolkit, environment, editable, source):
         | ci_dependencies
     )
 
-    install_traitsui = "edm run -e {environment} -- pip install "
+    install_traitsui = (
+        "edm run -e {environment} -- "
+        "pip install --no-deps --force-reinstall "
+    )
     if editable:
         install_traitsui += "--editable "
-    install_traitsui += ". --no-deps"
+    install_traitsui += "."
 
     # edm commands to setup the development environment
     if sys.platform == 'linux':

--- a/etstool.py
+++ b/etstool.py
@@ -224,7 +224,7 @@ def install(runtime, toolkit, environment, editable, source):
     install_traitsui = "edm run -e {environment} -- pip install "
     if editable:
         install_traitsui += "--editable "
-    install_traitsui += "."
+    install_traitsui += ". --no-deps"
 
     # edm commands to setup the development environment
     if sys.platform == 'linux':

--- a/etstool.py
+++ b/etstool.py
@@ -187,6 +187,10 @@ environment_vars = {
     'null': {'ETS_TOOLKIT': 'null'},
 }
 
+CONSTRAINT_MODIFIERS = {
+    "--allow-newer pyface",
+}
+
 
 def normalize(name):
     return name.replace("_", "-")
@@ -235,8 +239,20 @@ def install(runtime, toolkit, environment, editable, source):
     else:
         commands = ["edm environments create {environment} --force --version={runtime}"]
 
+    # NOTE : Pinning traits to an older version e.g. 6.0 forces older versions
+    # of dependencies e.g. traitsui/pyface < 7.0, which is a problem for
+    # traitsui master because it requires pyface >= 7.0.
+    # So, for now, if an older version of traits is required, we explicitly
+    # allow newer versions of pyface.
+    # This constraint modifier can be removed when we stop supporting traits
+    # 6.0.
+    if TRAITS_VERSION_REQUIRES:
+        constraint_modifiers = CONSTRAINT_MODIFIERS
+    else:
+        constraint_modifiers = ""
+
     commands.extend([
-        "edm install -y -e {environment} " + " ".join(packages),
+        "edm install -y -e {environment} " + " ".join(packages) + " " + " ".join(constraint_modifiers),
         "edm run -e {environment} -- pip install --force-reinstall -r ci-src-requirements.txt --no-dependencies",
         "edm run -e {environment} -- python setup.py clean --all",
         install_traitsui,


### PR DESCRIPTION
When `etstool.py install` is run in CI, because we are not passing `--no-deps`, `pyface` gets installed once via edm and a second time via pip/setup.

This should not usually be a problem as ideally pip would try to install the same version that edm installed - but this cron job begs to differ - https://travis-ci.com/github/enthought/traitsui/jobs/428569793. For reasons that are not entirely clear, edm installed pyfave version 6.1.2 and then running `pip install .` installed version 7.1.0. After that, removing the edm package worked as expected but trying to install pyface from source crashed because pyface was already installed.