### PR TITLE
Remove info about non-existent pyprotocols

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -26,8 +26,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The software contained in the traits/protocols/ directory is
-the pyprotocols project (http://peak.telecommunity.com/PyProtocols.html),
-it is originaly licensed under the terms of the Python Software
-Foundation License, which is compatible with the above terms.


### PR DESCRIPTION
This PR removes information about the non-existent `traits/protocols` directory from the main license file.