### PR TITLE
Change Dialog flag to Window to allow minimize/maximize buttons to be shown

### DIFF
--- a/traitsui/qt4/tests/test_ui_base.py
+++ b/traitsui/qt4/tests/test_ui_base.py
@@ -39,5 +39,6 @@ class TestStickyDialog(unittest.TestCase):
         with create_ui(obj, dict(view=parent_view)) as ui:
             with create_ui(obj2, dict(parent=ui.control, view=nested)) as ui2:
                 from pyface.qt import QtCore
-                self.assertTrue(
-                    ui2.control.windowFlags() & QtCore.Qt.WindowMaximized)
+                self.assertFalse(
+                    ui2.control.windowFlags() & QtCore.Qt.WindowMaximized
+                )

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -128,7 +128,15 @@ class _StickyDialog(QtGui.QDialog):
         self.setLayout(layout)
 
         # Set the dialog's window flags and properties.
-        flags = QtCore.Qt.Dialog
+        # On some X11 window managers, using the Dialog flag instead of
+        # just the Window flag could cause the subsequent minimize and maximize
+        # button hint to be ignored such that those actions are not
+        # available (but the window can still be resize unless the size
+        # constraint is fixed). On some X11 window managers, having two
+        # _StickyDialog open where one has a Window flag and other has a Dialog
+        # flag results in the latter (Dialog) to be always placed on top of
+        # the former (Window).
+        flags = QtCore.Qt.Window
         if not ui.view.resizable:
             flags |= QtCore.Qt.WindowSystemMenuHint
             layout.setSizeConstraint(QtGui.QLayout.SetFixedSize)


### PR DESCRIPTION
Fixes https://github.com/enthought/pyface/issues/802
This is an alternative fix to https://github.com/enthought/traitsui/issues/1078, i.e. it overrides https://github.com/enthought/traitsui/pull/1083 partially.

This PR:
- Change the Qt StickyDialog window flag from `Dialog` to `Window`. The StickyDialog is the main widget used when `configure_traits` or `edit_traits` are called with default settings.

With this, the only difference compared to TraitsUI 7.0.1 is that when `resizable` is false, the window flag is `Qt.Window | QtCore.Qt.WindowSystemMenuHint` instead of `Qt.Dialog | QtCore.Qt.WindowSystemMenuHint`. Before this change, the dialog may not have minimize/maximize buttons in some window managers.

In this part of the code base, there is in fact no information as to whether the window is intended to be top-level or a secondary window. I'd not be surprised if this then brings about other undesirable changes to the visuals on yet another desktop environment, or when one actually wants a secondary dialog-looking window and did so by setting `resizable` to false. In that case, we shall look into allowing additional information to be passed via `edit_traits` to select the appropriate setup based on more specific contextual information.

Details:
The issue in #1078 was observed where the first window has a Qt.Dialog flag (because it is not resizable) but the new window has a Qt.Window flag (because it is resizable). This was the original code:
https://github.com/enthought/traitsui/blob/c4ee6fd978b21acd152df2eeb27504a3609405ea/traitsui/qt4/ui_base.py#L131-L134
In retrospect, #1083 _fixed_ #1078 by making both windows to have the same flag (out of `Dialog` or `Window` flag). CentOS window manager may have decided that "Dialog" should always be on top of "Window" (this is a guess).

Whether the window is actually resizable is handled by the subsequent call to `setSizeConstraint(QtGui.QLayout.SetFixedSize)`, the `Window` and `Dialog` flags do not change that. However, a window manager may decorate the window frame differently based on these flags. In Ubuntu default desktop environment, it ignores the subsequent `WindowMinimizeButtonHint` and `WindowMaximizeButtonHint` flags if the `Dialog` flag is active. In CentOS, it similarly excludes the capability to maximize the window by double clicking the frame. Yet some X11 desktop environments (e.g. LXDE) respect these resize button hints and provide the buttons despite the Dialog flag.

On Windows, none of the above had any noticeable effect: Both `WindowMinimizeButtonHint` and `WindowMaximizeButtonHint` are respected such that the window can be maximized or minimized. 

On OSX, when the `Dialog` flag is used, the minimize button is disabled, but the maximize button can still be used. 

<details>
  <summary> Screenshots for #1078 on Windows with this branch </summary>

![main](https://user-images.githubusercontent.com/3673984/99968161-b16a3400-2d90-11eb-8321-cb4371dd5d84.png)
![subwindow](https://user-images.githubusercontent.com/3673984/99968175-b6c77e80-2d90-11eb-8032-8ecf10f9c94d.png)
(Windows has not been affected on #1078 to start with, and is not affected by #1083 nor changes in this PR)

</details>

<details>
  <summary> Screenshots for #1078 on MacOSX with this branch </summary>

![Screenshot 2020-11-20 at 09 50 56](https://user-images.githubusercontent.com/3673984/99968252-d3fc4d00-2d90-11eb-9cfa-8d8abc1b39ba.png)
![Screenshot 2020-11-20 at 09 51 06](https://user-images.githubusercontent.com/3673984/99968262-d8286a80-2d90-11eb-90a9-bd81a195be10.png)

</details>

<details>
  <summary> Screenshots for #1078 on MacOSX with master </summary>

![Screenshot 2020-11-20 at 09 46 35](https://user-images.githubusercontent.com/3673984/99968304-e4acc300-2d90-11eb-8395-ae06a02e0e01.png)

(Note that the minimize button is disabled.)
</details>


<details>
  <summary> Screenshots for #1078 on Ubuntu 18 with this branch </summary>

![Screenshot 2020-11-23 at 13 03 20](https://user-images.githubusercontent.com/3673984/99968451-0d34bd00-2d91-11eb-87dc-b4d0f01f260c.png)
![Screenshot 2020-11-23 at 13 03 28](https://user-images.githubusercontent.com/3673984/99968469-11f97100-2d91-11eb-9c8c-5bac799459f8.png)

</details>


<details>
  <summary> Screenshots for #1078 on Ubuntu 18 on master </summary>

![Screenshot 2020-11-23 at 14 14 24](https://user-images.githubusercontent.com/3673984/99972269-3b68cb80-2d96-11eb-9e2d-698651af6e06.png)

(Note the minimize and maximize buttons are not there.)

</details>


Understandably, no self-checking tests can be written for this.