### PR TITLE
Include flake8_ets plugin when running flake8 on codebase.

### DIFF
--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -107,6 +107,7 @@ dependencies = {
     "docutils",
     "eam",
     "flake8",
+    "flake8_ets",
     "traits",
     "traitsui",
     "pyface",

--- a/etstool.py
+++ b/etstool.py
@@ -162,6 +162,7 @@ extra_dependencies = {
 ci_dependencies = {
     "coverage",
     "flake8",
+    "flake8_ets",
 }
 
 doc_dependencies = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-per-file-ignores = */api.py:F401
+per-file-ignores = */api.py:F401,examples/*:H101
 exclude =
     # The following list should eventually be empty.
     docs,

--- a/traitsui/tests/test_actions.py
+++ b/traitsui/tests/test_actions.py
@@ -1,17 +1,12 @@
-# ------------------------------------------------------------------------------
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
 #
-#  Copyright (c) 2012, Enthought, Inc.
-#  All rights reserved.
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
-#  This software is provided without warranty under the terms of the BSD
-#  license included in LICENSE.txt and may be redistributed only
-#  under the conditions described in the aforementioned license.  The license
-#  is also available online at http://www.enthought.com/licenses/BSD.txt
-#
-#  Author: Pietro Berkes
-#  Date:   Feb 2012
-#
-# ------------------------------------------------------------------------------
+# Thanks for using Enthought open source!
 
 """
 Test that menu and toolbar actions are triggered.


### PR DESCRIPTION
This PR includes the `flake8_ets` package in the environment. Note that this PR also excludes the `examples` folder from copyright header violations.