### PR TITLE
Support HTMLEditor.open_externally on QtWebEngine

### DIFF
--- a/traitsui/qt4/html_editor.py
+++ b/traitsui/qt4/html_editor.py
@@ -26,6 +26,29 @@ from traits.api import Str
 
 from .editor import Editor
 
+
+# Subclass of QWebPage for QtWebEngine support
+
+class ExternallyOpeningWebPage(QtWebKit.QWebPage):
+    """ QWebEnginePage subclass that opens links in system browser
+
+    This subclass is only used when we are given a QWebEnginePage which is
+    pretending to be a QWebPage and we want the open_external feature
+    of the Editor.
+
+    This overrides the acceptNavigationRequest method to open links
+    in an external browser.  All other navigation requests are handled
+    internally as per the base class.
+    """
+
+    def acceptNavigationRequest(self, url, type, isMainFrame):
+        if type == QtWebKit.QWebPage.NavigationType:
+            webbrowser.open_new(url.toString())
+            return False
+        else:
+            return super().acceptNavigationRequest(url, type, isMainFrame)
+
+
 # -------------------------------------------------------------------------
 #  'SimpleEditor' class:
 # -------------------------------------------------------------------------
@@ -56,8 +79,17 @@ class SimpleEditor(Editor):
 
         if self.factory.open_externally:
             page = self.control.page()
-            page.setLinkDelegationPolicy(QtWebKit.QWebPage.DelegateAllLinks)
-            page.linkClicked.connect(self._link_clicked)
+            if hasattr(page, 'setLinkDelegationPolicy'):
+                # QtWebKit
+                page.setLinkDelegationPolicy(QtWebKit.QWebPage.DelegateAllLinks)
+                page.linkClicked.connect(self._link_clicked)
+            else:
+                # QtWebEngine pretending to be QtWebKit
+                # We need the subclass defined above instead of the regular
+                # we page so that links are opened externally
+                page = ExternallyOpeningWebPage()
+                self.control.setPage(page)
+
 
         self.base_url = self.factory.base_url
         self.sync_value(self.factory.base_url_name, "base_url", "from")
@@ -66,8 +98,12 @@ class SimpleEditor(Editor):
         """ Disposes of the contents of an editor.
         """
         if self.control is not None and self.factory.open_externally:
-            page = self.control.page()
-            page.linkClicked.disconnect(self._link_clicked)
+            if hasattr(page, 'setLinkDelegationPolicy'):
+                # QtWebKit
+                page = self.control.page()
+                page.linkClicked.disconnect(self._link_clicked)
+            else:
+                # QtWebEngine pretending to be QtWebKit
         super().dispose()
 
     def update_editor(self):

--- a/traitsui/qt4/html_editor.py
+++ b/traitsui/qt4/html_editor.py
@@ -42,7 +42,7 @@ class ExternallyOpeningWebPage(QtWebKit.QWebPage):
     """
 
     def acceptNavigationRequest(self, url, type, isMainFrame):
-        if type == QtWebKit.QWebPage.NavigationType:
+        if type == QtWebKit.QWebPage.NavigationTypeLinkClicked:
             webbrowser.open_new(url.toString())
             return False
         else:
@@ -89,7 +89,7 @@ class SimpleEditor(Editor):
                 # QtWebEngine pretending to be QtWebKit
                 # We need the subclass defined above instead of the regular
                 # we page so that links are opened externally
-                page = ExternallyOpeningWebPage()
+                page = ExternallyOpeningWebPage(self.control)
                 self.control.setPage(page)
 
         self.base_url = self.factory.base_url

--- a/traitsui/qt4/html_editor.py
+++ b/traitsui/qt4/html_editor.py
@@ -81,7 +81,9 @@ class SimpleEditor(Editor):
             page = self.control.page()
             if hasattr(page, 'setLinkDelegationPolicy'):
                 # QtWebKit
-                page.setLinkDelegationPolicy(QtWebKit.QWebPage.DelegateAllLinks)
+                page.setLinkDelegationPolicy(
+                    QtWebKit.QWebPage.DelegateAllLinks
+                )
                 page.linkClicked.connect(self._link_clicked)
             else:
                 # QtWebEngine pretending to be QtWebKit
@@ -90,7 +92,6 @@ class SimpleEditor(Editor):
                 page = ExternallyOpeningWebPage()
                 self.control.setPage(page)
 
-
         self.base_url = self.factory.base_url
         self.sync_value(self.factory.base_url_name, "base_url", "from")
 
@@ -98,9 +99,9 @@ class SimpleEditor(Editor):
         """ Disposes of the contents of an editor.
         """
         if self.control is not None and self.factory.open_externally:
+            page = self.control.page()
             if hasattr(page, 'setLinkDelegationPolicy'):
-                # QtWebKit
-                page = self.control.page()
+                # QtWebKit-only cleanup
                 page.linkClicked.disconnect(self._link_clicked)
         super().dispose()
 

--- a/traitsui/qt4/html_editor.py
+++ b/traitsui/qt4/html_editor.py
@@ -102,8 +102,6 @@ class SimpleEditor(Editor):
                 # QtWebKit
                 page = self.control.page()
                 page.linkClicked.disconnect(self._link_clicked)
-            else:
-                # QtWebEngine pretending to be QtWebKit
         super().dispose()
 
     def update_editor(self):

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -81,7 +81,11 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
         model = HTMLModel(
             content="<a href='enthought.com'>Link to click</a>"
         )
-        view = get_view(base_url_name="", open_externally=True)
+        view = get_view(
+            base_url_name="",
+            open_externally=True,
+            format_text=False,
+        )
 
         with reraise_exceptions():
             with create_ui(model, dict(view=view)) as ui:

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -91,7 +91,7 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
             with create_ui(model, dict(view=view)) as ui:
                 control = ui.info.content.control
                 page = control.page()
-                url = QtCore.QUrl('enthought.com')
+                url = QtCore.QUrl('http://example.com')
                 if hasattr(page, 'linkClicked'):
                     page.linkClicked.emit(url)
                 else:
@@ -102,4 +102,4 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
                     )
                     self.assertFalse(result)
 
-        open_new_mock.assert_called_once_with("enthought.com")
+        open_new_mock.assert_called_once_with("http://example.com")

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -9,6 +9,7 @@
 #  Thanks for using Enthought open source!
 
 import unittest
+from unittest import mock
 
 from traits.api import HasTraits, Str
 from traitsui.api import HTMLEditor, Item, View
@@ -29,13 +30,14 @@ class HTMLModel(HasTraits):
     model_base_url = Str()
 
 
-def get_view(base_url_name):
+def get_view(base_url_name, format_text=True, open_externally=False):
     return View(
         Item(
             "content",
             editor=HTMLEditor(
-                format_text=True,
+                format_text=format_text,
                 base_url_name=base_url_name,
+                open_externally=open_externally
             )
         )
     )
@@ -70,3 +72,30 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
                 pass
             # It is okay to modify base_url after the UI is closed
             model.model_base_url = "/new_dir"
+
+    @requires_toolkit([ToolkitName.qt])
+    @mock.patch('webbrowser.open_new')
+    def test_open_externally_qt(self, open_new_mock):
+        from pyface.qt import QtCore, QtWebKit
+
+        model = HTMLModel(
+            content="<a href='enthought.com'>Link to click</a>"
+        )
+        view = get_view(base_url_name="", open_externally=True)
+
+        with reraise_exceptions():
+            with create_ui(model, dict(view=view)) as ui:
+                control = ui.info.content.control
+                page = control.page()
+                url = QtCore.QUrl('enthought.com')
+                if hasattr(page, 'linkClicked'):
+                    page.linkClicked.emit(url)
+                else:
+                    result = page.acceptNavigationRequest(
+                        url,
+                        QtWebKit.QWebPage.NavigationTypeLinkClicked,
+                        True,
+                    )
+                    self.assertFalse(result)
+
+        open_new_mock.assert_called_once_with("enthought.com")


### PR DESCRIPTION
This is a fix for the issue with open_externally with the `QtWebEngine` version of `QWebView`.

Basic unit test which validates that open_externally behaves as expected assuming that Qt does what it says it should.

Currently raises two warnings in tests:
```
Qt WebEngine seems to be initialized from a plugin. Please set Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute before constructing QGuiApplication.
WebEngineContext used before QtWebEngine::initialize() or OpenGL context creation failed.
```
~However this seems like something that is a problem at the Pyface level.  If this PR is approved I will open an issue for these warnings in TraitsUI and we can track down what this means later.~ It looks like enthought/pyface#853 fixes this.

See #1449 and #1450 

Fixes #1448 and fixes #1452.