### PR TITLE
Open links externally instead of in the html editor in etsdemo application

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -873,8 +873,6 @@ demo_file_view = View(
             editor=HTMLEditor(
                 format_text=True,
                 base_url_name='base_url',
-                # Open links externally, in the default browser, instead of
-                # in the editor.
                 open_externally=True,
             ),
         ),

--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -873,6 +873,9 @@ demo_file_view = View(
             editor=HTMLEditor(
                 format_text=True,
                 base_url_name='base_url',
+                # Open links externally, in the default browser, instead of
+                # in the editor.
+                open_externally=True,
             ),
         ),
         VSplit(


### PR DESCRIPTION
This PR updates the etsdemo application such that clicking on links in the description will be opened in the default browser instead of in the html editor itself. This behavior was observed in #1445 and was recommended as the right user experience - https://github.com/enthought/traitsui/pull/1445#issuecomment-746182226