### PR TITLE
Fix link label to the documentation home page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,7 +111,7 @@ pygments_style = 'sphinx'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "TraitsUI {} User Manual".format(version.split('.')[0])
+html_title = "TraitsUI {} Documentation".format(version.split('.')[0])
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None


### PR DESCRIPTION
Closes #1484

This is before, these buttons are shown at the very top of the page. The first button actually links to the home page. :
![Screenshot 2021-01-19 at 11 05 13](https://user-images.githubusercontent.com/3673984/105026245-406c9300-5a46-11eb-9927-c7aa1afb8107.png)

This is after this PR:
![Screenshot 2021-01-19 at 11 06 40](https://user-images.githubusercontent.com/3673984/105026551-90e3f080-5a46-11eb-8003-3e69807dbd08.png)
