### PR TITLE
Remove job on Travis for testing against Traits 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
     - env: RUNTIME=3.6 TOOLKITS="null"
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt5" TRAITS_REQUIRES="^=6.0"
   allow_failures:
     - env: RUNTIME=3.6 TOOLKITS="wx"
   fast_finish: true

--- a/etstool.py
+++ b/etstool.py
@@ -105,14 +105,10 @@ DEFAULT_RUNTIME = '3.6'
 # Default toolkit to use if none specified.
 DEFAULT_TOOLKIT = 'null'
 
-# Traits version requirement (empty string to mean no specific requirement).
-# The requirement is to be interpreted by EDM
-TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
-
 # Required runtime dependencies. Should match install_requires in setup.py
 dependencies = {
     "pyface",
-    "traits" + TRAITS_VERSION_REQUIRES,
+    "traits",
 }
 
 # NOTE : pyface is always installed from source


### PR DESCRIPTION
This is motivated by the difficulties in fixing the cron job on Travis CI (see attempts in #1427 and #1395). By removing the dependency requirement given to EDM for pulling Traits 6.0, we would be able to fix the cron job on Travis more easily.

A job has been added on GitHub Actions for testing against Traits 6.0 (see #1415), so we are still testing against Traits 6.0.  However note that to conserve resources, the job on GitHub Actions is currently scheduled to be run per week, rather than per-PR.  We can change that event trigger setting too.