### PR TITLE
Fix cron job not installing additional dependencies

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -115,7 +115,9 @@ dependencies = {
     "traits" + TRAITS_VERSION_REQUIRES,
 }
 
-# NOTE : pyface is always installed from source
+# Dependencies we install from source for cron tests
+# Order from packages with the most dependencies to one with the least
+# dependencies. Packages are forced re-installed in this order.
 source_dependencies = {
     "pyface": "git+http://github.com/enthought/pyface.git#egg=pyface",
     "traits": "git+http://github.com/enthought/traits.git#egg=traits",
@@ -228,10 +230,6 @@ def install(runtime, toolkit, environment, editable, source):
         | ci_dependencies
     )
 
-    install_traitsui = "edm run -e {environment} -- pip install "
-    if editable:
-        install_traitsui += "--editable "
-    install_traitsui += "."
 
     # edm commands to setup the development environment
     if sys.platform == 'linux':
@@ -243,7 +241,6 @@ def install(runtime, toolkit, environment, editable, source):
         "edm install -y -e {environment} " + " ".join(packages),
         "edm run -e {environment} -- pip install --force-reinstall -r ci-src-requirements.txt --no-dependencies",
         "edm run -e {environment} -- python setup.py clean --all",
-        install_traitsui,
     ])
 
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
@@ -270,12 +267,25 @@ def install(runtime, toolkit, environment, editable, source):
         commands = [cmd_fmt+dependency for dependency in source_dependencies.keys()]
         execute(commands, parameters)
         source_pkgs = source_dependencies.values()
+        # Without the --no-dependencies flag such that new dependencies on
+        # master are brought in.
         commands = [
-            "python -m pip install {pkg} --no-deps".format(pkg=pkg)
+            "python -m pip install --force-reinstall {pkg}".format(pkg=pkg)
             for pkg in source_pkgs
         ]
         commands = ["edm run -e {environment} -- " + command for command in commands]
         execute(commands, parameters)
+
+    # Always install local source again with no dependencies
+    # to mitigate risk of testing against a distributed release.
+    install_traitsui = (
+        "edm run -e {environment} -- "
+        "pip install --force-reinstall  --no-dependencies "
+    )
+    if editable:
+        install_traitsui += "--editable "
+    install_traitsui += "."
+    execute([install_traitsui], parameters)
 
     click.echo('Done install')
 


### PR DESCRIPTION
The cron job on Travis is currently failing with this:
```
======================================================================
ERROR: traitsui.testing.tests.test_gui (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: traitsui.testing.tests.test_gui
Traceback (most recent call last):
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/traitsui/testing/tests/test_gui.py", line 17, in <module>
    from pyface.api import GUI
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/api.py", line 24, in <module>
    from .gui_application import GUIApplication
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/gui_application.py", line 39, in <module>
    from .i_splash_screen import ISplashScreen
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/i_splash_screen.py", line 20, in <module>
    from pyface.image_resource import ImageResource
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/image_resource.py", line 19, in <module>
    ImageResource = toolkit_object("image_resource:ImageResource")
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/base_toolkit.py", line 152, in __call__
    module = import_module(mname, package)
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/ui/null/image_resource.py", line 19, in <module>
    from pyface.i_image_resource import IImageResource, MImageResource
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/i_image_resource.py", line 14, in <module>
    from pyface.resource_manager import resource_manager
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/resource_manager.py", line 14, in <module>
    from pyface.resource.api import ResourceManager
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/resource/api.py", line 13, in <module>
    from .resource_manager import ResourceManager
  File "/home/travis/.edm/envs/traitsui-test-3.6-null/lib/python3.6/site-packages/pyface/resource/resource_manager.py", line 20, in <module>
    from importlib_resources import files
ModuleNotFoundError: No module named 'importlib_resources'
```
This is because pyface master now requires importlib_metadata, but our CI command for the cron job is installing sources with `--no-deps` flag. This PR fixes the 

Context: We do already have a new cron job set up on GitHub Actions. The setup there is decoupled from the install command for development use and should not be affected by the above issue. However its first scheduled trigger has not yet happened.

Travis CI configuration is still live, and the cron job is still being run, monitored and displayed.
It is likely we will be removing the cron job from Travis eventually, but for now, this PR will fix the cron job on Travis.