### PR TITLE
Use correct source_path in example

### DIFF
--- a/traitsui/examples/demo/Applications/Python_source_browser.py
+++ b/traitsui/examples/demo/Applications/Python_source_browser.py
@@ -46,9 +46,8 @@ from io import open
 
 #-- Constants ------------------------------------------------------------
 
-# Necessary because of the dynamic way in which the demos are loaded:
-search_path = [join(dirname(traitsui.api.__file__),
-                    '..', 'examples', 'demo', 'Applications')]
+# The images folder is in the same folder as this file:
+search_path = [dirname(__file__)]
 
 
 #-- FileInfo Class Definition --------------------------------------------

--- a/traitsui/examples/demo/Extras/Image_editor_demo.py
+++ b/traitsui/examples/demo/Extras/Image_editor_demo.py
@@ -6,16 +6,12 @@ A simple demonstration of how to use the ImageEditor to add a graphic element
 to a Traits UI View.
 """
 
-import traits
-
 # Imports:
 from os.path \
     import join, dirname
 
 from traits.api \
     import HasTraits, Str
-
-import traitsui.api
 
 from traitsui.api \
     import View, VGroup, Item, ImageEditor

--- a/traitsui/examples/demo/Extras/Image_editor_demo.py
+++ b/traitsui/examples/demo/Extras/Image_editor_demo.py
@@ -25,8 +25,8 @@ from pyface.image_resource \
 
 # Constants:
 
-# Necessary because of the dynamic way in which the demos are loaded:
-search_path = [join(dirname(__file__))]
+# The images folder is in the same folder as this file:
+search_path = [dirname(__file__)]
 
 # Define the demo class:
 

--- a/traitsui/examples/demo/Extras/Image_editor_demo.py
+++ b/traitsui/examples/demo/Extras/Image_editor_demo.py
@@ -15,11 +15,10 @@ from os.path \
 from traits.api \
     import HasTraits, Str
 
-from traitsui.api \
-    import View, VGroup, Item
+import traitsui.api
 
 from traitsui.api \
-    import ImageEditor
+    import View, VGroup, Item, ImageEditor
 
 from pyface.image_resource \
     import ImageResource
@@ -27,8 +26,8 @@ from pyface.image_resource \
 # Constants:
 
 # Necessary because of the dynamic way in which the demos are loaded:
-search_path = [join(dirname(traits.api.__file__),
-                    '..', '..', 'examples', 'demo', 'Extras')]
+search_path = [join(dirname(traitsui.api.__file__),
+                    '..', 'examples', 'demo', 'Extras')]
 
 # Define the demo class:
 

--- a/traitsui/examples/demo/Extras/Image_editor_demo.py
+++ b/traitsui/examples/demo/Extras/Image_editor_demo.py
@@ -26,8 +26,7 @@ from pyface.image_resource \
 # Constants:
 
 # Necessary because of the dynamic way in which the demos are loaded:
-search_path = [join(dirname(traitsui.api.__file__),
-                    '..', 'examples', 'demo', 'Extras')]
+search_path = [join(dirname(__file__))]
 
 # Define the demo class:
 

--- a/traitsui/examples/demo/Extras/tests/test_Image_editor_demo.py
+++ b/traitsui/examples/demo/Extras/tests/test_Image_editor_demo.py
@@ -1,0 +1,22 @@
+import os
+import runpy
+import unittest
+
+#: Filename of the demo script
+FILENAME = "Image_editor_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestImageEditorDemo(unittest.TestCase):
+
+    def test_image_path_exists(self):
+        search_path, = runpy.run_path(DEMO_PATH)["search_path"]
+        self.assertTrue(os.path.exists(search_path))
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestImageEditorDemo)
+)

--- a/traitsui/examples/demo/Extras/tests/test_Image_editor_demo.py
+++ b/traitsui/examples/demo/Extras/tests/test_Image_editor_demo.py
@@ -1,3 +1,16 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+""" This file provides tests for the demo of the same name located in the
+directory one level up.  
+"""
 import os
 import runpy
 import unittest


### PR DESCRIPTION
fixes #1432 

This PR changes the search path the be the correct path to the directory that contains the image folder containing the images of interest.