### PR TITLE
Remove clause that deviates from PEP8 backward compatibility convention in the testing package

### DIFF
--- a/traitsui/testing/__init__.py
+++ b/traitsui/testing/__init__.py
@@ -12,7 +12,7 @@
 This package provide functionality to help testing GUI applications built
 using TraitsUI.
 
-The top-level ``api`` module exposes the public API for external projects.
+The top-level ``api`` module re-exposes the public API for convenience.
 
 Private modules in this package serve TraitsUI only.
 """

--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -11,10 +11,6 @@
 """
 Core API for traitsui.testing
 
-Functionalities exposed via this package are intended to be used by external
-projects and stability is maintained as much as possible. Imports from other
-packages and subpackages do NOT receive the same stability guarantee.
-
 Tester
 ------
 


### PR DESCRIPTION
This PR updates the API documentation for `traitsui.testing.api` and `traitsui.testing` to remove clauses that deviate from the convention of backward compatibility guarantee in PEP8.

These clauses were added following the suggestion in https://github.com/enthought/traits/issues/1213 and similar changes in Traits-Futures. The idea that things outside of the `api` module don't get backward compatibility guarantee has really got into my head, but over time, I find it confusing as a developer working with this convention, because it differs from the one followed by the wider Python community. As a result, I would change code that break backward compatibility for PEP8-public components because this alternative convention allows me to do that, but then those changes may have to be reverted because it may break other people's code if they have followed PEP8.

All the packages and modules in `traitsui.testing` are already named appropriately following PEP8 convention: Things whose import name contain a single leading underscore are internal and no backward compatibility guarantee applies. There is no need to add an alternative convention for this subpackage.