### PR TITLE
[WIP] Test viewing a demo file

### DIFF
--- a/ets-demo/etsdemo/tests/test_app.py
+++ b/ets-demo/etsdemo/tests/test_app.py
@@ -122,9 +122,8 @@ class TestDemoFile(unittest.TestCase):
         # should handle it gracefully (with error message shown)
         demo_path = DemoPath()
         demo_file = DemoFile(parent=demo_path)
-        view = demo_file_view
         tester = UITester()
-        with tester.create_ui(demo_file, dict(view=view)):
+        with tester.create_ui(demo_file, dict(view=demo_file_view)):
             pass
 
 

--- a/ets-demo/etsdemo/tests/test_app.py
+++ b/ets-demo/etsdemo/tests/test_app.py
@@ -15,9 +15,12 @@ import unittest
 from xml.etree import ElementTree as ET
 
 from traitsui.api import Handler, UI, UIInfo
+from traitsui.testing.api import UITester
 
 from etsdemo.app import (
     Demo,
+    DemoFile,
+    demo_file_view,
     DemoImageFile,
     DemoPath,
     DemoVirtualDirectory,
@@ -27,6 +30,7 @@ from etsdemo.app import (
     previous_tool,
     parent_tool,
 )
+from etsdemo.tests.testing import require_gui
 
 HTML_NS_PREFIX = "{http://www.w3.org/1999/xhtml}"
 
@@ -105,6 +109,23 @@ class TestDemo(unittest.TestCase):
 
         # then
         self.assertIsNone(demo.selected_node)
+
+
+class TestDemoFile(unittest.TestCase):
+    """ Test DemoFile logic."""
+
+    @require_gui
+    def test_demo_file_view(self):
+        # Minimal test with a file to exercise a node with HTML view and
+        # code editor in order to ensure requirements are satisfied.
+        # The file cannot be read (as it actually does not exist), but DemoFile
+        # should handle it gracefully (with error message shown)
+        demo_path = DemoPath()
+        demo_file = DemoFile(parent=demo_path)
+        view = demo_file_view
+        tester = UITester()
+        with tester.create_ui(demo_file, dict(view=view)):
+            pass
 
 
 class TestDemoImageFile(unittest.TestCase):

--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -115,9 +115,17 @@ dependencies = {
 
 extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
-    'pyside2': set(),
-    'pyqt': {'pyqt<4.12'},  # FIXME: build 1 of 4.12.1 appears to be bad
-    'pyqt5': {'pyqt5'},
+    'pyside2': {
+        "pygments",
+    },
+    'pyqt': {
+        'pyqt<4.12',  # FIXME: build 1 of 4.12.1 appears to be bad
+        'pygments',
+    },
+    'pyqt5': {
+        'pyqt5',
+        'pygments',
+    },
     # XXX once wxPython 4 is available in EDM, we will want it here
     'wx': set(),
     'null': set(),


### PR DESCRIPTION
This PR adds a GUI test to exercise the view for a file in the ets-demo.

I expect CI to fail for two reasons:
(1) CI setup using EDM has not installed `pygments` (#1447)
(2) The CI job against PySide2 should fail due to (#1448).

Upon reverting #1449 and fixing (1), CI should pass.