### PR TITLE
Extract an interface from TargetRegistry to allow wider testing support for IsEnabled

### DIFF
--- a/traitsui/testing/tester/_abstract_target_registry.py
+++ b/traitsui/testing/tester/_abstract_target_registry.py
@@ -7,12 +7,6 @@ public when there is an external need.
 import abc
 
 
-from traitsui.testing.tester.exceptions import (
-    InteractionNotSupported,
-    LocationNotSupported,
-)
-
-
 class AbstractTargetRegistry(abc.ABC):
     """ Abstract base class which defines the registry interface expected
     by :class:`~traitsui.testing.tester.ui_wrapper.UIWrapper`.

--- a/traitsui/testing/tester/_abstract_target_registry.py
+++ b/traitsui/testing/tester/_abstract_target_registry.py
@@ -26,6 +26,8 @@ class AbstractTargetRegistry(abc.ABC):
     def _get_handler(self, target, interaction):
         """ Return a callable for handling an interaction for a given target.
 
+        This is a protected method expected to be implemented by a subclass.
+
         Parameters
         ----------
         target : any
@@ -49,6 +51,8 @@ class AbstractTargetRegistry(abc.ABC):
     def _get_interactions(self, target):
         """ Returns all the interactions supported for the given target.
 
+        This is a protected method expected to be implemented by a subclass.
+
         Parameters
         ----------
         target : any
@@ -63,6 +67,8 @@ class AbstractTargetRegistry(abc.ABC):
     @abc.abstractmethod
     def _get_interaction_doc(self, target, interaction_class):
         """ Return the documentation for the given target and interaction type.
+
+        This is a protected method expected to be implemented by a subclass.
 
         Parameters
         ----------
@@ -87,6 +93,8 @@ class AbstractTargetRegistry(abc.ABC):
         """ Return a callable registered for resolving a location for the
         given target and location.
 
+        This is a protected method expected to be implemented by a subclass.
+
         Parameters
         ----------
         target : any
@@ -104,6 +112,8 @@ class AbstractTargetRegistry(abc.ABC):
     def _get_locations(self, target):
         """ Returns all the location types supported for the given target.
 
+        This is a protected method expected to be implemented by a subclass.
+
         Parameters
         ----------
         target : any
@@ -118,6 +128,8 @@ class AbstractTargetRegistry(abc.ABC):
     @abc.abstractmethod
     def _get_location_doc(self, target, locator_class):
         """ Return the documentation for the given target and locator type.
+
+        This is a protected method expected to be implemented by a subclass.
 
         Parameters
         ----------

--- a/traitsui/testing/tester/_abstract_target_registry.py
+++ b/traitsui/testing/tester/_abstract_target_registry.py
@@ -1,0 +1,133 @@
+""" Interface of a registry depended on by the UIWrapper.
+
+This module is currently labelled as for internal use, but it can be made
+public when there is an external need.
+"""
+
+import abc
+
+
+from traitsui.testing.tester.exceptions import (
+    InteractionNotSupported,
+    LocationNotSupported,
+)
+
+
+class AbstractTargetRegistry(abc.ABC):
+    """ Abstract base class which defines the registry interface expected
+    by :class:`~traitsui.testing.tester.ui_wrapper.UIWrapper`.
+    """
+
+    @abc.abstractmethod
+    def get_handler(self, target, interaction):
+        """ Return a callable for handling an interaction for a given target.
+
+        Parameters
+        ----------
+        target : any
+            The UI target being operated on.
+        interaction : any
+            Any interaction object.
+
+        Returns
+        -------
+        handler : callable(UIWrapper, interaction) -> any
+            The function to handle the given interaction on a target.
+
+        Raises
+        ------
+        InteractionNotSupported
+            If the given target and interaction types are not supported
+            by this registry.
+        """
+
+    @abc.abstractmethod
+    def get_interactions(self, target):
+        """ Returns all the interactions supported for the given target.
+
+        Parameters
+        ----------
+        target : any
+            The UI target for which supported interactions are queried.
+
+        Returns
+        -------
+        interaction_classes : set
+            Supported interaction types for the given target type.
+        """
+
+    @abc.abstractmethod
+    def get_interaction_doc(self, target, interaction_class):
+        """ Return the documentation for the given target and interaction type.
+
+        Parameters
+        ----------
+        target : any
+            The UI target for which the interaction will be applied.
+        interaction_class : subclass of type
+            Any class.
+
+        Returns
+        -------
+        doc : str
+
+        Raises
+        ------
+        InteractionNotSupported
+            If the given target and interaction types are not supported
+            by this registry.
+        """
+
+    @abc.abstractmethod
+    def get_solver(self, target, location):
+        """ Return a callable registered for resolving a location for the
+        given target and location.
+
+        Parameters
+        ----------
+        target : any
+            The UI target being operated on.
+        location : subclass of type
+            The location to be resolved on the target.
+
+        Raises
+        ------
+        LocationNotSupported
+            If the given locator and target types are not supported.
+        """
+
+    @abc.abstractmethod
+    def get_locations(self, target):
+        """ Returns all the location types supported for the given target.
+
+        Parameters
+        ----------
+        target : any
+            The UI target for which supported location types are queried.
+
+        Returns
+        -------
+        locators_classes : set
+            Supported locator types for the given target type.
+        """
+
+    @abc.abstractmethod
+    def get_location_doc(self, target, locator_class):
+        """ Return the documentation for the given target and locator type.
+
+        Parameters
+        ----------
+        target : any
+            The UI target being operated on.
+        locator_class : subclass of type
+            Any class.
+
+        Returns
+        -------
+        doc : str
+
+        Raises
+        ------
+        LocationNotSupported
+            If the given locator and target types are not supported.
+        """

--- a/traitsui/testing/tester/_abstract_target_registry.py
+++ b/traitsui/testing/tester/_abstract_target_registry.py
@@ -23,7 +23,7 @@ class AbstractTargetRegistry(abc.ABC):
     """
 
     @abc.abstractmethod
-    def get_handler(self, target, interaction):
+    def _get_handler(self, target, interaction):
         """ Return a callable for handling an interaction for a given target.
 
         Parameters
@@ -46,7 +46,7 @@ class AbstractTargetRegistry(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_interactions(self, target):
+    def _get_interactions(self, target):
         """ Returns all the interactions supported for the given target.
 
         Parameters
@@ -61,7 +61,7 @@ class AbstractTargetRegistry(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_interaction_doc(self, target, interaction_class):
+    def _get_interaction_doc(self, target, interaction_class):
         """ Return the documentation for the given target and interaction type.
 
         Parameters
@@ -83,7 +83,7 @@ class AbstractTargetRegistry(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_solver(self, target, location):
+    def _get_solver(self, target, location):
         """ Return a callable registered for resolving a location for the
         given target and location.
 
@@ -101,7 +101,7 @@ class AbstractTargetRegistry(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_locations(self, target):
+    def _get_locations(self, target):
         """ Returns all the location types supported for the given target.
 
         Parameters
@@ -116,7 +116,7 @@ class AbstractTargetRegistry(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_location_doc(self, target, locator_class):
+    def _get_location_doc(self, target, locator_class):
         """ Return the documentation for the given target and locator type.
 
         Parameters

--- a/traitsui/testing/tester/_abstract_target_registry.py
+++ b/traitsui/testing/tester/_abstract_target_registry.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Interface of a registry depended on by the UIWrapper.
 
 This module is currently labelled as for internal use, but it can be made

--- a/traitsui/testing/tester/_base_dynamic_registry.py
+++ b/traitsui/testing/tester/_base_dynamic_registry.py
@@ -1,0 +1,85 @@
+""" Implement the interface of AbstractTargetRegistry to support
+dynamic checking on the target.
+"""
+import inspect
+
+from traitsui.testing.tester._abstract_target_registry import (
+    AbstractTargetRegistry,
+)
+from traitsui.testing.tester.exceptions import (
+    InteractionNotSupported,
+    LocationNotSupported,
+)
+
+
+class BaseDynamicRegistry(AbstractTargetRegistry):
+    """ A registry to support targets with dynamic checks.
+
+    Subclass should populate the _INTERACTION_TO_HANDLER mapping
+    and implement _is_target_accepted method.
+    """
+
+    #: A dictionary mapping from interaction type to handler callable
+    #: Subclass should propulate this mapping.
+    _INTERACTION_TO_HANDLER = {}
+
+    def _is_target_accepted(self, target):
+        """ Return true if the target is accepted by the registry.
+        Subclass must implement this method.
+
+        Parameters
+        ----------
+        target : any
+            Any UI target
+
+        Returns
+        -------
+        is_accepted : bool
+        """
+        raise NotImplementedError("_is_target_accepted must be implemented.")
+
+    def get_handler(self, target, interaction):
+        """ Reimplemented AbstractTargetRegistry.get_handler """
+        if interaction.__class__ not in self.get_interactions(target):
+            raise InteractionNotSupported(
+                target_class=target.__class__,
+                interaction_class=interaction.__class__,
+                supported=list(self.get_interactions(target)),
+            )
+        return self._INTERACTION_TO_HANDLER[interaction.__class__]
+
+    def get_interactions(self, target):
+        """ Reimplemented AbstractTargetRegistry.get_interactions """
+        if self._is_target_accepted(target):
+            return set(self._INTERACTION_TO_HANDLER)
+        return set()
+
+    def get_interaction_doc(self, target, interaction_class):
+        """ Reimplemented AbstractTargetRegistry.get_interaction_doc """
+        if interaction_class not in self.get_interactions(target):
+            raise InteractionNotSupported(
+                target_class=target.__class__,
+                interaction_class=interaction_class,
+                supported=list(self.get_interactions(target)),
+            )
+        return inspect.getdoc(interaction_class)
+
+    def get_solver(self, target, location):
+        """ Reimplemented AbstractTargetRegistry.get_solver """
+        raise LocationNotSupported(
+            target_class=target.__class__,
+            locator_class=location.__class__,
+            supported=[],
+        )
+
+    def get_locations(self, target):
+        """ Reimplemented AbstractTargetRegistry.get_locations """
+        return set()
+
+    def get_location_doc(self, target, locator_class):
+        """ Reimplemented AbstractTargetRegistry.get_location_doc """
+        raise LocationNotSupported(
+            target_class=target.__class__,
+            locator_class=locator_class,
+            supported=[],
+        )

--- a/traitsui/testing/tester/_dynamic_target_registry.py
+++ b/traitsui/testing/tester/_dynamic_target_registry.py
@@ -39,7 +39,28 @@ class DynamicTargetRegistry(AbstractTargetRegistry):
         self.interaction_to_handler = interaction_to_handler
 
     def _get_handler(self, target, interaction):
-        """ Reimplemented AbstractTargetRegistry._get_handler """
+        """ Return a callable for handling an interaction for a given target.
+
+        This is an implementation for an abstract method.
+
+        Parameters
+        ----------
+        target : any
+            The UI target being operated on.
+        interaction : any
+            Any interaction object.
+
+        Returns
+        -------
+        handler : callable(UIWrapper, interaction) -> any
+            The function to handle the given interaction on a target.
+
+        Raises
+        ------
+        InteractionNotSupported
+            If the given target and interaction types are not supported
+            by this registry.
+        """
         if interaction.__class__ not in self._get_interactions(target):
             raise InteractionNotSupported(
                 target_class=target.__class__,
@@ -49,13 +70,46 @@ class DynamicTargetRegistry(AbstractTargetRegistry):
         return self.interaction_to_handler[interaction.__class__]
 
     def _get_interactions(self, target):
-        """ Reimplemented AbstractTargetRegistry._get_interactions """
+        """ Returns all the interactions supported for the given target.
+
+        This is an implementation for an abstract method.
+
+        Parameters
+        ----------
+        target : any
+            The UI target for which supported interactions are queried.
+
+        Returns
+        -------
+        interaction_classes : set
+            Supported interaction types for the given target type.
+        """
         if self.can_support(target):
             return set(self.interaction_to_handler)
         return set()
 
     def _get_interaction_doc(self, target, interaction_class):
-        """ Reimplemented AbstractTargetRegistry._get_interaction_doc """
+        """ Return the documentation for the given target and interaction type.
+
+        This is an implementation for an abstract method.
+
+        Parameters
+        ----------
+        target : any
+            The UI target for which the interaction will be applied.
+        interaction_class : subclass of type
+            Any class.
+
+        Returns
+        -------
+        doc : str
+
+        Raises
+        ------
+        InteractionNotSupported
+            If the given target and interaction types are not supported
+            by this registry.
+        """
         if interaction_class not in self._get_interactions(target):
             raise InteractionNotSupported(
                 target_class=target.__class__,
@@ -65,7 +119,23 @@ class DynamicTargetRegistry(AbstractTargetRegistry):
         return inspect.getdoc(interaction_class)
 
     def _get_solver(self, target, location):
-        """ Reimplemented AbstractTargetRegistry._get_solver """
+        """ Return a callable registered for resolving a location for the
+        given target and location.
+
+        This is an implementation for an abstract method.
+
+        Parameters
+        ----------
+        target : any
+            The UI target being operated on.
+        location : subclass of type
+            The location to be resolved on the target.
+
+        Raises
+        ------
+        LocationNotSupported
+            If the given locator and target types are not supported.
+        """
         raise LocationNotSupported(
             target_class=target.__class__,
             locator_class=location.__class__,
@@ -73,11 +143,43 @@ class DynamicTargetRegistry(AbstractTargetRegistry):
         )
 
     def _get_locations(self, target):
-        """ Reimplemented AbstractTargetRegistry._get_locations """
+        """ Returns all the location types supported for the given target.
+
+        This is an implementation for an abstract method.
+
+        Parameters
+        ----------
+        target : any
+            The UI target for which supported location types are queried.
+
+        Returns
+        -------
+        locators_classes : set
+            Supported locator types for the given target type.
+        """
         return set()
 
     def _get_location_doc(self, target, locator_class):
-        """ Reimplemented AbstractTargetRegistry._get_location_doc """
+        """ Return the documentation for the given target and locator type.
+
+        This is an implementation for an abstract method.
+
+        Parameters
+        ----------
+        target : any
+            The UI target being operated on.
+        locator_class : subclass of type
+            Any class.
+
+        Returns
+        -------
+        doc : str
+
+        Raises
+        ------
+        LocationNotSupported
+            If the given locator and target types are not supported.
+        """
         raise LocationNotSupported(
             target_class=target.__class__,
             locator_class=locator_class,

--- a/traitsui/testing/tester/_dynamic_target_registry.py
+++ b/traitsui/testing/tester/_dynamic_target_registry.py
@@ -23,7 +23,28 @@ from traitsui.testing.tester.exceptions import (
 
 
 class DynamicTargetRegistry(AbstractTargetRegistry):
-    """ A registry to support targets with dynamic checks.
+    """ Registry to support testing targets that satisfy a given criterion.
+
+    An instance of this registry can be used with ``UITester`` and
+    ``UIWrapper`` such that all given interactions and handlers will be
+    applicable to any target that deemed to be supported by ``can_support``.
+    The general priority rule applies. See :ref:`testing-how-extension-works`
+    in the User Manual for further details.
+
+    For stricter checks on the target type, use
+    :class:`~traitsui.testing.tester.target_registry.TargetRegistry`.
+
+    As an example, this registry::
+
+        registry = DynamicTargetRegistry(
+            can_support=lambda target: target.__class__ is MyEditorClass,
+            interaction_to_handler={MyAction: handler},
+        )
+
+    has equivalent behaviors compared to this registry::
+
+        registry = TargetRegistry()
+        registry.register_interaction(MyEditorClass, MyAction, handler)
 
     Parameters
     ----------
@@ -31,7 +52,10 @@ class DynamicTargetRegistry(AbstractTargetRegistry):
         A callable that return true if the given target is supported
         by the registry.
     interaction_to_handler : dict(type, callable)
-        A dictionary mapping from interaction type to handler callables
+        A dictionary mapping from interaction type to handler callables.
+        Each handler callable in the values should have the signature
+        ``callable(UIWrapper, interaction) -> any``, where ``instance`` should
+        have the type defined in the associated key.
     """
 
     def __init__(self, *, can_support, interaction_to_handler):

--- a/traitsui/testing/tester/_dynamic_target_registry.py
+++ b/traitsui/testing/tester/_dynamic_target_registry.py
@@ -38,46 +38,46 @@ class DynamicTargetRegistry(AbstractTargetRegistry):
         self.can_support = can_support
         self.interaction_to_handler = interaction_to_handler
 
-    def get_handler(self, target, interaction):
-        """ Reimplemented AbstractTargetRegistry.get_handler """
-        if interaction.__class__ not in self.get_interactions(target):
+    def _get_handler(self, target, interaction):
+        """ Reimplemented AbstractTargetRegistry._get_handler """
+        if interaction.__class__ not in self._get_interactions(target):
             raise InteractionNotSupported(
                 target_class=target.__class__,
                 interaction_class=interaction.__class__,
-                supported=list(self.get_interactions(target)),
+                supported=list(self._get_interactions(target)),
             )
         return self.interaction_to_handler[interaction.__class__]
 
-    def get_interactions(self, target):
-        """ Reimplemented AbstractTargetRegistry.get_interactions """
+    def _get_interactions(self, target):
+        """ Reimplemented AbstractTargetRegistry._get_interactions """
         if self.can_support(target):
             return set(self.interaction_to_handler)
         return set()
 
-    def get_interaction_doc(self, target, interaction_class):
-        """ Reimplemented AbstractTargetRegistry.get_interaction_doc """
-        if interaction_class not in self.get_interactions(target):
+    def _get_interaction_doc(self, target, interaction_class):
+        """ Reimplemented AbstractTargetRegistry._get_interaction_doc """
+        if interaction_class not in self._get_interactions(target):
             raise InteractionNotSupported(
                 target_class=target.__class__,
                 interaction_class=interaction_class,
-                supported=list(self.get_interactions(target)),
+                supported=list(self._get_interactions(target)),
             )
         return inspect.getdoc(interaction_class)
 
-    def get_solver(self, target, location):
-        """ Reimplemented AbstractTargetRegistry.get_solver """
+    def _get_solver(self, target, location):
+        """ Reimplemented AbstractTargetRegistry._get_solver """
         raise LocationNotSupported(
             target_class=target.__class__,
             locator_class=location.__class__,
             supported=[],
         )
 
-    def get_locations(self, target):
-        """ Reimplemented AbstractTargetRegistry.get_locations """
+    def _get_locations(self, target):
+        """ Reimplemented AbstractTargetRegistry._get_locations """
         return set()
 
-    def get_location_doc(self, target, locator_class):
-        """ Reimplemented AbstractTargetRegistry.get_location_doc """
+    def _get_location_doc(self, target, locator_class):
+        """ Reimplemented AbstractTargetRegistry._get_location_doc """
         raise LocationNotSupported(
             target_class=target.__class__,
             locator_class=locator_class,

--- a/traitsui/testing/tester/_dynamic_target_registry.py
+++ b/traitsui/testing/tester/_dynamic_target_registry.py
@@ -20,7 +20,7 @@ class DynamicTargetRegistry(AbstractTargetRegistry):
     can_support : callable(target) -> bool
         A callable that return true if the given target is supported
         by the registry.
-    interaction_type_to_handler : dict(type, callable)
+    interaction_to_handler : dict(type, callable)
         A dictionary mapping from interaction type to handler callables
     """
 

--- a/traitsui/testing/tester/_dynamic_target_registry.py
+++ b/traitsui/testing/tester/_dynamic_target_registry.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Implement the interface of AbstractTargetRegistry to support
 dynamic checking on the target.
 """

--- a/traitsui/testing/tester/_ui_tester_registry/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/default_registry.py
@@ -19,7 +19,7 @@ from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
 from traitsui.ui import UI
 
 
-def get_default_registry():
+def get_default_registries():
     """ Creates a default registry for UITester that is toolkit specific.
 
     Returns
@@ -38,7 +38,7 @@ def get_default_registry():
         module = importlib.import_module(
             ".default_registry",
             this_package + '.' + toolkit)
-        registry = module.get_default_registry()
+        registry = module.get_default_registries()
     register_traitsui_ui_solvers(
         registry=registry,
         target_class=UI,

--- a/traitsui/testing/tester/_ui_tester_registry/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/default_registry.py
@@ -24,24 +24,26 @@ def get_default_registries():
 
     Returns
     -------
-    registry : TargetRegistry
-        The default registry containing implementations for TraitsUI editors
-        that is toolkit specific.
+    registries : list of AbstractTargetRegistry
+        The default registries containing implementations for TraitsUI editors
+        that are toolkit specific.
     """
     # side-effect to determine current toolkit
     from pyface.toolkit import toolkit_object  # noqa
     if ETSConfig.toolkit == "null":
-        registry = TargetRegistry()
+        registries = []
     else:
         toolkit = {'wx': 'wx', 'qt4': 'qt4', 'qt': 'qt4'}[ETSConfig.toolkit]
         this_package, _ = __name__.rsplit(".", 1)
         module = importlib.import_module(
             ".default_registry",
             this_package + '.' + toolkit)
-        registry = module.get_default_registries()
+        registries = module.get_default_registries()
+
+    ui_registry = TargetRegistry()
     register_traitsui_ui_solvers(
-        registry=registry,
+        registry=ui_registry,
         target_class=UI,
         traitsui_ui_getter=lambda target: target,
     )
-    return registry
+    return [ui_registry] + registries

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ This module provides a getter to obtain an AbstractTargetRegistry that can
 support testing any target whose 'control' attribute refers to a QWidget.
 """

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
@@ -1,0 +1,102 @@
+""" Implement the interface of AbstractTargetRegistry to support
+testing any target whose 'control' attribute refers to a QWidget.
+"""
+import inspect
+
+from pyface.qt import QtGui
+
+from traitsui.testing.tester._abstract_target_registry import (
+    AbstractTargetRegistry,
+)
+from traitsui.testing.tester.exceptions import (
+    InteractionNotSupported,
+    LocationNotSupported,
+)
+from traitsui.testing.tester.query import IsEnabled
+
+
+def _handle_is_enabled(wrapper, interaction):
+    """ Return true if the target's control is enabled.
+
+    Parameters
+    ----------
+    wrapper : UIWrapper
+        Wrapper on which the target's control should be a QWidget
+    interaction : IsEnabled
+        Not currently used.
+    """
+    return wrapper._target.control.isEnabled()
+
+
+class QtControlWidgetRegistry(AbstractTargetRegistry):
+    """ A registry to support any target with an attribute 'control' that is
+    an instance of QWidget.
+    """
+
+    # Mapping from interaction type to handler callable
+    _INTERACTION_TO_HANDLER = {
+        IsEnabled: _handle_is_enabled,
+    }
+
+    def _is_target_accepted(self, target):
+        """ Return true if the target is accepted by the registry.
+
+        Parameters
+        ----------
+        target : any
+            Any UI target
+
+        Returns
+        -------
+        is_accepted : bool
+        """
+        return (
+            hasattr(target, "control")
+            and isinstance(target.control, QtGui.QWidget)
+        )
+
+    def get_handler(self, target, interaction):
+        """ Reimplemented AbstractTargetRegistry.get_handler """
+        if interaction.__class__ not in self.get_interactions(target):
+            raise InteractionNotSupported(
+                target_class=target.__class__,
+                interaction_class=interaction.__class__,
+                supported=list(self.get_interactions(target)),
+            )
+        return self._INTERACTION_TO_HANDLER[interaction.__class__]
+
+    def get_interactions(self, target):
+        """ Reimplemented AbstractTargetRegistry.get_interactions """
+        if self._is_target_accepted(target):
+            return set(self._INTERACTION_TO_HANDLER)
+        return set()
+
+    def get_interaction_doc(self, target, interaction_class):
+        """ Reimplemented AbstractTargetRegistry.get_interaction_doc """
+        if interaction_class not in self.get_interactions(target):
+            raise InteractionNotSupported(
+                target_class=target.__class__,
+                interaction_class=interaction_class,
+                supported=list(self.get_interactions(target)),
+            )
+        return inspect.getdoc(interaction_class)
+
+    def get_solver(self, target, location):
+        """ Reimplemented AbstractTargetRegistry.get_solver """
+        raise LocationNotSupported(
+            target_class=target.__class__,
+            locator_class=location.__class__,
+            supported=[],
+        )
+
+    def get_locations(self, target):
+        """ Reimplemented AbstractTargetRegistry.get_locations """
+        return set()
+
+    def get_location_doc(self, target, locator_class):
+        """ Reimplemented AbstractTargetRegistry.get_location_doc """
+        raise LocationNotSupported(
+            target_class=target.__class__,
+            locator_class=locator_class,
+            supported=[],
+        )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
@@ -3,8 +3,8 @@ testing any target whose 'control' attribute refers to a QWidget.
 """
 from pyface.qt import QtGui
 
-from traitsui.testing.tester._base_dynamic_registry import (
-    BaseDynamicRegistry,
+from traitsui.testing.tester._dynamic_target_registry import (
+    DynamicTargetRegistry,
 )
 from traitsui.testing.tester.query import IsEnabled
 
@@ -22,29 +22,36 @@ def _handle_is_enabled(wrapper, interaction):
     return wrapper._target.control.isEnabled()
 
 
-class QtControlWidgetRegistry(BaseDynamicRegistry):
-    """ A registry to support any target with an attribute 'control' that is
-    an instance of QWidget.
+def _is_target_control_a_qt_widget(target):
+    """ Return true if the target is accepted by the registry.
+
+    Parameters
+    ----------
+    target : any
+        Any UI target
+
+    Returns
+    -------
+    is_accepted : bool
     """
+    return (
+        hasattr(target, "control")
+        and isinstance(target.control, QtGui.QWidget)
+    )
 
-    # Mapping from interaction type to handler callable
-    _INTERACTION_TO_HANDLER = {
-        IsEnabled: _handle_is_enabled,
-    }
 
-    def _is_target_accepted(self, target):
-        """ Return true if the target is accepted by the registry.
+def get_widget_registry():
+    """ Return a registry to support any target with an attribute 'control'
+    that is an instance of QWidget.
 
-        Parameters
-        ----------
-        target : any
-            Any UI target
-
-        Returns
-        -------
-        is_accepted : bool
-        """
-        return (
-            hasattr(target, "control")
-            and isinstance(target.control, QtGui.QWidget)
-        )
+    Returns
+    -------
+    registry : DynamicTargetRegistry
+        A registry that can be used with UIWrapper
+    """
+    return DynamicTargetRegistry(
+        can_support=_is_target_control_a_qt_widget,
+        interaction_to_handler={
+            IsEnabled: _handle_is_enabled,
+        }
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
@@ -1,5 +1,5 @@
-""" Implement the interface of AbstractTargetRegistry to support
-testing any target whose 'control' attribute refers to a QWidget.
+""" This module provides a getter to obtain an AbstractTargetRegistry that can
+support testing any target whose 'control' attribute refers to a QWidget.
 """
 from pyface.qt import QtGui
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_control_widget_registry.py
@@ -1,16 +1,10 @@
 """ Implement the interface of AbstractTargetRegistry to support
 testing any target whose 'control' attribute refers to a QWidget.
 """
-import inspect
-
 from pyface.qt import QtGui
 
-from traitsui.testing.tester._abstract_target_registry import (
-    AbstractTargetRegistry,
-)
-from traitsui.testing.tester.exceptions import (
-    InteractionNotSupported,
-    LocationNotSupported,
+from traitsui.testing.tester._base_dynamic_registry import (
+    BaseDynamicRegistry,
 )
 from traitsui.testing.tester.query import IsEnabled
 
@@ -28,7 +22,7 @@ def _handle_is_enabled(wrapper, interaction):
     return wrapper._target.control.isEnabled()
 
 
-class QtControlWidgetRegistry(AbstractTargetRegistry):
+class QtControlWidgetRegistry(BaseDynamicRegistry):
     """ A registry to support any target with an attribute 'control' that is
     an instance of QWidget.
     """
@@ -53,50 +47,4 @@ class QtControlWidgetRegistry(AbstractTargetRegistry):
         return (
             hasattr(target, "control")
             and isinstance(target.control, QtGui.QWidget)
-        )
-
-    def get_handler(self, target, interaction):
-        """ Reimplemented AbstractTargetRegistry.get_handler """
-        if interaction.__class__ not in self.get_interactions(target):
-            raise InteractionNotSupported(
-                target_class=target.__class__,
-                interaction_class=interaction.__class__,
-                supported=list(self.get_interactions(target)),
-            )
-        return self._INTERACTION_TO_HANDLER[interaction.__class__]
-
-    def get_interactions(self, target):
-        """ Reimplemented AbstractTargetRegistry.get_interactions """
-        if self._is_target_accepted(target):
-            return set(self._INTERACTION_TO_HANDLER)
-        return set()
-
-    def get_interaction_doc(self, target, interaction_class):
-        """ Reimplemented AbstractTargetRegistry.get_interaction_doc """
-        if interaction_class not in self.get_interactions(target):
-            raise InteractionNotSupported(
-                target_class=target.__class__,
-                interaction_class=interaction_class,
-                supported=list(self.get_interactions(target)),
-            )
-        return inspect.getdoc(interaction_class)
-
-    def get_solver(self, target, location):
-        """ Reimplemented AbstractTargetRegistry.get_solver """
-        raise LocationNotSupported(
-            target_class=target.__class__,
-            locator_class=location.__class__,
-            supported=[],
-        )
-
-    def get_locations(self, target):
-        """ Reimplemented AbstractTargetRegistry.get_locations """
-        return set()
-
-    def get_location_doc(self, target, locator_class):
-        """ Reimplemented AbstractTargetRegistry.get_location_doc """
-        raise LocationNotSupported(
-            target_class=target.__class__,
-            locator_class=locator_class,
-            supported=[],
         )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/button_editor.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 from traitsui.testing.tester.command import MouseClick
-from traitsui.testing.tester.query import DisplayedText, IsEnabled
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )
@@ -33,7 +33,6 @@ def register(registry):
                 wrapper._target.control, wrapper.delay)),
         (DisplayedText,
             lambda wrapper, _: wrapper._target.control.text()),
-        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled()),
     ]
 
     for target_class in [SimpleEditor, CustomEditor]:

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
@@ -32,7 +32,6 @@ def register(registry):
                 wrapper._target.control, wrapper.delay))),
         (DisplayedText,
             lambda wrapper, _: wrapper._target.control.text()),
-        (IsEnabled, lambda wrapper, _: wrapper._target.control.isEnabled()),
     ]
     for interaction_class, handler in handlers:
         registry.register_interaction(

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/ui_base.py
@@ -10,7 +10,7 @@
 
 from traitsui.qt4.ui_base import ButtonEditor
 from traitsui.testing.tester.command import MouseClick
-from traitsui.testing.tester.query import DisplayedText, IsEnabled
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.qt4 import (
     _interaction_helpers
 )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -24,7 +24,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
 )
 
 
-def get_default_registry():
+def get_default_registries():
     """ Creates a default registry for UITester that is qt specific.
 
     Returns

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -22,6 +22,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     text_editor,
     ui_base,
 )
+from ._control_widget_registry import QtControlWidgetRegistry
 
 
 def get_default_registries():
@@ -68,4 +69,9 @@ def get_default_registries():
     # Editor Factory
     editor_factory.register(registry)
 
-    return [registry]
+    # The more general QtControlWidgetRegistry goes after the more specific
+    # editor registry.
+    return [
+        registry,
+        QtControlWidgetRegistry(),
+    ]

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -25,13 +25,13 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
 
 
 def get_default_registries():
-    """ Creates a default registry for UITester that is qt specific.
+    """ Creates the default registries for UITester that are qt specific.
 
     Returns
     -------
-    registry : TargetRegistry
-        The default registry containing implementations for TraitsUI editors
-        that is qt specific.
+    registries : list of AbstractTargetRegistry
+        The default registries containing implementations for TraitsUI editors
+        that are qt specific.
     """
     registry = TargetRegistry()
 
@@ -68,4 +68,4 @@ def get_default_registries():
     # Editor Factory
     editor_factory.register(registry)
 
-    return registry
+    return [registry]

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -22,7 +22,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     text_editor,
     ui_base,
 )
-from ._control_widget_registry import QtControlWidgetRegistry
+from ._control_widget_registry import get_widget_registry
 
 
 def get_default_registries():
@@ -69,9 +69,8 @@ def get_default_registries():
     # Editor Factory
     editor_factory.register(registry)
 
-    # The more general QtControlWidgetRegistry goes after the more specific
-    # editor registry.
+    # The more general registry goes after the more specific registry.
     return [
         registry,
-        QtControlWidgetRegistry(),
+        get_widget_registry(),
     ]

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ Tests for QWidget's DynamicTargetRegistry """
 
 import unittest
@@ -19,9 +29,10 @@ except ImportError:
     if is_qt():
         raise
 else:
-    from traitsui.testing.tester._ui_tester_registry.qt4._control_widget_registry import (
+    from traitsui.testing.tester._ui_tester_registry.qt4._control_widget_registry import (   # noqa: E501
         get_widget_registry,
     )
+
 
 class TargetWithControl:
     """ An object holding a control attribute."""

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
@@ -1,4 +1,4 @@
-""" Tests for QtControlWidgetRegistry """
+""" Tests for QWidget's DynamicTargetRegistry """
 
 import unittest
 
@@ -32,8 +32,7 @@ class TargetWithControl:
 
 @requires_toolkit([ToolkitName.qt])
 class TestQtControlWidgetRegistry(unittest.TestCase):
-    """ Test the interface of AbstractTargetRegistry for
-    QtControlWidgetRegistry
+    """ Test the interface of AbstractTargetRegistry for QWidget's registry
     """
 
     def setUp(self):

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
@@ -64,26 +64,26 @@ class TestQtControlWidgetRegistry(unittest.TestCase):
 
     def test_get_interactions_good_target(self):
         self.assertEqual(
-            self.registry.get_interactions(self.target),
+            self.registry._get_interactions(self.target),
             set([IsEnabled])
         )
 
     def test_get_interactions_bad_target(self):
-        self.assertEqual(self.registry.get_interactions(None), set())
+        self.assertEqual(self.registry._get_interactions(None), set())
 
     def test_get_interaction_doc(self):
         self.assertGreater(
-            len(self.registry.get_interaction_doc(self.target, IsEnabled)), 0
+            len(self.registry._get_interaction_doc(self.target, IsEnabled)), 0
         )
 
     def test_get_location_solver(self):
         # There are currently no solvers
         with self.assertRaises(LocationNotSupported):
-            self.registry.get_solver(self.target, None)
+            self.registry._get_solver(self.target, None)
 
-    def test_get_locations(self):
-        self.assertEqual(self.registry.get_locations(self.target), set())
+    def test__get_locations(self):
+        self.assertEqual(self.registry._get_locations(self.target), set())
 
     def test_error_get_location_doc(self):
         with self.assertRaises(LocationNotSupported):
-            self.registry.get_location_doc(self.target, None)
+            self.registry._get_location_doc(self.target, None)

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
@@ -6,9 +6,6 @@ from traitsui.testing.api import IsEnabled
 from traitsui.testing.tester.exceptions import (
     LocationNotSupported,
 )
-from traitsui.testing.tester._ui_tester_registry.qt4._control_widget_registry import (
-    QtControlWidgetRegistry,
-)
 from traitsui.testing.tester.ui_wrapper import UIWrapper
 from traitsui.tests._tools import (
     is_qt,
@@ -21,7 +18,10 @@ try:
 except ImportError:
     if is_qt():
         raise
-
+else:
+    from traitsui.testing.tester._ui_tester_registry.qt4._control_widget_registry import (
+        QtControlWidgetRegistry,
+    )
 
 class TargetWithControl:
     """ An object holding a control attribute."""

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
@@ -20,7 +20,7 @@ except ImportError:
         raise
 else:
     from traitsui.testing.tester._ui_tester_registry.qt4._control_widget_registry import (
-        QtControlWidgetRegistry,
+        get_widget_registry,
     )
 
 class TargetWithControl:
@@ -38,7 +38,7 @@ class TestQtControlWidgetRegistry(unittest.TestCase):
 
     def setUp(self):
         self.widget = QtGui.QWidget()
-        self.registry = QtControlWidgetRegistry()
+        self.registry = get_widget_registry()
         self.target = TargetWithControl(self.widget)
         self.good_wrapper = UIWrapper(
             target=self.target,

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_control_widget_registry.py
@@ -1,0 +1,79 @@
+""" Tests for QtControlWidgetRegistry """
+
+import unittest
+
+from traitsui.testing.api import IsEnabled
+from traitsui.testing.tester.exceptions import (
+    LocationNotSupported,
+)
+from traitsui.testing.tester._ui_tester_registry.qt4._control_widget_registry import (
+    QtControlWidgetRegistry,
+)
+from traitsui.testing.tester.ui_wrapper import UIWrapper
+from traitsui.tests._tools import (
+    is_qt,
+    requires_toolkit,
+    ToolkitName,
+)
+
+try:
+    from pyface.qt import QtGui
+except ImportError:
+    if is_qt():
+        raise
+
+
+class TargetWithControl:
+    """ An object holding a control attribute."""
+
+    def __init__(self, control):
+        self.control = control
+
+
+@requires_toolkit([ToolkitName.qt])
+class TestQtControlWidgetRegistry(unittest.TestCase):
+    """ Test the interface of AbstractTargetRegistry for
+    QtControlWidgetRegistry
+    """
+
+    def setUp(self):
+        self.widget = QtGui.QWidget()
+        self.registry = QtControlWidgetRegistry()
+        self.target = TargetWithControl(self.widget)
+        self.good_wrapper = UIWrapper(
+            target=self.target,
+            registries=[self.registry],
+        )
+
+    def test_is_enabled(self):
+        self.assertTrue(self.good_wrapper.inspect(IsEnabled()))
+
+    def test_is_disabled(self):
+        self.widget.setEnabled(False)
+        self.assertFalse(self.good_wrapper.inspect(IsEnabled()))
+
+    def test_get_interactions_good_target(self):
+        self.assertEqual(
+            self.registry.get_interactions(self.target),
+            set([IsEnabled])
+        )
+
+    def test_get_interactions_bad_target(self):
+        self.assertEqual(self.registry.get_interactions(None), set())
+
+    def test_get_interaction_doc(self):
+        self.assertGreater(
+            len(self.registry.get_interaction_doc(self.target, IsEnabled)), 0
+        )
+
+    def test_get_location_solver(self):
+        # There are currently no solvers
+        with self.assertRaises(LocationNotSupported):
+            self.registry.get_solver(self.target, None)
+
+    def test_get_locations(self):
+        self.assertEqual(self.registry.get_locations(self.target), set())
+
+    def test_error_get_location_doc(self):
+        with self.assertRaises(LocationNotSupported):
+            self.registry.get_location_doc(self.target, None)

--- a/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
@@ -10,6 +10,9 @@
 
 import unittest
 
+from traitsui.testing.tester._abstract_target_registry import (
+    AbstractTargetRegistry,
+)
 from traitsui.testing.tester._ui_tester_registry.default_registry import (
     get_default_registries
 )
@@ -20,10 +23,8 @@ from traitsui.tests._tools import is_null
 class TestDefaultRegistry(unittest.TestCase):
 
     def test_load_default_registries(self):
-        registry = get_default_registries()
-        self.assertIsInstance(registry, TargetRegistry)
-        if not is_null():
-            self.assertGreaterEqual(
-                len(registry._interaction_registry._target_to_key_to_value),
-                1,
-            )
+        registries = get_default_registries()
+        for registry in registries:
+            self.assertIsInstance(registry, AbstractTargetRegistry)
+
+        self.assertGreaterEqual(len(registries), 1)

--- a/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
@@ -16,8 +16,6 @@ from traitsui.testing.tester._abstract_target_registry import (
 from traitsui.testing.tester._ui_tester_registry.default_registry import (
     get_default_registries
 )
-from traitsui.testing.api import TargetRegistry
-from traitsui.tests._tools import is_null
 
 
 class TestDefaultRegistry(unittest.TestCase):

--- a/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/tests/test_default_registry.py
@@ -11,7 +11,7 @@
 import unittest
 
 from traitsui.testing.tester._ui_tester_registry.default_registry import (
-    get_default_registry
+    get_default_registries
 )
 from traitsui.testing.api import TargetRegistry
 from traitsui.tests._tools import is_null
@@ -20,7 +20,7 @@ from traitsui.tests._tools import is_null
 class TestDefaultRegistry(unittest.TestCase):
 
     def test_load_default_registries(self):
-        registry = get_default_registry()
+        registry = get_default_registries()
         self.assertIsInstance(registry, TargetRegistry)
         if not is_null():
             self.assertGreaterEqual(

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_control_widget_registry.py
@@ -1,3 +1,13 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
 """ This module provides a getter to obtain an AbstractTargetRegistry that can
 support testing any target whose 'control' attribute refers to a wx.Window.
 """

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_control_widget_registry.py
@@ -1,0 +1,58 @@
+""" This module provides a getter to obtain an AbstractTargetRegistry that can
+support testing any target whose 'control' attribute refers to a wx.Window.
+"""
+import wx
+
+from traitsui.testing.tester._dynamic_target_registry import (
+    DynamicTargetRegistry,
+)
+from traitsui.testing.tester.query import IsEnabled
+
+
+def _handle_is_enabled(wrapper, interaction):
+    """ Return true if the target's control is enabled.
+
+    Parameters
+    ----------
+    wrapper : UIWrapper
+        Wrapper on which the target's control should be a wx.Window
+    interaction : IsEnabled
+        Not currently used.
+    """
+    return wrapper._target.control.IsEnabled()
+
+
+def _is_target_control_a_wx_window(target):
+    """ Return true if the target has a control that is an instance of
+    wx.Window
+
+    Parameters
+    ----------
+    target : any
+        Any UI target
+
+    Returns
+    -------
+    is_accepted : bool
+    """
+    return (
+        hasattr(target, "control")
+        and isinstance(target.control, wx.Window)
+    )
+
+
+def get_widget_registry():
+    """ Return a registry to support any target with an attribute 'control'
+    that is an instance of wx.Window.
+
+    Returns
+    -------
+    registry : DynamicTargetRegistry
+        A registry that can be used with UIWrapper
+    """
+    return DynamicTargetRegistry(
+        can_support=_is_target_control_a_wx_window,
+        interaction_to_handler={
+            IsEnabled: _handle_is_enabled,
+        }
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/button_editor.py
@@ -12,7 +12,7 @@ import wx
 
 from traitsui.wx.button_editor import SimpleEditor, CustomEditor
 from traitsui.testing.tester.command import MouseClick
-from traitsui.testing.tester.query import DisplayedText, IsEnabled
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -70,12 +70,6 @@ def register(registry):
     )
 
     registry.register_interaction(
-        target_class=SimpleEditor,
-        interaction_class=IsEnabled,
-        handler=lambda wrapper, _: wrapper._target.control.IsEnabled()
-    )
-
-    registry.register_interaction(
         target_class=CustomEditor,
         interaction_class=MouseClick,
         handler=mouse_click_ImageButton
@@ -85,10 +79,4 @@ def register(registry):
         target_class=CustomEditor,
         interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
-    )
-
-    registry.register_interaction(
-        target_class=CustomEditor,
-        interaction_class=IsEnabled,
-        handler=lambda wrapper, _: wrapper._target.control.IsEnabled()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/ui_base.py
@@ -10,7 +10,7 @@
 
 from traitsui.wx.ui_base import ButtonEditor
 from traitsui.testing.tester.command import MouseClick
-from traitsui.testing.tester.query import DisplayedText, IsEnabled
+from traitsui.testing.tester.query import DisplayedText
 from traitsui.testing.tester._ui_tester_registry.wx import _interaction_helpers
 
 
@@ -36,10 +36,4 @@ def register(registry):
         target_class=ButtonEditor,
         interaction_class=DisplayedText,
         handler=lambda wrapper, _: wrapper._target.control.GetLabel()
-    )
-
-    registry.register_interaction(
-        target_class=ButtonEditor,
-        interaction_class=IsEnabled,
-        handler=lambda wrapper, _: wrapper._target.control.IsEnabled()
     )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -24,7 +24,7 @@ from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
 )
 
 
-def get_default_registry():
+def get_default_registries():
     """ Creates a default registry for UITester that is wx specific.
 
     Returns

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -25,13 +25,13 @@ from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
 
 
 def get_default_registries():
-    """ Creates a default registry for UITester that is wx specific.
+    """ Creates the default registries for UITester that are wx specific.
 
     Returns
     -------
-    registry : TargetRegistry
-        The default registry containing implementations for TraitsUI editors
-        that is wx specific.
+    registries : list of AbstractTargetRegistry
+        The default registries containing implementations for TraitsUI editors
+        that are wx specific.
     """
     registry = TargetRegistry()
 
@@ -68,4 +68,4 @@ def get_default_registries():
     # Editor Factory
     editor_factory.register(registry)
 
-    return registry
+    return [registry]

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -22,6 +22,7 @@ from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
     text_editor,
     ui_base,
 )
+from ._control_widget_registry import get_widget_registry
 
 
 def get_default_registries():
@@ -68,4 +69,8 @@ def get_default_registries():
     # Editor Factory
     editor_factory.register(registry)
 
-    return [registry]
+    # More general registry follows more specific registry
+    return [
+        registry,
+        get_widget_registry(),
+    ]

--- a/traitsui/testing/tester/_ui_tester_registry/wx/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/tests/test_control_widget_registry.py
@@ -1,0 +1,86 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Tests for wx.Window's DynamicTargetRegistry
+"""
+
+import unittest
+from unittest import mock
+
+from traitsui.testing.api import IsEnabled
+from traitsui.testing.tester.exceptions import (
+    LocationNotSupported,
+)
+from traitsui.testing.tester.ui_wrapper import UIWrapper
+from traitsui.tests._tools import (
+    is_wx,
+    requires_toolkit,
+    ToolkitName,
+)
+
+try:
+    import wx
+except ImportError:
+    if is_wx():
+        raise
+else:
+    from traitsui.testing.tester._ui_tester_registry.wx._control_widget_registry import (
+        get_widget_registry,
+    )
+
+
+class TargetWithControl:
+    """ An object holding a control attribute."""
+
+    def __init__(self, control):
+        self.control = control
+
+
+@requires_toolkit([ToolkitName.wx])
+class TestWxControlWidgetRegistry(unittest.TestCase):
+
+    def setUp(self):
+        self.widget = wx.Window()
+        self.registry = get_widget_registry()
+        self.target = TargetWithControl(self.widget)
+        self.good_wrapper = UIWrapper(
+            target=self.target,
+            registries=[self.registry],
+        )
+
+    def test_is_enabled(self):
+        self.widget.Enable(True)
+        self.assertTrue(self.good_wrapper.inspect(IsEnabled()))
+
+    def test_get_interactions_good_target(self):
+        self.assertEqual(
+            self.registry.get_interactions(self.target),
+            set([IsEnabled])
+        )
+
+    def test_get_interactions_bad_target(self):
+        self.assertEqual(self.registry.get_interactions(None), set())
+
+    def test_get_interaction_doc(self):
+        self.assertGreater(
+            len(self.registry.get_interaction_doc(self.target, IsEnabled)), 0
+        )
+
+    def test_get_location_solver(self):
+        # There are currently no solvers
+        with self.assertRaises(LocationNotSupported):
+            self.registry.get_solver(self.target, None)
+
+    def test_get_locations(self):
+        self.assertEqual(self.registry.get_locations(self.target), set())
+
+    def test_error_get_location_doc(self):
+        with self.assertRaises(LocationNotSupported):
+            self.registry.get_location_doc(self.target, None)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/tests/test_control_widget_registry.py
@@ -60,26 +60,26 @@ class TestWxControlWidgetRegistry(unittest.TestCase):
 
     def test_get_interactions_good_target(self):
         self.assertEqual(
-            self.registry.get_interactions(self.target),
+            self.registry._get_interactions(self.target),
             set([IsEnabled])
         )
 
     def test_get_interactions_bad_target(self):
-        self.assertEqual(self.registry.get_interactions(None), set())
+        self.assertEqual(self.registry._get_interactions(None), set())
 
     def test_get_interaction_doc(self):
         self.assertGreater(
-            len(self.registry.get_interaction_doc(self.target, IsEnabled)), 0
+            len(self.registry._get_interaction_doc(self.target, IsEnabled)), 0
         )
 
     def test_get_location_solver(self):
         # There are currently no solvers
         with self.assertRaises(LocationNotSupported):
-            self.registry.get_solver(self.target, None)
+            self.registry._get_solver(self.target, None)
 
     def test_get_locations(self):
-        self.assertEqual(self.registry.get_locations(self.target), set())
+        self.assertEqual(self.registry._get_locations(self.target), set())
 
     def test_error_get_location_doc(self):
         with self.assertRaises(LocationNotSupported):
-            self.registry.get_location_doc(self.target, None)
+            self.registry._get_location_doc(self.target, None)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/tests/test_control_widget_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/tests/test_control_widget_registry.py
@@ -12,7 +12,6 @@
 """
 
 import unittest
-from unittest import mock
 
 from traitsui.testing.api import IsEnabled
 from traitsui.testing.tester.exceptions import (
@@ -31,7 +30,7 @@ except ImportError:
     if is_wx():
         raise
 else:
-    from traitsui.testing.tester._ui_tester_registry.wx._control_widget_registry import (
+    from traitsui.testing.tester._ui_tester_registry.wx._control_widget_registry import (   # noqa: E501
         get_widget_registry,
     )
 

--- a/traitsui/testing/tester/target_registry.py
+++ b/traitsui/testing/tester/target_registry.py
@@ -140,7 +140,7 @@ class TargetRegistry(AbstractTargetRegistry):
             value=handler,
         )
 
-    def get_handler(self, target, interaction):
+    def _get_handler(self, target, interaction):
         """ Return a callable for handling an interaction for a given target.
 
         Parameters
@@ -166,7 +166,7 @@ class TargetRegistry(AbstractTargetRegistry):
             key=interaction.__class__,
         )
 
-    def get_interactions(self, target):
+    def _get_interactions(self, target):
         """ Returns all the interactions supported for the given target.
 
         Parameters
@@ -183,7 +183,7 @@ class TargetRegistry(AbstractTargetRegistry):
             target_class=target.__class__
         )
 
-    def get_interaction_doc(self, target, interaction_class):
+    def _get_interaction_doc(self, target, interaction_class):
         """ Return the documentation for the given target and interaction type.
 
         Parameters
@@ -236,7 +236,7 @@ class TargetRegistry(AbstractTargetRegistry):
             value=solver,
         )
 
-    def get_solver(self, target, location):
+    def _get_solver(self, target, location):
         """ Return a callable registered for resolving a location for the
         given target and location.
 
@@ -257,7 +257,7 @@ class TargetRegistry(AbstractTargetRegistry):
             key=location.__class__,
         )
 
-    def get_locations(self, target):
+    def _get_locations(self, target):
         """ Returns all the location types supported for the given target.
 
         Parameters
@@ -272,7 +272,7 @@ class TargetRegistry(AbstractTargetRegistry):
         """
         return self._location_registry.get_keys(target_class=target.__class__)
 
-    def get_location_doc(self, target, locator_class):
+    def _get_location_doc(self, target, locator_class):
         """ Return the documentation for the given target and locator type.
 
         Parameters

--- a/traitsui/testing/tester/target_registry.py
+++ b/traitsui/testing/tester/target_registry.py
@@ -136,22 +136,21 @@ class TargetRegistry:
             value=handler,
         )
 
-    def get_handler(self, target_class, interaction_class):
+    def get_handler(self, target, interaction):
         """ Return a callable for handling an interaction for a given target
         type.
 
         Parameters
         ----------
-        target_class : subclass of type
-            The type of a UI target being operated on.
-        interaction_class : subclass of type
-            Any class.
+        target : any
+            The UI target being operated on.
+        interaction : any
+            Any interaction object.
 
         Returns
         -------
         handler : callable(UIWrapper, interaction) -> any
-            The function to handle the particular interaction on a target.
-            ``interaction`` should be an instance of ``interaction_class``.
+            The function to handle the given interaction on a target.
 
         Raises
         ------
@@ -160,32 +159,34 @@ class TargetRegistry:
             by this registry.
         """
         return self._interaction_registry.get_value(
-            target_class=target_class,
-            key=interaction_class,
+            target_class=target.__class__,
+            key=interaction.__class__,
         )
 
-    def get_interactions(self, target_class):
+    def get_interactions(self, target):
         """ Returns all the interactions supported for the given target type.
 
         Parameters
         ----------
-        target_class : subclass of type
-            The type of a UI target being operated on.
+        target : any
+            The UI target for which supported interactions are queried.
 
         Returns
         -------
         interaction_classes : set
             Supported interaction types for the given target type.
         """
-        return self._interaction_registry.get_keys(target_class=target_class)
+        return self._interaction_registry.get_keys(
+            target_class=target.__class__
+        )
 
-    def get_interaction_doc(self, target_class, interaction_class):
-        """ Return the documentation for the given target and locator type.
+    def get_interaction_doc(self, target, interaction_class):
+        """ Return the documentation for the given target and interaction type.
 
         Parameters
         ----------
-        target_class : subclass of type
-            The type of a UI target being operated on.
+        target : any
+            The UI target for which the interaction will be applied.
         interaction_class : subclass of type
             Any class.
 
@@ -200,7 +201,7 @@ class TargetRegistry:
             by this registry.
         """
         self._interaction_registry.get_value(
-            target_class=target_class,
+            target_class=target.__class__,
             key=interaction_class,
         )
         # This maybe configurable in the future via register_interaction
@@ -232,16 +233,16 @@ class TargetRegistry:
             value=solver,
         )
 
-    def get_solver(self, target_class, locator_class):
+    def get_solver(self, target, location):
         """ Return a callable registered for resolving a location for the
-        given target type and locator type.
+        given target and location.
 
         Parameters
         ----------
-        target_class : subclass of type
-            The type of a UI target being operated on.
-        locator_class : subclass of type
-            Any class.
+        target : any
+            The UI target being operated on.
+        location : subclass of type
+            The location to be resolved on the target.
 
         Raises
         ------
@@ -249,32 +250,32 @@ class TargetRegistry:
             If the given locator and target types are not supported.
         """
         return self._location_registry.get_value(
-            target_class=target_class,
-            key=locator_class,
+            target_class=target.__class__,
+            key=location.__class__,
         )
 
-    def get_locations(self, target_class):
+    def get_locations(self, target):
         """ Returns all the location types supported for the given target type.
 
         Parameters
         ----------
-        target_class : subclass of type
-            The type of a UI target being operated on.
+        target : any
+            The UI target for which supported location types are queried.
 
         Returns
         -------
         locators_classes : set
             Supported locator types for the given target type.
         """
-        return self._location_registry.get_keys(target_class=target_class)
+        return self._location_registry.get_keys(target_class=target.__class__)
 
-    def get_location_doc(self, target_class, locator_class):
+    def get_location_doc(self, target, locator_class):
         """ Return the documentation for the given target and locator type.
 
         Parameters
         ----------
-        target_class : subclass of type
-            The type of a UI target being operated on.
+        target : any
+            The UI target being operated on.
         locator_class : subclass of type
             Any class.
 
@@ -288,7 +289,7 @@ class TargetRegistry:
             If the given locator and target types are not supported.
         """
         self._location_registry.get_value(
-            target_class=target_class,
+            target_class=target.__class__,
             key=locator_class,
         )
         # This maybe configurable in the future via register_location

--- a/traitsui/testing/tester/target_registry.py
+++ b/traitsui/testing/tester/target_registry.py
@@ -14,6 +14,10 @@ implementations for testing various GUI elements.
 
 import inspect
 
+
+from traitsui.testing.tester._abstract_target_registry import (
+    AbstractTargetRegistry,
+)
 from traitsui.testing.tester.exceptions import (
     InteractionNotSupported,
     LocationNotSupported,
@@ -75,7 +79,7 @@ class _TargetToKeyRegistry:
         return set(self._target_to_key_to_value.get(target_class, []))
 
 
-class TargetRegistry:
+class TargetRegistry(AbstractTargetRegistry):
     """ An object for registering interaction and location resolution logic
     for different UI target types.
 
@@ -137,8 +141,7 @@ class TargetRegistry:
         )
 
     def get_handler(self, target, interaction):
-        """ Return a callable for handling an interaction for a given target
-        type.
+        """ Return a callable for handling an interaction for a given target.
 
         Parameters
         ----------
@@ -164,7 +167,7 @@ class TargetRegistry:
         )
 
     def get_interactions(self, target):
-        """ Returns all the interactions supported for the given target type.
+        """ Returns all the interactions supported for the given target.
 
         Parameters
         ----------
@@ -255,7 +258,7 @@ class TargetRegistry:
         )
 
     def get_locations(self, target):
-        """ Returns all the location types supported for the given target type.
+        """ Returns all the location types supported for the given target.
 
         Parameters
         ----------

--- a/traitsui/testing/tester/tests/test_registry.py
+++ b/traitsui/testing/tester/tests/test_registry.py
@@ -22,14 +22,21 @@ from traitsui.testing.tester.exceptions import (
 class TestInteractionRegistry(unittest.TestCase):
 
     def test_registry_empty(self):
+
+        class SpecificTarget:
+            pass
+
+        class Action:
+            pass
+
         registry = TargetRegistry()
         with self.assertRaises(InteractionNotSupported) as exception_context:
-            registry.get_handler(None, None)
+            registry.get_handler(SpecificTarget(), Action())
 
         self.assertEqual(
             str(exception_context.exception),
-            "No handler is found for target None with interaction None. "
-            "Supported these: []",
+            f"No handler is found for target {SpecificTarget!r} with "
+            f"interaction {Action!r}. Supported these: []",
         )
 
     def test_register_editor_with_action(self):
@@ -52,8 +59,41 @@ class TestInteractionRegistry(unittest.TestCase):
         )
 
         # then
-        actual = registry.get_handler(SpecificEditor, UserAction)
+        actual = registry.get_handler(SpecificEditor(), UserAction())
         self.assertIs(actual, handler)
+
+    def test_get_interactions_supported(self):
+        registry = TargetRegistry()
+
+        class SpecificEditor:
+            pass
+
+        class UserAction:
+            pass
+
+        class UserAction2:
+            pass
+
+        def handler(wrapper, interaction):
+            pass
+
+        # when
+        registry.register_interaction(
+            target_class=SpecificEditor,
+            interaction_class=UserAction,
+            handler=handler,
+        )
+        registry.register_interaction(
+            target_class=SpecificEditor,
+            interaction_class=UserAction2,
+            handler=handler,
+        )
+
+        # then
+        self.assertEqual(
+            registry.get_interactions(SpecificEditor()),
+            set([UserAction, UserAction2])
+        )
 
     def test_action_not_supported_report_supported_action(self):
         # Test raise InteractionNotSupported contains information about what
@@ -83,7 +123,7 @@ class TestInteractionRegistry(unittest.TestCase):
         registry.register_interaction(SpecificEditor2, UserAction3, handler)
 
         with self.assertRaises(InteractionNotSupported) as exception_context:
-            registry.get_handler(SpecificEditor2, None)
+            registry.get_handler(SpecificEditor2(), None)
 
         self.assertIn(UserAction2, exception_context.exception.supported)
         self.assertIn(UserAction3, exception_context.exception.supported)
@@ -111,7 +151,7 @@ class TestInteractionRegistry(unittest.TestCase):
         # The registry is empty
         registry = TargetRegistry()
         with self.assertRaises(InteractionNotSupported):
-            registry.get_interaction_doc(float, int)
+            registry.get_interaction_doc(2.1, int)
 
     def test_get_default_interaction_doc(self):
 
@@ -130,7 +170,7 @@ class TestInteractionRegistry(unittest.TestCase):
         )
 
         actual = registry.get_interaction_doc(
-            target_class=float, interaction_class=Action,
+            target=21.2, interaction_class=Action,
         )
         self.assertEqual(actual, "Some action.")
 
@@ -138,14 +178,22 @@ class TestInteractionRegistry(unittest.TestCase):
 class TestLocationRegistry(unittest.TestCase):
 
     def test_location_registry_empty(self):
+
+        class SpecificTarget:
+            pass
+
+        class Locator:
+            pass
+
         registry = TargetRegistry()
         with self.assertRaises(LocationNotSupported) as exception_context:
-            registry.get_solver(None, None)
+            registry.get_solver(SpecificTarget(), Locator())
 
         self.assertEqual(exception_context.exception.supported, [])
         self.assertEqual(
             str(exception_context.exception),
-            "Location None is not supported for None. Supported these: []",
+            f"Location {Locator!r} is not supported for {SpecificTarget!r}. "
+            "Supported these: []",
         )
 
     def test_register_location(self):
@@ -157,7 +205,7 @@ class TestLocationRegistry(unittest.TestCase):
         registry.register_location(
             target_class=float, locator_class=str, solver=solver)
 
-        self.assertIs(registry.get_solver(float, str), solver)
+        self.assertIs(registry.get_solver(2.1, "dummy"), solver)
 
     def test_register_location_report_existing(self):
 
@@ -169,9 +217,43 @@ class TestLocationRegistry(unittest.TestCase):
             target_class=float, locator_class=str, solver=solver)
 
         with self.assertRaises(LocationNotSupported) as exception_context:
-            registry.get_solver(float, None)
+            registry.get_solver(3.4, None)
 
         self.assertEqual(exception_context.exception.supported, [str])
+
+    def test_get_locations_supported(self):
+        # Test get_locations return the supported location types.
+        registry = TargetRegistry()
+
+        class SpecificEditor:
+            pass
+
+        class Locator1:
+            pass
+
+        class Locator2:
+            pass
+
+        def solver(wrapper, location):
+            return 1
+
+        # when
+        registry.register_location(
+            target_class=SpecificEditor,
+            locator_class=Locator1,
+            solver=solver,
+        )
+        registry.register_location(
+            target_class=SpecificEditor,
+            locator_class=Locator2,
+            solver=solver,
+        )
+
+        # then
+        self.assertEqual(
+            registry.get_locations(SpecificEditor()),
+            set([Locator1, Locator2])
+        )
 
     def test_get_location_help_default(self):
 
@@ -187,7 +269,7 @@ class TestLocationRegistry(unittest.TestCase):
         )
 
         help_text = registry.get_location_doc(
-            target_class=float, locator_class=Locator,
+            target=2.345, locator_class=Locator,
         )
         self.assertEqual(help_text, "Some default documentation.")
 
@@ -195,4 +277,4 @@ class TestLocationRegistry(unittest.TestCase):
         # The registry is empty
         registry = TargetRegistry()
         with self.assertRaises(LocationNotSupported):
-            registry.get_location_doc(float, int)
+            registry.get_location_doc(3.456, int)

--- a/traitsui/testing/tester/tests/test_registry.py
+++ b/traitsui/testing/tester/tests/test_registry.py
@@ -92,7 +92,7 @@ class TestInteractionRegistry(unittest.TestCase):
         # then
         self.assertEqual(
             registry._get_interactions(SpecificEditor()),
-            set([UserAction, UserAction2])
+            {UserAction, UserAction2}
         )
 
     def test_action_not_supported_report_supported_action(self):
@@ -252,7 +252,7 @@ class TestLocationRegistry(unittest.TestCase):
         # then
         self.assertEqual(
             registry._get_locations(SpecificEditor()),
-            set([Locator1, Locator2])
+            {Locator1, Locator2}
         )
 
     def test_get_location_help_default(self):

--- a/traitsui/testing/tester/tests/test_registry.py
+++ b/traitsui/testing/tester/tests/test_registry.py
@@ -31,7 +31,7 @@ class TestInteractionRegistry(unittest.TestCase):
 
         registry = TargetRegistry()
         with self.assertRaises(InteractionNotSupported) as exception_context:
-            registry.get_handler(SpecificTarget(), Action())
+            registry._get_handler(SpecificTarget(), Action())
 
         self.assertEqual(
             str(exception_context.exception),
@@ -59,7 +59,7 @@ class TestInteractionRegistry(unittest.TestCase):
         )
 
         # then
-        actual = registry.get_handler(SpecificEditor(), UserAction())
+        actual = registry._get_handler(SpecificEditor(), UserAction())
         self.assertIs(actual, handler)
 
     def test_get_interactions_supported(self):
@@ -91,7 +91,7 @@ class TestInteractionRegistry(unittest.TestCase):
 
         # then
         self.assertEqual(
-            registry.get_interactions(SpecificEditor()),
+            registry._get_interactions(SpecificEditor()),
             set([UserAction, UserAction2])
         )
 
@@ -123,7 +123,7 @@ class TestInteractionRegistry(unittest.TestCase):
         registry.register_interaction(SpecificEditor2, UserAction3, handler)
 
         with self.assertRaises(InteractionNotSupported) as exception_context:
-            registry.get_handler(SpecificEditor2(), None)
+            registry._get_handler(SpecificEditor2(), None)
 
         self.assertIn(UserAction2, exception_context.exception.supported)
         self.assertIn(UserAction3, exception_context.exception.supported)
@@ -151,7 +151,7 @@ class TestInteractionRegistry(unittest.TestCase):
         # The registry is empty
         registry = TargetRegistry()
         with self.assertRaises(InteractionNotSupported):
-            registry.get_interaction_doc(2.1, int)
+            registry._get_interaction_doc(2.1, int)
 
     def test_get_default_interaction_doc(self):
 
@@ -169,7 +169,7 @@ class TestInteractionRegistry(unittest.TestCase):
             handler=handler,
         )
 
-        actual = registry.get_interaction_doc(
+        actual = registry._get_interaction_doc(
             target=21.2, interaction_class=Action,
         )
         self.assertEqual(actual, "Some action.")
@@ -187,7 +187,7 @@ class TestLocationRegistry(unittest.TestCase):
 
         registry = TargetRegistry()
         with self.assertRaises(LocationNotSupported) as exception_context:
-            registry.get_solver(SpecificTarget(), Locator())
+            registry._get_solver(SpecificTarget(), Locator())
 
         self.assertEqual(exception_context.exception.supported, [])
         self.assertEqual(
@@ -205,7 +205,7 @@ class TestLocationRegistry(unittest.TestCase):
         registry.register_location(
             target_class=float, locator_class=str, solver=solver)
 
-        self.assertIs(registry.get_solver(2.1, "dummy"), solver)
+        self.assertIs(registry._get_solver(2.1, "dummy"), solver)
 
     def test_register_location_report_existing(self):
 
@@ -217,12 +217,12 @@ class TestLocationRegistry(unittest.TestCase):
             target_class=float, locator_class=str, solver=solver)
 
         with self.assertRaises(LocationNotSupported) as exception_context:
-            registry.get_solver(3.4, None)
+            registry._get_solver(3.4, None)
 
         self.assertEqual(exception_context.exception.supported, [str])
 
     def test_get_locations_supported(self):
-        # Test get_locations return the supported location types.
+        # Test _get_locations return the supported location types.
         registry = TargetRegistry()
 
         class SpecificEditor:
@@ -251,7 +251,7 @@ class TestLocationRegistry(unittest.TestCase):
 
         # then
         self.assertEqual(
-            registry.get_locations(SpecificEditor()),
+            registry._get_locations(SpecificEditor()),
             set([Locator1, Locator2])
         )
 
@@ -268,7 +268,7 @@ class TestLocationRegistry(unittest.TestCase):
             solver=lambda w, l: 1,
         )
 
-        help_text = registry.get_location_doc(
+        help_text = registry._get_location_doc(
             target=2.345, locator_class=Locator,
         )
         self.assertEqual(help_text, "Some default documentation.")
@@ -277,4 +277,4 @@ class TestLocationRegistry(unittest.TestCase):
         # The registry is empty
         registry = TargetRegistry()
         with self.assertRaises(LocationNotSupported):
-            registry.get_location_doc(3.456, int)
+            registry._get_location_doc(3.456, int)

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -197,17 +197,17 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         wrapper = example_ui_wrapper(
             registries=[registry2, registry1],
         )
-        wrapper = wrapper.locate("some string")
+        new_wrapper = wrapper.locate("some string")
 
-        self.assertEqual(wrapper._target, 2)
+        self.assertEqual(new_wrapper._target, 2)
 
         # swap the order
         wrapper = example_ui_wrapper(
             registries=[registry1, registry2],
         )
-        wrapper = wrapper.locate("some other string")
+        new_wrapper = wrapper.locate("some other string")
 
-        self.assertEqual(wrapper._target, 1)
+        self.assertEqual(new_wrapper._target, 1)
 
     def test_location_registry_selection(self):
         # If the first registry says it can't handle the interaction, the next

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -77,7 +77,7 @@ class StubRegistry(AbstractTargetRegistry):
         self.interaction_doc = interaction_doc
         self.location_doc = location_doc
 
-    def get_handler(self, target, interaction):
+    def _get_handler(self, target, interaction):
         if interaction.__class__ not in self.supported_interaction_classes:
             raise InteractionNotSupported(
                 target_class=target.__class__,
@@ -86,13 +86,13 @@ class StubRegistry(AbstractTargetRegistry):
             )
         return self.handler
 
-    def get_interactions(self, target):
+    def _get_interactions(self, target):
         return set(self.supported_interaction_classes)
 
-    def get_interaction_doc(self, target, interaction_class):
+    def _get_interaction_doc(self, target, interaction_class):
         return self.interaction_doc
 
-    def get_solver(self, target, location):
+    def _get_solver(self, target, location):
         if location.__class__ not in self.supported_locator_classes:
             raise LocationNotSupported(
                 target_class=target.__class__,
@@ -101,10 +101,10 @@ class StubRegistry(AbstractTargetRegistry):
             )
         return self.solver
 
-    def get_locations(self, target):
+    def _get_locations(self, target):
         return set(self.supported_locator_classes)
 
-    def get_location_doc(self, target, locator_class):
+    def _get_location_doc(self, target, locator_class):
         return self.location_doc
 
 

--- a/traitsui/testing/tester/tests/test_ui_wrapper.py
+++ b/traitsui/testing/tester/tests/test_ui_wrapper.py
@@ -22,6 +22,9 @@ from traitsui.tests._tools import (
     requires_toolkit,
     ToolkitName,
 )
+from traitsui.testing.tester._abstract_target_registry import (
+    AbstractTargetRegistry,
+)
 from traitsui.testing.tester.exceptions import (
     InteractionNotSupported,
     LocationNotSupported,
@@ -54,17 +57,55 @@ def example_ui_wrapper(**kwargs):
     return UIWrapper(**values)
 
 
-class StubRegistry:
+class StubRegistry(AbstractTargetRegistry):
+    """ A stub implementation of the AbstractTargetRegistry for testing
+    """
 
-    def __init__(self, handler=None, solver=None):
+    def __init__(
+            self,
+            handler=None,
+            solver=None,
+            supported_interaction_classes=(),
+            supported_locator_classes=(),
+            interaction_doc="",
+            location_doc="",
+            ):
         self.handler = handler
         self.solver = solver
+        self.supported_interaction_classes = supported_interaction_classes
+        self.supported_locator_classes = supported_locator_classes
+        self.interaction_doc = interaction_doc
+        self.location_doc = location_doc
 
-    def get_handler(self, target_class, interaction_class):
+    def get_handler(self, target, interaction):
+        if interaction.__class__ not in self.supported_interaction_classes:
+            raise InteractionNotSupported(
+                target_class=target.__class__,
+                interaction_class=interaction.__class__,
+                supported=list(self.supported_interaction_classes),
+            )
         return self.handler
 
-    def get_solver(self, target_class, locator_class):
+    def get_interactions(self, target):
+        return set(self.supported_interaction_classes)
+
+    def get_interaction_doc(self, target, interaction_class):
+        return self.interaction_doc
+
+    def get_solver(self, target, location):
+        if location.__class__ not in self.supported_locator_classes:
+            raise LocationNotSupported(
+                target_class=target.__class__,
+                locator_class=location.__class__,
+                supported=list(self.supported_locator_classes),
+            )
         return self.solver
+
+    def get_locations(self, target):
+        return set(self.supported_locator_classes)
+
+    def get_location_doc(self, target, locator_class):
+        return self.location_doc
 
 
 # Use of perform/inspect requires the GUI event loop
@@ -76,13 +117,19 @@ class TestUIWrapperInteractionRegistries(unittest.TestCase):
     def test_registry_priority(self):
         # If two registries have a handler for the same target and interaction
         # types, the first register is used.
-        registry1 = StubRegistry(handler=lambda w, l: 1)
-        registry2 = StubRegistry(handler=lambda w, l: 2)
+        registry1 = StubRegistry(
+            handler=lambda w, l: 1,
+            supported_interaction_classes=[str],
+        )
+        registry2 = StubRegistry(
+            handler=lambda w, l: 2,
+            supported_interaction_classes=[str],
+        )
 
         wrapper = example_ui_wrapper(
             registries=[registry2, registry1],
         )
-        value = wrapper.inspect(None)
+        value = wrapper.inspect("some string")
 
         self.assertEqual(value, 2)
 
@@ -90,7 +137,7 @@ class TestUIWrapperInteractionRegistries(unittest.TestCase):
         wrapper = example_ui_wrapper(
             registries=[registry1, registry2]
         )
-        value = wrapper.inspect(None)
+        value = wrapper.inspect("some other string")
 
         self.assertEqual(value, 1)
 
@@ -98,22 +145,17 @@ class TestUIWrapperInteractionRegistries(unittest.TestCase):
         # If the first registry says it can't handle the interaction, the next
         # registry is tried.
 
-        class EmptyRegistry:
-            def get_handler(self, target_class, interaction_class):
-                raise InteractionNotSupported(
-                    target_class=None,
-                    interaction_class=None,
-                    supported=[],
-                )
-
-        registry1 = EmptyRegistry()
+        registry1 = StubRegistry()
         registry2_handler = mock.Mock()
-        registry2 = StubRegistry(handler=registry2_handler)
+        registry2 = StubRegistry(
+            handler=registry2_handler,
+            supported_interaction_classes=[int],
+        )
 
         wrapper = example_ui_wrapper(
             registries=[registry1, registry2],
         )
-        wrapper.perform(None)
+        wrapper.perform(123)
 
         self.assertEqual(registry2_handler.call_count, 1)
 
@@ -122,26 +164,11 @@ class TestUIWrapperInteractionRegistries(unittest.TestCase):
         # exception raised provide information on what actions are
         # supported.
 
-        class EmptyRegistry1:
-
-            def get_handler(self, target_class, interaction_class):
-                raise InteractionNotSupported(
-                    target_class=None,
-                    interaction_class=None,
-                    supported=[int],
-                )
-
-        class EmptyRegistry2:
-
-            def get_handler(self, target_class, interaction_class):
-                raise InteractionNotSupported(
-                    target_class=None,
-                    interaction_class=None,
-                    supported=[float],
-                )
-
         wrapper = example_ui_wrapper(
-            registries=[EmptyRegistry1(), EmptyRegistry2()],
+            registries=[
+                StubRegistry(supported_interaction_classes=[int]),
+                StubRegistry(supported_interaction_classes=[float]),
+            ],
         )
         with self.assertRaises(InteractionNotSupported) as exception_context:
             wrapper.perform(None)
@@ -158,14 +185,19 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
     """ Test the use of registries with locate. """
 
     def test_location_registry_priority(self):
-
-        registry1 = StubRegistry(solver=lambda w, l: 1)
-        registry2 = StubRegistry(solver=lambda w, l: 2)
+        registry1 = StubRegistry(
+            solver=lambda w, l: 1,
+            supported_locator_classes=[str],
+        )
+        registry2 = StubRegistry(
+            solver=lambda w, l: 2,
+            supported_locator_classes=[str],
+        )
 
         wrapper = example_ui_wrapper(
             registries=[registry2, registry1],
         )
-        wrapper = wrapper.locate(None)
+        wrapper = wrapper.locate("some string")
 
         self.assertEqual(wrapper._target, 2)
 
@@ -173,7 +205,7 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         wrapper = example_ui_wrapper(
             registries=[registry1, registry2],
         )
-        wrapper = wrapper.locate(None)
+        wrapper = wrapper.locate("some other string")
 
         self.assertEqual(wrapper._target, 1)
 
@@ -181,24 +213,19 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         # If the first registry says it can't handle the interaction, the next
         # registry is tried.
 
-        class EmptyRegistry:
-            def get_solver(self, target_class, locator_class):
-                raise LocationNotSupported(
-                    target_class=None,
-                    locator_class=None,
-                    supported=[],
-                )
-
         def solver2(wrapper, location):
             return 2
 
-        registry1 = EmptyRegistry()
-        registry2 = StubRegistry(solver=solver2)
+        registry1 = StubRegistry()
+        registry2 = StubRegistry(
+            solver=solver2,
+            supported_locator_classes=[str],
+        )
 
         wrapper = example_ui_wrapper(
             registries=[registry1, registry2],
         )
-        new_wrapper = wrapper.locate(None)
+        new_wrapper = wrapper.locate("some string")
 
         self.assertEqual(new_wrapper._target, 2)
         self.assertEqual(
@@ -211,24 +238,11 @@ class TestUIWrapperLocationRegistry(unittest.TestCase):
         # exception raised provide information on what actions are
         # supported.
 
-        class EmptyRegistry1:
-            def get_solver(self, target_class, locator_class):
-                raise LocationNotSupported(
-                    target_class=None,
-                    locator_class=None,
-                    supported=[int],
-                )
-
-        class EmptyRegistry2:
-            def get_solver(self, target_class, locator_class):
-                raise LocationNotSupported(
-                    target_class=None,
-                    locator_class=None,
-                    supported=[float],
-                )
-
         wrapper = example_ui_wrapper(
-            registries=[EmptyRegistry1(), EmptyRegistry2()],
+            registries=[
+                StubRegistry(supported_locator_classes=[int]),
+                StubRegistry(supported_locator_classes=[float]),
+            ],
         )
         with self.assertRaises(LocationNotSupported) as exception_context:
             wrapper.locate(None)
@@ -301,42 +315,18 @@ class TestUIWrapperHelp(unittest.TestCase):
         # The first registry in the list has the highest priority
         # The last registry in the list has the least priority
 
-        class HighPriorityRegistry(TargetRegistry):
-            def get_interaction_doc(self, target_class, interaction_class):
-                return "Interaction: I get a higher priority."
-
-            def get_location_doc(self, target_class, interaction_class):
-                return "Location: I get a higher priority."
-
-        class LowPriorityRegistry(TargetRegistry):
-            def get_interaction_doc(self, target_class, interaction_class):
-                return "Interaction: I get a lower priority."
-
-            def get_location_doc(self, target_class, interaction_class):
-                return "Location: I get a lower priority."
-
-        high_priority_registry = HighPriorityRegistry()
-        high_priority_registry.register_interaction(
-            target_class=str,
-            interaction_class=float,
-            handler=mock.Mock(),
-        )
-        high_priority_registry.register_location(
-            target_class=str,
-            locator_class=str,
-            solver=mock.Mock(),
+        high_priority_registry = StubRegistry(
+            supported_locator_classes=[str],
+            supported_interaction_classes=[float],
+            interaction_doc="Interaction: I get a higher priority.",
+            location_doc="Location: I get a higher priority.",
         )
 
-        low_priority_registry = LowPriorityRegistry()
-        low_priority_registry.register_interaction(
-            target_class=str,
-            interaction_class=float,
-            handler=mock.Mock(),
-        )
-        low_priority_registry.register_location(
-            target_class=str,
-            locator_class=str,
-            solver=mock.Mock(),
+        low_priority_registry = StubRegistry(
+            supported_locator_classes=[str],
+            supported_interaction_classes=[float],
+            interaction_doc="Interaction: I get a lower priority.",
+            location_doc="Location: I get a lower priority.",
         )
 
         # Put higher priority registry first.
@@ -411,11 +401,16 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
             gui.set_trait_later(model, "number", 2)
 
         wrapper = example_ui_wrapper(
-            registries=[StubRegistry(handler=handler)],
+            registries=[
+                StubRegistry(
+                    handler=handler,
+                    supported_interaction_classes=[float],
+                ),
+            ],
         )
 
         with self.assertTraitChanges(model, "number"):
-            wrapper.perform(None)
+            wrapper.perform(2.123)
 
     def test_event_processed_prior_to_resolving_location(self):
         # Test GUI events are processed prior to resolving location
@@ -427,10 +422,15 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
             return model.number
 
         wrapper = example_ui_wrapper(
-            registries=[StubRegistry(solver=solver)],
+            registries=[
+                StubRegistry(
+                    solver=solver,
+                    supported_locator_classes=[float],
+                )
+            ],
         )
 
-        new_wrapper = wrapper.locate(None)
+        new_wrapper = wrapper.locate(4.567)
         self.assertEqual(new_wrapper._target, 2)
 
     def test_event_processed_with_exception_captured(self):
@@ -445,11 +445,15 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
             gui.invoke_later(raise_error)
 
         wrapper = example_ui_wrapper(
-            registries=[StubRegistry(handler=handler)],
+            registries=[
+                StubRegistry(
+                    handler=handler,
+                    supported_interaction_classes=[float],
+                ),
+            ],
         )
-
         with self.assertRaises(RuntimeError), self.assertLogs("traitsui"):
-            wrapper.perform(None)
+            wrapper.perform(1.234)
 
     def test_exception_not_in_gui(self):
         # Exceptions from code executed outside of the event loop are
@@ -459,11 +463,16 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
             raise ZeroDivisionError()
 
         wrapper = example_ui_wrapper(
-            registries=[StubRegistry(handler=handler)],
+            registries=[
+                StubRegistry(
+                    handler=handler,
+                    supported_interaction_classes=[float],
+                ),
+            ],
         )
 
         with self.assertRaises(ZeroDivisionError):
-            wrapper.perform(None)
+            wrapper.perform(9.99)
 
     def test_perform_event_processed_optional(self):
         # Allow event processing to be switched off.
@@ -474,13 +483,18 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
             gui.invoke_later(side_effect)
 
         wrapper = example_ui_wrapper(
-            registries=[StubRegistry(handler=handler)],
+            registries=[
+                StubRegistry(
+                    handler=handler,
+                    supported_interaction_classes=[float],
+                ),
+            ],
             auto_process_events=False,
         )
 
         # With auto_process_events set to False, events are not automatically
         # processed.
-        wrapper.perform(None)
+        wrapper.perform(12.345)
         self.addCleanup(process_cascade_events)
 
         self.assertEqual(side_effect.call_count, 0)
@@ -496,13 +510,18 @@ class TestUIWrapperEventProcessed(unittest.TestCase, UnittestTools):
             return 1
 
         wrapper = example_ui_wrapper(
-            registries=[StubRegistry(solver=solver)],
+            registries=[
+                StubRegistry(
+                    solver=solver,
+                    supported_locator_classes=[float],
+                ),
+            ],
             auto_process_events=False,
         )
 
         # With auto_process_events set to False, events are not automatically
         # processed.
-        new_wrapper = wrapper.locate(None)
+        new_wrapper = wrapper.locate(1.234)
 
         self.assertEqual(side_effect.call_count, 0)
         self.assertFalse(new_wrapper._auto_process_events)

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -16,7 +16,7 @@ import contextlib
 from traitsui.testing._gui import process_cascade_events
 from traitsui.testing._exception_handling import reraise_exceptions
 from traitsui.testing.tester._ui_tester_registry.default_registry import (
-    get_default_registry
+    get_default_registries
 )
 from traitsui.testing.tester.ui_wrapper import UIWrapper
 
@@ -62,7 +62,7 @@ class UITester:
         # This registry contributes the support for TraitsUI UI and editors.
         # The find_by_name/find_by_id methods in this class also depend on
         # this registry.
-        self._registries.append(get_default_registry())
+        self._registries.append(get_default_registries())
         self.delay = delay
         self._auto_process_events = auto_process_events
 

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -32,7 +32,7 @@ class UITester:
     registries : list of TargetRegistry, optional
         Registries of interaction for different targets, in the order
         of decreasing priority. If provided, a shallow copy will be made.
-        A default registry is always appended to the list to provide
+        Additional registries are appended to the list to provide
         builtin support for TraitsUI UI and editors.
     delay : int, optional
         Time delay (in ms) in which actions by the tester are performed. Note
@@ -59,9 +59,9 @@ class UITester:
         else:
             self._registries = registries.copy()
 
-        # This registry contributes the support for TraitsUI UI and editors.
+        # These registries contribute the support for TraitsUI UI and editors.
         # The find_by_name/find_by_id methods in this class also depend on
-        # this registry.
+        # one of these registries.
         self._registries.extend(get_default_registries())
         self.delay = delay
         self._auto_process_events = auto_process_events

--- a/traitsui/testing/tester/ui_tester.py
+++ b/traitsui/testing/tester/ui_tester.py
@@ -62,7 +62,7 @@ class UITester:
         # This registry contributes the support for TraitsUI UI and editors.
         # The find_by_name/find_by_id methods in this class also depend on
         # this registry.
-        self._registries.append(get_default_registries())
+        self._registries.extend(get_default_registries())
         self.delay = delay
         self._auto_process_events = auto_process_events
 

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -54,7 +54,7 @@ class UIWrapper:
     target : any
         An object on which further UI target can be searched for, or can be
         a leaf target that can be operated on.
-    registries : list of TargetRegistry
+    registries : list of AbstractTargetRegistry
         Registries of interaction for different target, in the order
         of decreasing priority.
     delay : int, optional
@@ -101,13 +101,17 @@ class UIWrapper:
 
         # Order registries by their priority (low to high)
         for registry in self._registries[::-1]:
-            for type_ in registry.get_interactions(self._target.__class__):
+            for type_ in registry.get_interactions(self._target):
                 interaction_to_doc[type_] = registry.get_interaction_doc(
-                    self._target.__class__, type_)
+                    target=self._target,
+                    interaction_class=type_,
+                )
 
-            for type_ in registry.get_locations(self._target.__class__):
+            for type_ in registry.get_locations(self._target):
                 location_to_doc[type_] = registry.get_location_doc(
-                    self._target.__class__, type_)
+                    target=self._target,
+                    locator_class=type_,
+                )
 
         print("Interactions")
         print("------------")
@@ -290,13 +294,12 @@ class UIWrapper:
             If the given interaction does not have a corresponding
             implementation for the wrapped UI target.
         """
-        interaction_class = interaction.__class__
         supported = []
         for registry in self._registries:
             try:
                 handler = registry.get_handler(
-                    target_class=self._target.__class__,
-                    interaction_class=interaction_class,
+                    target=self._target,
+                    interaction=interaction,
                 )
             except InteractionNotSupported as e:
                 supported.extend(e.supported)
@@ -337,8 +340,8 @@ class UIWrapper:
         for registry in self._registries:
             try:
                 handler = registry.get_solver(
-                    self._target.__class__,
-                    location.__class__,
+                    target=self._target,
+                    location=location,
                 )
             except LocationNotSupported as e:
                 supported |= set(e.supported)

--- a/traitsui/testing/tester/ui_wrapper.py
+++ b/traitsui/testing/tester/ui_wrapper.py
@@ -101,14 +101,14 @@ class UIWrapper:
 
         # Order registries by their priority (low to high)
         for registry in self._registries[::-1]:
-            for type_ in registry.get_interactions(self._target):
-                interaction_to_doc[type_] = registry.get_interaction_doc(
+            for type_ in registry._get_interactions(self._target):
+                interaction_to_doc[type_] = registry._get_interaction_doc(
                     target=self._target,
                     interaction_class=type_,
                 )
 
-            for type_ in registry.get_locations(self._target):
-                location_to_doc[type_] = registry.get_location_doc(
+            for type_ in registry._get_locations(self._target):
+                location_to_doc[type_] = registry._get_location_doc(
                     target=self._target,
                     locator_class=type_,
                 )
@@ -297,7 +297,7 @@ class UIWrapper:
         supported = []
         for registry in self._registries:
             try:
-                handler = registry.get_handler(
+                handler = registry._get_handler(
                     target=self._target,
                     interaction=interaction,
                 )
@@ -339,7 +339,7 @@ class UIWrapper:
         supported = set()
         for registry in self._registries:
             try:
-                handler = registry.get_solver(
+                handler = registry._get_solver(
                     target=self._target,
                     location=location,
                 )

--- a/traitsui/tests/editors/test_enum_editor.py
+++ b/traitsui/tests/editors/test_enum_editor.py
@@ -27,6 +27,7 @@ from traitsui.testing.api import (
     Disabled,
     DisplayedText,
     Index,
+    IsEnabled,
     KeyClick,
     KeySequence,
     MouseClick,
@@ -340,6 +341,7 @@ class TestSimpleEnumEditor(BaseTestMixin, unittest.TestCase):
                 combobox.perform(KeyClick("Enter"))
             with self.assertRaises(Disabled):
                 combobox.perform(KeySequence("two"))
+            self.assertFalse(combobox.inspect(IsEnabled()))
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])


### PR DESCRIPTION
This is a draft PR to show implementations and API that would solve #1418.

Narrow goal:
- Allow alternative registries to be written in order to support testing `IsEnabled` check on any QWidget or wx.Window

Wider goal:
- Allow more flexibility in extending of the testing API

Changes:
- All the `get_*` methods on the current `TargetRegistry` are extracted to an interface, `AbstractTargetRegistry`. Any objects that implement the interface can be a registry given to `UIWrapper`.
- Some of the arguments in the `get_*` methods that used to require the type of `UIWrapper._target` is now changed to just an instance. While this adds requirements on the information required by a registry, `UIWrapper._target` is always an instance so that information is almost always available.
- A `DynamicTargetRegistry` is added. Both the existing `TargetRegistry` and the new `DynamicTargetRegistry` implement the interface.
- `UITester` now extends the given custom registries with more than one built-in registries. One of the those built-in registries is a `DynamicTargetRegistry`. On Qt, such registry supports querying for `QWidget.isEnabled()`. On wx, such registry supports `wx.Window.IsEnabled()`. With that `get_default_registry` is changed to `get_default_registries` to return a list instead of a single registry.
- The specific implementation of `IsEnabled` for `ButtonEditor` is replaced by the more general registry.

Note:
- As noted in #1418, the change in parameter types on `TargetRegistry.get_*` is strictly speaking a change to the public API. However I believe these methods are only called by `UIWrapper` and is hardly useful otherwise, so it is unlikely to break downstream code. We should probably rename the methods to mark them as internal though.
- It will be easy to add support for `IsVisible` after the changes in this PR (https://github.com/enthought/traitsui/issues/1291)
- Very early on there was an abstract base class in my draft implementation for the `testing` package... that abstract base class was killed early to defer decisions on generalizing an interface. With a concrete use case, the resulting interface here is different from that old one. I'm glad to have avoided early generalization/abstraction.

With regret, I will be closing this PR (without merging) once it is good enough to be kept for future reference. This was due to my lack of availability and I would not want to keep a PR open unless I know I can commit to follow through with it. I hope that this PR, as a record, helps solving #1418 in the future.

I will be pushing a few more changes before I close it. 
Comments are very welcome any time!