### PR TITLE
Add help aliases to etsdemo etstool module

### DIFF
--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -143,9 +143,9 @@ environment_vars = {
     'null': {'ETS_TOOLKIT': 'null'},
 }
 
-CONTEXT_SETTINGS = dict(
-    help_option_names=["-h", "--help"],
-)
+CONTEXT_SETTINGS = {
+    "help_option_names": ["-h", "--help"],
+}
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)

--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -143,8 +143,12 @@ environment_vars = {
     'null': {'ETS_TOOLKIT': 'null'},
 }
 
+CONTEXT_SETTINGS = dict(
+    help_option_names=["-h", "--help"],
+)
 
-@click.group()
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     pass
 


### PR DESCRIPTION
This PR makes `-h` an alias to `--help` in the etstool module in ets-demo distribution.