### PR TITLE
Backport fixes to 7.1

### DIFF
--- a/.github/actions/apt-get-qt-deps/README.md
+++ b/.github/actions/apt-get-qt-deps/README.md
@@ -1,0 +1,29 @@
+# Install Qt dependencies on Ubuntu
+
+This action calls `apt-get` to install packages required for running Qt on Ubuntu.
+
+## Inputs
+
+There are no inputs.
+
+## Outputs
+
+There are no outputs.
+
+## Example usage
+
+```yml
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolkit: ['pyqt5']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Qt dependencies for Linux
+        uses: ./.github/actions/apt-get-qt-deps
+        if: startsWith(matrix.os, 'ubuntu')
+```

--- a/.github/actions/apt-get-qt-deps/action.yml
+++ b/.github/actions/apt-get-qt-deps/action.yml
@@ -1,0 +1,19 @@
+# This action installs dependencies for Qt on Ubuntu
+# It does not install any Qt-Python wrapper.
+
+name: 'Install Ubuntu packages for Qt'
+description: 'This action should only be run on Ubuntu'
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        sudo apt-get update
+        sudo apt-get install qt5-default
+        sudo apt-get install libxkbcommon-x11-0
+        sudo apt-get install libxcb-icccm4
+        sudo apt-get install libxcb-image0
+        sudo apt-get install libxcb-keysyms1
+        sudo apt-get install libxcb-randr0
+        sudo apt-get install libxcb-render-util0
+        sudo apt-get install libxcb-xinerama0
+      shell: bash

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -1,0 +1,42 @@
+# This workflow installs dependencies from master
+
+name: ETS from source
+
+on:
+  schedule:
+    - cron:  '0 0 * * 4'
+
+jobs:
+  test:
+    env:
+      # Enforce selection of toolkit
+      ETS_TOOLKIT: qt
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolkit: ['pyside2']
+        python-version: [3.9]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Qt dependencies for Linux
+        uses: ./.github/actions/apt-get-qt-deps
+        if: startsWith(matrix.os, 'ubuntu')
+      - name: Install local packages
+        run: python -m pip install .[${{ matrix.toolkit }},editors,test]
+      - name: Install source dependencies
+        run: |
+          python -m pip install --force-reinstall git+http://github.com/enthought/pyface.git#egg=pyface
+          python -m pip install --force-reinstall git+http://github.com/enthought/traits.git#egg=traits
+      - name: Sanity check dependencies
+        run: python -m pip list
+      - name: Run test suite
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m unittest discover -v traitsui
+          working-directory: ${{ runner.temp }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,40 @@
+# This workflow runs integration tests (e.g. demo examples), which requires
+# more dependencies
+
+
+name: Integration tests
+
+on:
+  schedule:
+    - cron:  '0 0 * * 4'
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        toolkit: ['pyside2']
+        # Dependencies include chaco/enable, whose installation fails
+        # on Python 3.8 and 3.9
+        python-version: [3.6]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Qt dependencies for Linux
+        uses: ./.github/actions/apt-get-qt-deps
+        if: startsWith(matrix.os, 'ubuntu')
+      - name: Install Python packages and dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install .[${{ matrix.toolkit }},test,editors]
+          python -m pip install .[examples]
+      - name: Run integration tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m unittest discover -v ${{ github.workspace }}/integrationtests
+          working-directory: ${{ runner.temp }}

--- a/.github/workflows/minimal-deps.yml
+++ b/.github/workflows/minimal-deps.yml
@@ -8,7 +8,10 @@ on: pull_request
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out
         uses: actions/checkout@v2

--- a/.github/workflows/minimal-deps.yml
+++ b/.github/workflows/minimal-deps.yml
@@ -1,0 +1,25 @@
+# This workflow targets stable released dependencies from PyPI with
+# minimal dependencies.
+
+
+name: Minimal setup
+
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install Python packages
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install .[test]
+      - name: Run test suite
+        run: python -m unittest discover -v traitsui
+        working-directory: ${{ runner.temp }}

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -1,0 +1,28 @@
+# This workflow run flake8 on the code base
+
+name: Style check
+
+on: pull_request
+
+jobs:
+  style:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.6, 3.9]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies and local packages
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8
+    - name: Run style checks
+      run: |
+        python -m flake8

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -1,0 +1,74 @@
+# This workflow targets stable released dependencies from PyPI
+# The matrix is conservative to avoid using too much public resources.
+
+name: Test with PyPI
+
+on: pull_request
+
+jobs:
+  # Tests against Qt/Python packages from PyPI
+  pip-qt:
+    env:
+      # Enforce selection of toolkit
+      ETS_TOOLKIT: qt
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolkit: ['pyside2']
+        python-version: [3.6]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Qt dependencies for Linux
+        uses: ./.github/actions/apt-get-qt-deps
+        if: startsWith(matrix.os, 'ubuntu')
+      - name: Update pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install local packages
+        run: python -m pip install .[${{ matrix.toolkit }},editors,test]
+      - name: Run test suite
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m unittest discover -v traitsui
+          working-directory: ${{ runner.temp }}
+
+  # Tests against wxPython from PyPI
+  # On OSX:
+  #   - wxPython complains about 'This program needs access to the screen'.
+  # On Ubuntu:
+  #   - For wxPython 4.0, we need libsdl-image1.2
+  #   - For wxPython 4.1, we need libsdl2-2.0-0
+  #   - The Ubuntu build can be run but it fails and there are no equivalence
+  #     of allow-failure on GitHub Actions.
+  pip-wx:
+    env:
+      # Enforce selection of toolkit
+      ETS_TOOLKIT: wx
+    strategy:
+      # Test failure is currently expected to fail on Ubuntu
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        python-version: [3.6]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Update pip, setuptools and wheel
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Install local packages
+        run: python -m pip install .[wx,editors,test]
+      - name: Run test suite
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m unittest discover -v traitsui
+          working-directory: ${{ runner.temp }}

--- a/.github/workflows/traits-6-compat.yml
+++ b/.github/workflows/traits-6-compat.yml
@@ -1,0 +1,39 @@
+# This workflow is for running tests against Traits 6.0
+# The entire workflow can be removed when Traits 6.0 support is dropped.
+
+name: Test with Traits 6
+
+on:
+  schedule:
+    - cron:  '0 0 * * 4'
+
+jobs:
+  trait-6:
+    env:
+      # Enforce selection of toolkit
+      ETS_TOOLKIT: qt
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        toolkit: ['pyside2']
+        python-version: [3.6]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Qt dependencies for Linux
+        uses: ./.github/actions/apt-get-qt-deps
+        if: startsWith(matrix.os, 'ubuntu')
+      - name: Install Traits 6
+        run: python -m pip install "traits<6.1"
+      - name: Install local packages
+        run: python -m pip install .[${{ matrix.toolkit }},editors,test]
+      - name: Run test suite
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: python -m unittest discover -v traitsui
+          working-directory: ${{ runner.temp }}

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,20 @@
 Traits UI Changelog
 ===================
 
+Bugfix release 7.1.1
+--------------------
+
+This is a bugfix release that fixes a number of issues since the 7.1.0 release.
+Thanks to Corran Webster and Kit Choi for the patches.
+
+Fixes
+~~~~~
+- Fix ``scrollable`` trait of a Group not being implemented on Qt (#1406)
+- Fix icon button's clickable area too small for FileEditor and RangeEditor on
+  Qt and OSX (#1383)
+- Fix missing minimize and maximize buttons for dialogs opened on certain
+  Linux platforms (#1409)
+
 Release 7.1.0
 -------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,6 @@ environment:
       TOOLKIT: "pyqt"
     - RUNTIME: '3.6'
       TOOLKIT: "pyqt5"
-    - RUNTIME: '3.6'
-      TOOLKIT: "pyside2"
-    - RUNTIME: '3.6'
-      TOOLKIT: "wx"
-    - RUNTIME: '3.6'
-      TOOLKIT: "null"
 
 matrix:
   fast_finish: true

--- a/etstool.py
+++ b/etstool.py
@@ -300,13 +300,6 @@ def test(runtime, toolkit, environment):
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
 
-    if toolkit == "wx":
-        environ["EXCLUDE_TESTS"] = "qt"
-    elif toolkit in {"pyqt", "pyqt5", "pyside", "pyside2"}:
-        environ["EXCLUDE_TESTS"] = "wx"
-    else:
-        environ["EXCLUDE_TESTS"] = "(wx|qt)"
-
     parameters["integrationtests"] = os.path.abspath("integrationtests")
     commands = [
         "edm run -e {environment} -- python -W default -m coverage run -p -m unittest discover -v traitsui",

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 per-file-ignores = */api.py:F401
 exclude =
     # The following list should eventually be empty.
+    docs,
+    etstool.py,
     examples/tutorials/traitsui_4.0,
     integrationtests/styled_date_editor_test.py,
     integrationtests/ui,

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -74,19 +74,25 @@ def load_tests(loader, standard_tests, pattern):
         TestSuite representing all package tests that did not match specified
         exclusion pattern.
     """
-    from os import environ
     from os.path import dirname
-    from traitsui.tests._tools import filter_tests
     from unittest import TestSuite
+    from traits.etsconfig.api import ETSConfig
+    from traitsui.tests._tools import filter_tests
 
     # Make sure the right toolkit is up and running before importing tests
     from traitsui.toolkit import toolkit
     toolkit()
 
+    if ETSConfig.toolkit.startswith("qt"):
+        exclusion_pattern = "wx"
+    elif ETSConfig.toolkit == "wx":
+        exclusion_pattern = "qt"
+    else:
+        exclusion_pattern = "(wx|qt)"
+
     this_dir = dirname(__file__)
     package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
 
-    exclusion_pattern = environ.get("EXCLUDE_TESTS", None)
     if exclusion_pattern is None:
         return package_tests
 

--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -173,12 +173,29 @@ class IconButton(QtGui.QPushButton):
 
         # Configure the button.
         self.setIcon(ico)
-        self.setMaximumSize(ico_sz, ico_sz)
         self.setFlat(True)
         self.setFocusPolicy(QtCore.Qt.NoFocus)
 
         self.clicked.connect(slot)
 
+    def sizeHint(self):
+        """ Reimplement sizeHint to return a recommended button size based on
+        the size of the icon.
+
+        Returns
+        -------
+        size : QtCore.QSize
+        """
+        self.ensurePolished()
+
+        # We want the button to have a size similar to the icon.
+        # Using the size computed for a tool button gives a desirable size.
+        option = QtGui.QStyleOptionButton()
+        self.initStyleOption(option)
+        size = self.style().sizeFromContents(
+            QtGui.QStyle.CT_ToolButton, option, option.iconSize
+        )
+        return size
 
 # ------------------------------------------------------------------------
 # Text Rendering helpers

--- a/traitsui/qt4/tests/test_ui_base.py
+++ b/traitsui/qt4/tests/test_ui_base.py
@@ -39,5 +39,6 @@ class TestStickyDialog(unittest.TestCase):
         with create_ui(obj, dict(view=parent_view)) as ui:
             with create_ui(obj2, dict(parent=ui.control, view=nested)) as ui2:
                 from pyface.qt import QtCore
-                self.assertTrue(
-                    ui2.control.windowFlags() & QtCore.Qt.WindowMaximized)
+                self.assertFalse(
+                    ui2.control.windowFlags() & QtCore.Qt.WindowMaximized
+                )

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -48,6 +48,57 @@ class FooDialog(HasTraits):
         return FooPanel()
 
 
+class ScrollableGroupExample(HasTraits):
+
+    my_int = Int(2)
+
+    my_str = Str("The group is scrollable")
+
+
+scrollable_group_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=True,
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+non_scrollable_group_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=False,
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+scrollable_group_box_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=True,
+        label="Scrollable View",
+        show_border=True,
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+scrollable_labelled_group_view = View(
+    Group(
+        Item(name="my_int"),
+        Item(name="my_str"),
+        scrollable=True,
+        label="Scrollable View",
+    ),
+    title="FooPanel",
+    kind='subpanel',
+)
+
+
 @requires_toolkit([ToolkitName.qt])
 class TestUIPanel(unittest.TestCase):
     def setup_qt4_dock_window(self):
@@ -110,3 +161,66 @@ class TestUIPanel(unittest.TestCase):
 
             # No button
             self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
+
+
+@requires_toolkit([ToolkitName.qt])
+class TestPanelLayout(unittest.TestCase):
+
+    def test_scrollable_group_typical(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample()
+
+        ui = example.edit_traits(view=scrollable_group_view)
+        try:
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            scroll_area = mainwindow.centralWidget()
+            self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+            content = scroll_area.widget()
+            self.assertEqual(type(content), QtGui.QWidget)
+        finally:
+            ui.dispose()
+
+    def test_scrollable_group_box(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample()
+
+        ui = example.edit_traits(view=scrollable_group_box_view)
+        try:
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            scroll_area = mainwindow.centralWidget()
+            self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+            group_box = scroll_area.widget()
+            self.assertIsInstance(group_box, QtGui.QGroupBox)
+            self.assertEqual(group_box.title(), "Scrollable View")
+        finally:
+            ui.dispose()
+
+    def test_scrollable_labelled_group(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample()
+
+        ui = example.edit_traits(view=scrollable_labelled_group_view)
+        try:
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            scroll_area = mainwindow.centralWidget()
+            self.assertIsInstance(scroll_area, QtGui.QScrollArea)
+            content = scroll_area.widget()
+            self.assertEqual(type(content), QtGui.QWidget)
+        finally:
+            ui.dispose()
+
+    def test_non_scrollable_group_typical(self):
+        from pyface.qt import QtGui
+
+        example = ScrollableGroupExample(my_str="The group is not scrollable")
+
+        ui = example.edit_traits(view=non_scrollable_group_view)
+        try:
+            mainwindow = ui.control.layout().itemAt(0).widget()
+            content = mainwindow.centralWidget()
+            self.assertEqual(type(content), QtGui.QWidget)
+        finally:
+            ui.dispose()

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -128,7 +128,15 @@ class _StickyDialog(QtGui.QDialog):
         self.setLayout(layout)
 
         # Set the dialog's window flags and properties.
-        flags = QtCore.Qt.Dialog
+        # On some X11 window managers, using the Dialog flag instead of
+        # just the Window flag could cause the subsequent minimize and maximize
+        # button hint to be ignored such that those actions are not
+        # available (but the window can still be resize unless the size
+        # constraint is fixed). On some X11 window managers, having two
+        # _StickyDialog open where one has a Window flag and other has a Dialog
+        # flag results in the latter (Dialog) to be always placed on top of
+        # the former (Window).
+        flags = QtCore.Qt.Window
         if not ui.view.resizable:
             flags |= QtCore.Qt.WindowSystemMenuHint
             layout.setSizeConstraint(QtGui.QLayout.SetFixedSize)

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -596,6 +596,21 @@ class _GroupPanel(object):
                 # Create an editor.
                 self._setup_editor(group, GroupEditor(control=outer))
 
+            if group.scrollable:
+                # ensure a widget rather than a layout for the scroll area
+                if outer is None:
+                    outer = inner = QtGui.QBoxLayout(self.direction)
+                if isinstance(outer, QtGui.QLayout):
+                    widget = QtGui.QWidget()
+                    widget.setLayout(outer)
+                    outer = widget
+
+                # now create a scroll area for the widget
+                scroll_area = QtGui.QScrollArea()
+                scroll_area.setWidget(outer)
+                scroll_area.setWidgetResizable(True)
+                outer = scroll_area
+
             if isinstance(content[0], Group):
                 layout = self._add_groups(content, inner)
             else:

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -379,7 +379,7 @@ class TestUIWrapperHelp(unittest.TestCase):
         # then
         self.assertEqual(
             stream.getvalue(),
-            textwrap.dedent(f"""\
+            textwrap.dedent("""\
                 Interactions
                 ------------
                 No interactions are supported.


### PR DESCRIPTION
This PR backports bug fixes for 7.1 series in preparation for #1419

This also backports the changes to CI setup: it replaces some of Appveyor test matrix with GitHub actions, in an effort to speed up the release process. 

The changelog is updated, that is the only one change that is not previously reviewed.