### PR TITLE
Reduce CI matrix on Appveyor

### DIFF
--- a/.github/workflows/minimal-deps.yml
+++ b/.github/workflows/minimal-deps.yml
@@ -8,7 +8,10 @@ on: pull_request
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
         uses: actions/checkout@v2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,6 @@ environment:
       TOOLKIT: "pyqt"
     - RUNTIME: '3.6'
       TOOLKIT: "pyqt5"
-    - RUNTIME: '3.6'
-      TOOLKIT: "pyside2"
-    - RUNTIME: '3.6'
-      TOOLKIT: "wx"
-    - RUNTIME: '3.6'
-      TOOLKIT: "null"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Part of #1416

This PR removes part of the test matrix on Appveyor, which has been the bottleneck of per-PR CI build.

We do lose one test job from this change. The (allow-to-fail) job with wxPython and OSX is now gone.
The other removed jobs are now covered on GitHub Actions.

The setup on OSX with wxPython has not been successful as I ran into this issue: https://stackoverflow.com/questions/48531006/wxpython-this-program-needs-access-to-the-screen 
On the other hand, TraitsUI test suite for wxPython + OSX has been failing.
