### PR TITLE
Better document auto_process_events

### DIFF
--- a/traitsui/testing/tester/tests/test_ui_tester.py
+++ b/traitsui/testing/tester/tests/test_ui_tester.py
@@ -210,3 +210,15 @@ class TestUITesterFindEditor(unittest.TestCase):
         with tester.create_ui(Order(), dict(view=view)) as ui:
             tester.find_by_id(ui, "item")
             self.assertEqual(side_effect.call_count, 0)
+
+
+class TestUITesterGuiFree(unittest.TestCase):
+    """ Test GUI free interface on UITester."""
+
+    def test_auto_process_events_readonly(self):
+        # auto_process_events can be inspected, but it cannot be changed.
+        tester = UITester(auto_process_events=False)
+        self.assertIs(tester.auto_process_events, False)
+
+        with self.assertRaises(AttributeError):
+            tester.auto_process_events = True

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -66,6 +66,22 @@ class UITester:
         self.delay = delay
         self._auto_process_events = auto_process_events
 
+    @property
+    def auto_process_events(self):
+        """ Flag to indicate whether to process (cascade) GUI events
+        automatically. This is propagated through to
+        :class:`~traitsui.testing.tester.ui_wrapper.UIWrapper` instances
+        created from this tester.
+
+        Although this value can only be set at instantiation, multiple
+        :class:`~traitsui.testing.tester.ui_tester.UITester` instances with
+        different settings can be used together.
+        """
+        # No mutations post-init are allowed because UIWrapper created prior to
+        # the mutation will not respect the new value, and so it would be
+        # confusing if this attribute was allowed to be mutated.
+        return self._auto_process_events
+
     @contextlib.contextmanager
     def create_ui(self, object, ui_kwargs=None):
         """ Context manager to create a UI and dispose it upon exit.

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -73,9 +73,7 @@ class UITester:
         :class:`~traitsui.testing.tester.ui_wrapper.UIWrapper` instances
         created from this tester.
 
-        Although this value can only be set at instantiation, multiple
-        :class:`~traitsui.testing.tester.ui_tester.UITester` instances with
-        different settings can be used together.
+        This value can only be set at instantiation.
         """
         # No mutations post-init are allowed because UIWrapper created prior to
         # the mutation will not respect the new value, and so it would be


### PR DESCRIPTION
Following up observation from refactoring the documentation: The `auto_process_events` flag is only exposed from the object `__init__` method, making it difficult to cross reference in sphinx (there exists sphinx extensions for that, but we may not want to depend on them).

The flag is an internal state of `UITester` not allowed to be mutated post instantiation. The immutability is important in my opinion because if it was allowed to mutate, one may expect this value to be observed by `UIWrapper` created prior to the mutation. Any attempt to "fix" that is going to add complexity. It is not necessary to mutate the flag, because one can simply create another `UITester` in the same test.

By exposing the attribute as a readonly property, this allows space in the API documentation to describe and expand on these details (this is documentation-driven development here). 