### PR TITLE
Enable the scrollable trait of a Group in the Qt backend

### DIFF
--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -172,11 +172,14 @@ class TestPanelLayout(unittest.TestCase):
         example = ScrollableGroupExample()
 
         ui = example.edit_traits(view=scrollable_group_view)
-        mainwindow = ui.control.layout().itemAt(0).widget()
-        scroll_area = mainwindow.centralWidget()
-        self.assertIsInstance(scroll_area, QtGui.QScrollArea)
-        content = scroll_area.widget()
-        self.assertIsInstance(content, QtGui.QWidget)
+        try:
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            scroll_area = mainwindow.centralWidget()
+            self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+            content = scroll_area.widget()
+            self.assertIsInstance(content, QtGui.QWidget)
+        finally:
+            ui.dispose()
 
     def test_scrollable_group_box(self):
         from pyface.qt import QtGui
@@ -184,11 +187,14 @@ class TestPanelLayout(unittest.TestCase):
         example = ScrollableGroupExample()
 
         ui = example.edit_traits(view=scrollable_group_box_view)
-        mainwindow = ui.control.layout().itemAt(0).widget()
-        scroll_area = mainwindow.centralWidget()
-        self.assertIsInstance(scroll_area, QtGui.QScrollArea)
-        group_box = scroll_area.widget()
-        self.assertIsInstance(group_box, QtGui.QGroupBox)
+        try:
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            scroll_area = mainwindow.centralWidget()
+            self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+            group_box = scroll_area.widget()
+            self.assertIsInstance(group_box, QtGui.QGroupBox)
+        finally:
+            ui.dispose()
 
     def test_scrollable_labelled_group(self):
         from pyface.qt import QtGui
@@ -196,18 +202,24 @@ class TestPanelLayout(unittest.TestCase):
         example = ScrollableGroupExample()
 
         ui = example.edit_traits(view=scrollable_labelled_group_view)
-        mainwindow = ui.control.layout().itemAt(0).widget()
-        scroll_area = mainwindow.centralWidget()
-        self.assertIsInstance(scroll_area, QtGui.QScrollArea)
-        group_box = scroll_area.widget()
-        self.assertIsInstance(group_box, QtGui.QWidget)
+        try:
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            scroll_area = mainwindow.centralWidget()
+            self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+            group_box = scroll_area.widget()
+            self.assertIsInstance(group_box, QtGui.QWidget)
+        finally:
+            ui.dispose()
 
     def test_non_scrollable_group_typical(self):
         from pyface.qt import QtGui
 
         example = ScrollableGroupExample()
 
-        ui = example.edit_traits(view=non_scrollable_group_view)
-        mainwindow = ui.control.layout().itemAt(0).widget()
-        content = mainwindow.centralWidget()
-        self.assertIsInstance(content, QtGui.QWidget)
+        try:
+            ui = example.edit_traits(view=non_scrollable_group_view)
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            content = mainwindow.centralWidget()
+            self.assertIsInstance(content, QtGui.QWidget)
+        finally:
+            ui.dispose()

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -48,6 +48,57 @@ class FooDialog(HasTraits):
         return FooPanel()
 
 
+class ScrollableGroupExample(HasTraits):
+
+    my_int = Int(2)
+
+    my_str = Str("The group is scrollable")
+
+
+scrollable_group_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=True,
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+non_scrollable_group_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=False,
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+scrollable_group_box_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=True,
+        label="Scrollable View",
+        show_border=True,
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+scrollable_labelled_group_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=True,
+        label="Scrollable View",
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+
 @requires_toolkit([ToolkitName.qt])
 class TestUIPanel(unittest.TestCase):
     def setup_qt4_dock_window(self):
@@ -110,3 +161,53 @@ class TestUIPanel(unittest.TestCase):
 
             # No button
             self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
+
+
+@requires_toolkit([ToolkitName.qt])
+class TestPanelLayout(unittest.TestCase):
+
+    def test_scrollable_group_typical(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample()
+
+        ui = example.edit_traits(view=scrollable_group_view)
+        mainwindow = ui.control.children()[1]
+        scroll_area = mainwindow.children()[1]
+        self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+        content = scroll_area.widget()
+        self.assertIsInstance(content, QtGui.QWidget)
+
+    def test_scrollable_group_box(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample()
+
+        ui = example.edit_traits(view=scrollable_group_box_view)
+        mainwindow = ui.control.children()[1]
+        scroll_area = mainwindow.children()[1]
+        self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+        group_box = scroll_area.widget()
+        self.assertIsInstance(group_box, QtGui.QGroupBox)
+
+    def test_scrollable_labelled_group(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample()
+
+        ui = example.edit_traits(view=scrollable_labelled_group_view)
+        mainwindow = ui.control.children()[1]
+        scroll_area = mainwindow.children()[1]
+        self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+        group_box = scroll_area.widget()
+        self.assertIsInstance(group_box, QtGui.QWidget)
+
+    def test_non_scrollable_group_typical(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample()
+
+        ui = example.edit_traits(view=non_scrollable_group_view)
+        mainwindow = ui.control.children()[1]
+        content = mainwindow.children()[1]
+        self.assertIsInstance(content, QtGui.QWidget)

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -177,7 +177,7 @@ class TestPanelLayout(unittest.TestCase):
             scroll_area = mainwindow.centralWidget()
             self.assertIsInstance(scroll_area, QtGui.QScrollArea)
             content = scroll_area.widget()
-            self.assertIsInstance(content, QtGui.QWidget)
+            self.assertEqual(type(content), QtGui.QWidget)
         finally:
             ui.dispose()
 
@@ -193,6 +193,7 @@ class TestPanelLayout(unittest.TestCase):
             self.assertIsInstance(scroll_area, QtGui.QScrollArea)
             group_box = scroll_area.widget()
             self.assertIsInstance(group_box, QtGui.QGroupBox)
+            self.assertEqual(group_box.title(), "Scrollable View")
         finally:
             ui.dispose()
 
@@ -206,20 +207,20 @@ class TestPanelLayout(unittest.TestCase):
             mainwindow = ui.control.layout().itemAt(0).widget()
             scroll_area = mainwindow.centralWidget()
             self.assertIsInstance(scroll_area, QtGui.QScrollArea)
-            group_box = scroll_area.widget()
-            self.assertIsInstance(group_box, QtGui.QWidget)
+            content = scroll_area.widget()
+            self.assertEqual(type(content), QtGui.QWidget)
         finally:
             ui.dispose()
 
     def test_non_scrollable_group_typical(self):
         from pyface.qt import QtGui
 
-        example = ScrollableGroupExample()
+        example = ScrollableGroupExample(my_str="The group is not scrollable")
 
+        ui = example.edit_traits(view=non_scrollable_group_view)
         try:
-            ui = example.edit_traits(view=non_scrollable_group_view)
             mainwindow = ui.control.layout().itemAt(0).widget()
             content = mainwindow.centralWidget()
-            self.assertIsInstance(content, QtGui.QWidget)
+            self.assertEqual(type(content), QtGui.QWidget)
         finally:
             ui.dispose()

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -172,8 +172,8 @@ class TestPanelLayout(unittest.TestCase):
         example = ScrollableGroupExample()
 
         ui = example.edit_traits(view=scrollable_group_view)
-        mainwindow = ui.control.children()[1]
-        scroll_area = mainwindow.children()[1]
+        mainwindow = ui.control.layout().itemAt(0).widget()
+        scroll_area = mainwindow.centralWidget()
         self.assertIsInstance(scroll_area, QtGui.QScrollArea)
         content = scroll_area.widget()
         self.assertIsInstance(content, QtGui.QWidget)
@@ -184,8 +184,8 @@ class TestPanelLayout(unittest.TestCase):
         example = ScrollableGroupExample()
 
         ui = example.edit_traits(view=scrollable_group_box_view)
-        mainwindow = ui.control.children()[1]
-        scroll_area = mainwindow.children()[1]
+        mainwindow = ui.control.layout().itemAt(0).widget()
+        scroll_area = mainwindow.centralWidget()
         self.assertIsInstance(scroll_area, QtGui.QScrollArea)
         group_box = scroll_area.widget()
         self.assertIsInstance(group_box, QtGui.QGroupBox)
@@ -196,8 +196,8 @@ class TestPanelLayout(unittest.TestCase):
         example = ScrollableGroupExample()
 
         ui = example.edit_traits(view=scrollable_labelled_group_view)
-        mainwindow = ui.control.children()[1]
-        scroll_area = mainwindow.children()[1]
+        mainwindow = ui.control.layout().itemAt(0).widget()
+        scroll_area = mainwindow.centralWidget()
         self.assertIsInstance(scroll_area, QtGui.QScrollArea)
         group_box = scroll_area.widget()
         self.assertIsInstance(group_box, QtGui.QWidget)
@@ -208,6 +208,6 @@ class TestPanelLayout(unittest.TestCase):
         example = ScrollableGroupExample()
 
         ui = example.edit_traits(view=non_scrollable_group_view)
-        mainwindow = ui.control.children()[1]
-        content = mainwindow.children()[1]
+        mainwindow = ui.control.layout().itemAt(0).widget()
+        content = mainwindow.centralWidget()
         self.assertIsInstance(content, QtGui.QWidget)

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -597,7 +597,7 @@ class _GroupPanel(object):
                 self._setup_editor(group, GroupEditor(control=outer))
 
             if group.scrollable:
-                # ensure we have a widget rather than a layout for the scroll area
+                # ensure a widget rather than a layout for the scroll area
                 if outer is None:
                     outer = inner = QtGui.QBoxLayout(self.direction)
                 if isinstance(outer, QtGui.QLayout):

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -596,6 +596,21 @@ class _GroupPanel(object):
                 # Create an editor.
                 self._setup_editor(group, GroupEditor(control=outer))
 
+            if group.scrollable:
+                # ensure we have a widget rather than a layout for the scroll area
+                if outer is None:
+                    outer = inner = QtGui.QBoxLayout(self.direction)
+                if isinstance(outer, QtGui.QLayout):
+                    widget = QtGui.QWidget()
+                    widget.setLayout(outer)
+                    outer = widget
+
+                # now create a scroll area for the widget
+                scroll_area = QtGui.QScrollArea()
+                scroll_area.setWidget(outer)
+                scroll_area.setWidgetResizable(True)
+                outer = scroll_area
+
             if isinstance(content[0], Group):
                 layout = self._add_groups(content, inner)
             else:


### PR DESCRIPTION
Fixes #1403 

This only attempts to add scrolling to vertical, horizontal and grid groups, as it doesn't make sense for tabbed, split or vfold groups.

Currently no tests: I could hack one together, but it would be good to know if this can be integrated into the new testing framework easily.