### PR TITLE
Doc: Clarify which of traitsui.api and traitsui.editors.api is recommended

### DIFF
--- a/traitsui/editors/api.py
+++ b/traitsui/editors/api.py
@@ -1,6 +1,6 @@
 """ API for traitsui.editors subpackage.
 
-Note that the followings are also available from :mod:`traitsui.api`, which
+Note that the following are also available from :mod:`traitsui.api`, which
 is the preferred module for imports.
 
 - :attr:`~.ArrayEditor`

--- a/traitsui/editors/api.py
+++ b/traitsui/editors/api.py
@@ -1,5 +1,8 @@
 """ API for traitsui.editors subpackage.
 
+Note that the followings are also available from :mod:`traitsui.api`, which
+is the preferred module for imports.
+
 - :attr:`~.ArrayEditor`
 - :attr:`~.BooleanEditor`
 - :attr:`~.ButtonEditor`


### PR DESCRIPTION
This PR adds a sentence to the API documentation of `traitsui.editors.api` to refer users to `traitsui.api` instead. `traitsui.editors.api` is NOT being deprecated. Since `traitsui.editors.api` is merely a subset of `traitsui.api`, this simply clarifies the relationship and recommendation.