### PR TITLE
Drop Python 3.5 support in TraitsUI

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -51,7 +51,7 @@ using::
 
     python etstool.py test_all
 
-Currently supported runtime values are ``3.5`` and ``3.6``, and currently
+Currently supported runtime values are ``3.6``, and currently
 supported toolkits are ``null``, ``pyqt``, ``pyqt5``, ``pyside`` and ``wx``.
 Not all combinations of toolkits and runtimes will work, but the tasks will
 fail with a clear error if that is the case.
@@ -95,7 +95,6 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.5': {'pyside2', 'pyqt', 'pyqt5', 'null'},
     '3.6': {'pyside2', 'pyqt', 'pyqt5', 'wx', 'null'},
 }
 

--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,7 @@ if __name__ == "__main__":
             Operating System :: POSIX
             Operating System :: Unix
             Programming Language :: Python
-            Programming Language :: Python :: 3.5
+            Programming Language :: Python :: 3
             Programming Language :: Python :: 3.6
             Programming Language :: Python :: 3.7
             Programming Language :: Python :: 3.8
@@ -354,5 +354,6 @@ if __name__ == "__main__":
             ]
         },
         platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
+        python_requires=">=3.6",
         zip_safe=False,
     )


### PR DESCRIPTION
Closes #1435

This PR removes Python 3.5 from etstool.py (it is not used by CI), and most importantly, updated setup.py so that package installer will no longer pick up the next release in a Python <=3.5 environment.