### PR TITLE
Install pyface source dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
-  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit; done; fi
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install-from-source --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit; done; fi
   # etsdemo
   - pushd ets-demo && for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done && popd
 script:

--- a/etstool.py
+++ b/etstool.py
@@ -269,6 +269,18 @@ def install(runtime, toolkit, environment, editable, source):
         cmd_fmt = "edm plumbing remove-package --environment {environment} --force "
         commands = [cmd_fmt+dependency for dependency in source_dependencies.keys()]
         execute(commands, parameters)
+        # Install dependencies of pyface.
+        # This is needed until a new release of pyface is available. At the
+        # moment, installing the pyface egg does not bring in the new
+        # dependencies that the pyface master branch needs.
+        # NOTE : fetch-install expects exact version-build number.
+        install_pkgs = [
+            "edm plumbing fetch-install --environment {environment} importlib_resources==3.3.0-1",
+            # NOTE : --force is needed here because `importlib_metadata` already exists in the environment.
+            "edm plumbing fetch-install --environment {environment} importlib_metadata==2.0.0-1 --force",
+        ]
+        execute(install_pkgs, parameters)
+        # Install packages from source.
         source_pkgs = source_dependencies.values()
         commands = [
             "python -m pip install {pkg} --no-deps".format(pkg=pkg)


### PR DESCRIPTION
This PR explicitly installs the newer pyface dependencies when pyface is installed from source. This should fix the cron jobs.
This is necessary until a new release of pyface is available because the two new dependencies won't be installed in the environment otherwise.