### PR TITLE
Fix link for installing wxPython on CI (for etsdemo)

### DIFF
--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -204,7 +204,7 @@ def install(runtime, toolkit, environment, editable):
         else:
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 wxPython"   # noqa: E501
+                "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 wxPython"   # noqa: E501
             )
 
     click.echo("Creating environment '{environment}'".format(**parameters))


### PR DESCRIPTION
Currently Travis CI setup install etsdemo for the wx toolkit (because it is otherwise to break it out in a single config file), but the install step fails at the point of installing `wxPython`. We still expect tests to fail/error for the wx toolkit for the etsdemo application though.

This is a quick fix to get CI to at least run the tests. We need a better solution to replace this hardcoded ubuntu version in the install command.

(Note that this PR is independent of TraitsUI, but the CI between TraitsUI and etsdemo are tied.)