### PR TITLE
Revert "Open links externally instead of in the html editor in etsdemo application"

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -873,7 +873,6 @@ demo_file_view = View(
             editor=HTMLEditor(
                 format_text=True,
                 base_url_name='base_url',
-                open_externally=True,
             ),
         ),
         VSplit(


### PR DESCRIPTION
Reverts enthought/traitsui#1446

Unfortunately this does not work well with PySide2 (with QtWebEngine) due to #1448.