### PR TITLE
Support -h for getting help

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -540,4 +540,4 @@ def execute(commands, parameters):
 
 
 if __name__ == '__main__':
-    cli()
+    cli(prog_name="python etstool.py")

--- a/etstool.py
+++ b/etstool.py
@@ -192,7 +192,14 @@ def normalize(name):
     return name.replace("_", "-")
 
 
-@click.group(context_settings={"token_normalize_func": normalize})
+# Ensure that "-h" is supported for getting help.
+CONTEXT_SETTINGS = dict(
+    help_option_names=["-h", "--help"],
+    token_normalize_func=normalize,
+)
+
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     pass
 


### PR DESCRIPTION
Currently, `python -m etstool --help` works for getting help but `python -m etstool -h` does not. This breaks user expectations when working with a command line application. This PR makes `-h` work as expected.

(For @achabotl )