### PR TITLE
Include a few badges in the README from GitHub Actions jobs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,12 @@ TraitsUI: Traits-capable windowing framework
 .. image:: https://ci.appveyor.com/api/projects/status/n2qy8kcwh8ibi9g3/branch/master?svg=true
    :target: https://ci.appveyor.com/project/EnthoughtOSS/traitsui/branch/master
 
+.. image:: https://github.com/enthought/traitsui/workflows/ETS%20from%20source/badge.svg 
+.. image:: https://github.com/enthought/traitsui/workflows/Test%20with%20PyPI/badge.svg
+.. image:: https://github.com/enthought/traitsui/workflows/Test%20with%20EDM/badge.svg
+.. image:: https://github.com/enthought/traitsui/workflows/Integration%20tests/badge.svg
+
+
 The TraitsUI project contains a toolkit-independent GUI abstraction layer,
 which is used to support the "visualization" features of the
 `Traits <http://github.com/enthought/traits>`__ package.


### PR DESCRIPTION
This PR updates README to include a few badges from GitHub Actions CI - 4 out of 8 jobs - https://github.com/enthought/traitsui/actions

I intentionally ignored the minimal setup, test with traits 6, style check and doc build jobs.