### PR TITLE
Use viewcode sphinx extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,8 +28,13 @@ base_path = os.path.dirname(__file__)
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.extlinks', 'sphinx.ext.autodoc', 'sphinx.ext.napoleon',
-    'sphinx.ext.intersphinx', 'traits.util.trait_documenter'
+    'sphinx.ext.autodoc',
+    'sphinx.ext.extlinks',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon',
+    # Link to code in sphinx generated API docs
+    "sphinx.ext.viewcode",
+    'traits.util.trait_documenter',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Using this extension means that API docs now link to source code. See example below which now includes the `source` button.

![sphinx-viewcode](https://user-images.githubusercontent.com/1926457/102229315-8c766600-3ee3-11eb-8a39-359c549d4ec7.png)
