### PR TITLE
Refactor and extend tests for Qt HTMLEditor handling of opening links

### DIFF
--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -124,7 +124,7 @@ def wait_for_qt_signal(qt_signal, timeout):
         raise RuntimeError("Timeout waiting for signal.")
 
 
-def qt_allow_page_to_load(page, step_timeout=0.1):
+def qt_allow_page_to_load(page, step_timeout=0.5):
     """ Allow QWebPage/QWebEnginePage to finish loading.
 
     Out of context, this function does not know if the page has started

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -16,10 +16,12 @@ from traitsui.api import HTMLEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
     create_ui,
+    is_qt,
     requires_toolkit,
     reraise_exceptions,
     ToolkitName,
 )
+from traitsui.testing.api import MouseClick, TargetRegistry, UITester
 
 
 class HTMLModel(HasTraits):
@@ -30,17 +32,234 @@ class HTMLModel(HasTraits):
     model_base_url = Str()
 
 
-def get_view(base_url_name, format_text=True, open_externally=False):
+def get_view(base_url_name):
     return View(
         Item(
             "content",
             editor=HTMLEditor(
-                format_text=format_text,
+                format_text=True,
                 base_url_name=base_url_name,
-                open_externally=open_externally
             )
         )
     )
+
+
+class CurrentURL:
+    """ Represent a query to obtain the current URL displayed by the
+    web page.
+    Implementation should return a str.
+    """
+    pass
+
+
+class HTMLContent:
+    """ Action to retrieve the HTML content currently displayed.
+    Implementation should return a str, whose content conforms to HTML markup.
+    """
+    pass
+
+
+def _is_web_engine_page(page):
+    """ Return true if the given page is a QWebEnginePage.
+
+    Intended for handling the compatibility between QtWebKit and QtWebEngine.
+
+    Parameters
+    ----------
+    page : QWebEnginePage or QWebPage
+    """
+    return not hasattr(page, "setLinkDelegationPolicy")
+
+
+def qt_get_page_url(page):
+    """ Return the URL (in string format) currently being viewed.
+
+    Parameters
+    ----------
+    page : QWebEnginePage or QWebPage
+
+    Returns
+    -------
+    html : str
+    """
+    qt_allow_page_to_load(page)
+    if _is_web_engine_page(page):
+        return page.url().toString()
+    return page.mainFrame().url().toString()
+
+
+def qt_get_page_html_content(page):
+    """ Return the HTML content currently being viewed.
+
+    Parameters
+    ----------
+    page : QWebEnginePage or QWebPage
+
+    Returns
+    -------
+    html : str
+    """
+    if _is_web_engine_page(page):
+        content = []
+        page.toHtml(content.append)
+        qt_allow_page_to_load(page)
+        return "".join(content)
+    return page.mainFrame().toHtml()
+
+
+def wait_for_qt_signal(qt_signal, timeout):
+    """ Wait for the given Qt signal to fire, or timeout.
+
+    A mock implementation of QSignalSpy.wait, which is one of the missing
+    bindings in PySide2, and is not available in Qt4.
+
+    Parameters
+    ----------
+    qt_signal : signal
+        Qt signal to wait for
+    timeout : int
+        Timeout in milliseconds, to match Qt API.
+
+    Raises
+    ------
+    RuntimeError
+    """
+    from pyface.qt import QtCore, QtGui
+
+    qt_app = QtGui.QApplication.instance()
+
+    def exit(*args, **kwargs):
+        qt_app.quit()
+
+    timeout_timer = QtCore.QTimer()
+    timeout_timer.setSingleShot(True)
+    timeout_timer.setInterval(timeout)
+    timeout_timer.timeout.connect(exit)
+    qt_signal.connect(exit)
+
+    timeout_timer.start()
+    qt_app.exec_()
+
+    qt_signal.disconnect(exit)
+    if timeout_timer.isActive():
+        timeout_timer.stop()
+    else:
+        raise RuntimeError("Timeout waiting for signal.")
+
+
+def qt_allow_page_to_load(page, step_timeout=0.1):
+    """ Allow QWebPage/QWebEnginePage to finish loading.
+
+    Out of context, this function does not know if the page has started
+    loading. Therefore it tries to see if the page is busy by watching its
+    loadStarted or loadProgress signal. If the loadStarted signal has been
+    emitted before this function is called, and/or the loadProgress is taking
+    too long to be emitted, then it is possible that the page is not in a
+    loaded state when this function returns.
+
+    However for most testing purposes, this function should be good enough to
+    avoid interacting with the Qt web page before it has finished loading, at
+    a cost of a slower test.
+
+    Parameters
+    ----------
+    page : QWebPage or QWebEnginePage
+        The page to allow loading to finish.
+    step_timeout : float
+        Timeout in seconds for each signal being observed.
+    """
+
+    step_timeout_ms = round(step_timeout * 1000)
+    try:
+        wait_for_qt_signal(page.loadStarted, timeout=step_timeout_ms)
+    except RuntimeError:
+        # It might have been started before this function is called.
+        # Check for progress too.
+        try:
+            wait_for_qt_signal(page.loadProgress, timeout=step_timeout_ms)
+        except RuntimeError:
+            # Probably haven't started.
+            return
+
+    wait_for_qt_signal(page.loadFinished, timeout=step_timeout_ms)
+
+
+def qt_mouse_click_web_view(view, delay):
+    """ Perform a mouse click at the center of the web view.
+
+    Note that the page is allowed time to load before and after the mouse
+    click.
+
+    Parameters
+    ----------
+    view : QWebView or QWebEngineView
+    """
+    from pyface.qt import QtCore
+    from pyface.qt.QtTest import QTest
+
+    qt_allow_page_to_load(view.page())
+
+    if view.focusProxy() is not None:
+        # QWebEngineView
+        widget = view.focusProxy()
+    else:
+        # QWebView
+        widget = view
+
+    try:
+        QTest.mouseClick(
+            widget,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.NoModifier,
+            delay=delay,
+        )
+    finally:
+        qt_allow_page_to_load(view.page())
+
+
+def qt_target_registry():
+    """ Return an instance of TargetRegistry for testing Qt + HTMLEditor
+
+    Returns
+    -------
+    target_registry : TargetRegistry
+    """
+    from traitsui.qt4.html_editor import SimpleEditor
+
+    registry = TargetRegistry()
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=MouseClick,
+        handler=lambda wrapper, _: qt_mouse_click_web_view(
+            wrapper._target.control, wrapper.delay
+        )
+    )
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=CurrentURL,
+        handler=lambda wrapper, _: (
+            qt_get_page_url(wrapper._target.control.page())
+        )
+    )
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=HTMLContent,
+        handler=lambda wrapper, _: (
+            qt_get_page_html_content(wrapper._target.control.page())
+        )
+    )
+    return registry
+
+
+def get_custom_ui_tester():
+    """ Return an instance of UITester that contains extended testing
+    functionality for HTMLEditor. These implementations are used by
+    TraitsUI only, are more ad hoc than they would have been if they were made
+    public.
+    """
+    if is_qt():
+        return UITester(registries=[qt_target_registry()])
+    return UITester()
 
 
 # Run this against wx as well once enthought/traitsui#752 is fixed.
@@ -50,6 +269,7 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
 
     def setUp(self):
         BaseTestMixin.setUp(self)
+        self.tester = get_custom_ui_tester()
 
     def tearDown(self):
         BaseTestMixin.tearDown(self)
@@ -74,32 +294,138 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
             model.model_base_url = "/new_dir"
 
     @requires_toolkit([ToolkitName.qt])
-    @mock.patch('webbrowser.open_new')
-    def test_open_externally_qt(self, open_new_mock):
-        from pyface.qt import QtCore, QtWebKit
-
-        model = HTMLModel(
-            content="<a href='enthought.com'>Link to click</a>"
+    def test_open_internal_link(self):
+        # this test requires Qt because it relies on the link filling up
+        # the entire page through the use of CSS, which isn't supported
+        # by Wx.
+        model = HTMLModel(content="""
+        <html>
+            <a
+              href='/#'
+              target='_self'
+              style='display:block; width: 100%; height: 100%'>
+                Internal Link
+            </a>
+        </html>
+        """)
+        view = View(
+            Item("content", editor=HTMLEditor())
         )
-        view = get_view(
-            base_url_name="",
-            open_externally=True,
-            format_text=False,
+
+        with self.tester.create_ui(model, dict(view=view)) as ui:
+            html_view = self.tester.find_by_name(ui, "content")
+            self.assertFalse(
+                html_view.inspect(CurrentURL()).startswith("about:blank")
+            )
+
+            # when
+            with mock.patch("webbrowser.open_new") as mocked_browser:
+                html_view.perform(MouseClick())
+
+            # then
+            self.assertTrue(
+                html_view.inspect(CurrentURL()).startswith("about:blank")
+            )
+        mocked_browser.assert_not_called()
+
+    @requires_toolkit([ToolkitName.qt])
+    def test_open_external_link(self):
+        # this test requires Qt because it relies on the link filling up
+        # the entire page through the use of CSS, which isn't supported
+        # by Wx.
+        model = HTMLModel(content="""
+        <html>
+            <a
+              href='test://testing'
+              target='_blank'
+              style='display:block; width: 100%; height: 100%'>
+                External Link
+            </a>
+        </html>
+        """)
+        view = View(
+            Item("content", editor=HTMLEditor())
         )
 
-        with reraise_exceptions():
-            with create_ui(model, dict(view=view)) as ui:
-                control = ui.info.content.control
-                page = control.page()
-                url = QtCore.QUrl('http://example.com')
-                if hasattr(page, 'linkClicked'):
-                    page.linkClicked.emit(url)
-                else:
-                    result = page.acceptNavigationRequest(
-                        url,
-                        QtWebKit.QWebPage.NavigationTypeLinkClicked,
-                        True,
-                    )
-                    self.assertFalse(result)
+        with self.tester.create_ui(model, dict(view=view)) as ui:
+            html_view = self.tester.find_by_name(ui, "content")
+            with mock.patch("webbrowser.open_new") as mocked_browser:
+                html_view.perform(MouseClick())
+            self.assertIn(
+                "External Link",
+                html_view.inspect(HTMLContent()),
+            )
 
-        open_new_mock.assert_called_once_with("http://example.com")
+        # See enthought/traitsui#1464
+        # This is the expected behaviour:
+        # mocked_browser.assert_called_once_with("test://testing")
+        # However, this is the current unexpected behaviour
+        mocked_browser.assert_not_called()
+
+    @requires_toolkit([ToolkitName.qt])
+    def test_open_internal_link_externally(self):
+        # this test requires Qt because it relies on the link filling up
+        # the entire page through the use of CSS, which isn't supported
+        # by Wx.
+        model = HTMLModel(content="""
+        <html>
+            <a
+              href='test://testing'
+              target='_self'
+              style='display:block; width: 100%; height: 100%'>
+                Internal Link
+            </a>
+        </html>
+        """)
+        view = View(
+            Item("content", editor=HTMLEditor(open_externally=True))
+        )
+
+        with self.tester.create_ui(model, dict(view=view)) as ui:
+            html_view = self.tester.find_by_name(ui, "content")
+            with mock.patch("webbrowser.open_new") as mocked_browser:
+                html_view.perform(MouseClick())
+            self.assertIn(
+                "Internal Link",
+                html_view.inspect(HTMLContent()),
+            )
+
+        mocked_browser.assert_called_once_with("test://testing")
+
+    @requires_toolkit([ToolkitName.qt])
+    def test_open_externally_link_externally(self):
+        model = HTMLModel(content="""
+        <html>
+            <a
+              href='test://testing'
+              target='_blank'
+              style='display:block; width: 100%; height: 100%'>
+                External Link
+            </a>
+        </html>
+        """)
+        view = View(
+            Item("content", editor=HTMLEditor(open_externally=True))
+        )
+
+        with self.tester.create_ui(model, dict(view=view)) as ui:
+            html_view = self.tester.find_by_name(ui, "content")
+            with mock.patch("webbrowser.open_new") as mocked_browser:
+                html_view.perform(MouseClick())
+            self.assertIn(
+                "External Link",
+                html_view.inspect(HTMLContent()),
+            )
+
+            is_web_engine = _is_web_engine_page(
+                html_view._target.control.page()
+            )
+
+        if is_web_engine:
+            # Expected failure:
+            # See enthought/traitsui#1464
+            # This is the current unexpected behavior if QtWebEngine is used.
+            mocked_browser.assert_not_called()
+        else:
+            # This is the expected behavior.
+            mocked_browser.assert_called_once_with("test://testing")

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -356,7 +356,7 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
         mocked_browser.assert_called_once_with("test://testing")
 
     @requires_toolkit([ToolkitName.qt])
-    def test_open_externally_link_externally(self):
+    def test_open_external_link_externally(self):
         model = HTMLModel(content="""
         <html>
             <a

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -80,6 +80,7 @@ def qt_get_page_html_content(page):
 
     content = []
     page.toHtml(content.append)
+    qt_allow_page_to_load(page)
     return "".join(content)
 
 

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -124,17 +124,13 @@ def wait_for_qt_signal(qt_signal, timeout):
         raise RuntimeError("Timeout waiting for signal.")
 
 
-def qt_allow_page_to_load(page, step_timeout=0.5):
+def qt_allow_page_to_load(page, timeout=0.5):
     """ Allow QWebPage/QWebEnginePage to finish loading.
 
     Out of context, this function does not know if the page has started
-    loading. Therefore it tries to see if the page is busy by watching its
-    loadStarted or loadProgress signal. If the loadStarted signal has been
-    emitted before this function is called, and/or the loadProgress is taking
-    too long to be emitted, then it is possible that the page is not in a
-    loaded state when this function returns.
+    loading. Therefore no timeout error is raised.
 
-    However for most testing purposes, this function should be good enough to
+    For most testing purposes, this function should be good enough to
     avoid interacting with the Qt web page before it has finished loading, at
     a cost of a slower test.
 
@@ -142,23 +138,15 @@ def qt_allow_page_to_load(page, step_timeout=0.5):
     ----------
     page : QWebPage or QWebEnginePage
         The page to allow loading to finish.
-    step_timeout : float
+    timeout : float
         Timeout in seconds for each signal being observed.
     """
 
-    step_timeout_ms = round(step_timeout * 1000)
+    timeout_ms = round(timeout * 1000)
     try:
-        wait_for_qt_signal(page.loadStarted, timeout=step_timeout_ms)
+        wait_for_qt_signal(page.loadFinished, timeout=timeout_ms)
     except RuntimeError:
-        # It might have been started before this function is called.
-        # Check for progress too.
-        try:
-            wait_for_qt_signal(page.loadProgress, timeout=step_timeout_ms)
-        except RuntimeError:
-            # Probably haven't started.
-            return
-
-    wait_for_qt_signal(page.loadFinished, timeout=step_timeout_ms)
+        return
 
 
 def qt_mouse_click_web_view(view, delay):

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -63,23 +63,6 @@ def _is_webkit_page(page):
     return hasattr(page, "setLinkDelegationPolicy")
 
 
-def qt_get_page_url(page):
-    """ Return the URL (in string format) currently being viewed.
-
-    Parameters
-    ----------
-    page : QWebEnginePage or QWebPage
-
-    Returns
-    -------
-    html : str
-    """
-    qt_allow_page_to_load(page)
-    if _is_webkit_page(page):
-        return page.mainFrame().url().toString()
-    return page.url().toString()
-
-
 def qt_get_page_html_content(page):
     """ Return the HTML content currently being viewed.
 

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -74,13 +74,13 @@ def qt_get_page_html_content(page):
     -------
     html : str
     """
-    qt_allow_page_to_load(page)
+    qt_allow_view_to_load(page)
     if _is_webkit_page(page):
         return page.mainFrame().toHtml()
 
     content = []
     page.toHtml(content.append)
-    qt_allow_page_to_load(page)
+    qt_allow_view_to_load(page)
     return "".join(content)
 
 
@@ -124,8 +124,9 @@ def wait_for_qt_signal(qt_signal, timeout):
         raise RuntimeError("Timeout waiting for signal.")
 
 
-def qt_allow_page_to_load(page, timeout=0.5):
-    """ Allow QWebPage/QWebEnginePage to finish loading.
+def qt_allow_view_to_load(loadable, timeout=0.5):
+    """ Allow QWebView/QWebPage/QWebEngineView/QWebEnginePage to finish
+    loading.
 
     Out of context, this function does not know if the page has started
     loading. Therefore no timeout error is raised.
@@ -136,15 +137,15 @@ def qt_allow_page_to_load(page, timeout=0.5):
 
     Parameters
     ----------
-    page : QWebPage or QWebEnginePage
-        The page to allow loading to finish.
+    loadable : QWebView or QWebPage or QWebEngineView or QWebEnginePage
+        The view / page to allow loading to finish. Any object with the
+        loadFinished signal can be used.
     timeout : float
         Timeout in seconds for each signal being observed.
     """
-
     timeout_ms = round(timeout * 1000)
     try:
-        wait_for_qt_signal(page.loadFinished, timeout=timeout_ms)
+        wait_for_qt_signal(loadable.loadFinished, timeout=timeout_ms)
     except RuntimeError:
         return
 
@@ -162,7 +163,7 @@ def qt_mouse_click_web_view(view, delay):
     from pyface.qt import QtCore
     from pyface.qt.QtTest import QTest
 
-    qt_allow_page_to_load(view.page())
+    qt_allow_view_to_load(view)
 
     if view.focusProxy() is not None:
         # QWebEngineView
@@ -179,7 +180,7 @@ def qt_mouse_click_web_view(view, delay):
             delay=delay,
         )
     finally:
-        qt_allow_page_to_load(view.page())
+        qt_allow_view_to_load(view)
 
 
 def qt_target_registry():

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -99,12 +99,12 @@ def qt_get_page_html_content(page):
     -------
     html : str
     """
+    qt_allow_page_to_load(page)
     if _is_webkit_page(page):
         return page.mainFrame().toHtml()
 
     content = []
     page.toHtml(content.append)
-    qt_allow_page_to_load(page)
     return "".join(content)
 
 

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -101,12 +101,14 @@ def wait_for_qt_signal(qt_signal, timeout):
     ------
     RuntimeError
     """
-    from pyface.qt import QtCore, QtGui
+    from pyface.qt import QtCore
 
-    qt_app = QtGui.QApplication.instance()
+    # QEventLoop is used instead of QApplication due to observed
+    # hangs with Qt4.
+    event_loop = QtCore.QEventLoop()
 
     def exit(*args, **kwargs):
-        qt_app.quit()
+        event_loop.quit()
 
     timeout_timer = QtCore.QTimer()
     timeout_timer.setSingleShot(True)
@@ -115,7 +117,7 @@ def wait_for_qt_signal(qt_signal, timeout):
     qt_signal.connect(exit)
 
     timeout_timer.start()
-    qt_app.exec_()
+    event_loop.exec_()
 
     qt_signal.disconnect(exit)
     if timeout_timer.isActive():

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -44,14 +44,6 @@ def get_view(base_url_name):
     )
 
 
-class CurrentURL:
-    """ Represent a query to obtain the current URL displayed by the
-    web page.
-    Implementation should return a str.
-    """
-    pass
-
-
 class HTMLContent:
     """ Action to retrieve the HTML content currently displayed.
     Implementation should return a str, whose content conforms to HTML markup.
@@ -237,13 +229,6 @@ def qt_target_registry():
     )
     registry.register_interaction(
         target_class=SimpleEditor,
-        interaction_class=CurrentURL,
-        handler=lambda wrapper, _: (
-            qt_get_page_url(wrapper._target.control.page())
-        )
-    )
-    registry.register_interaction(
-        target_class=SimpleEditor,
         interaction_class=HTMLContent,
         handler=lambda wrapper, _: (
             qt_get_page_html_content(wrapper._target.control.page())
@@ -315,18 +300,11 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
 
         with self.tester.create_ui(model, dict(view=view)) as ui:
             html_view = self.tester.find_by_name(ui, "content")
-            self.assertFalse(
-                html_view.inspect(CurrentURL()).startswith("about:blank")
-            )
 
             # when
             with mock.patch("webbrowser.open_new") as mocked_browser:
                 html_view.perform(MouseClick())
 
-            # then
-            self.assertTrue(
-                html_view.inspect(CurrentURL()).startswith("about:blank")
-            )
         mocked_browser.assert_not_called()
 
     @requires_toolkit([ToolkitName.qt])


### PR DESCRIPTION
Motivated by #1464, this PR extends the tests for testing how the HTMLEditor opens `<a>` links with/without `target` set, along with the `open_externally` flag.

The tests rely on Qt webkit/webengine being able render CSS so that the link can fill up the entire page and the tests can simply click anywhere to trigger the link.

Only test code is changed. Two of the tests are effectively tests with "expected failures" to illustrate the issue described in #1464.

Note the draft implementation in https://github.com/enthought/traitsui/issues/1464#issuecomment-754662151 requires the existing test be modified as the slot to `linkClicked` (WebKit only) is removed there. The draft implementation passes the new tests (after replacing expected failures with expected successes).
