### PR TITLE
Fix changelog section title for consistency

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,8 @@
 Traits UI Changelog
 ===================
 
-Bugfix release 7.1.1
---------------------
+Release 7.1.1
+-------------
 
 This is a bugfix release that fixes a number of issues since the 7.1.0 release.
 Thanks to Corran Webster and Kit Choi for the patches.


### PR DESCRIPTION
[Targeting maint/7.1]

When I build the documentation, I realize that the section title "Bugfix release" in the changelog is really an odd one out. This PR fixes the title to be more consistent.