### PR TITLE
Formal editor interface for tooltips

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,7 +111,7 @@ pygments_style = 'sphinx'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "TraitsUI {} User Manual".format(version.split('.')[0])
+html_title = "TraitsUI {} Documentation".format(version.split('.')[0])
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -173,6 +173,25 @@ class Editor(HasPrivateTraits):
         """
         raise NotImplementedError("This method must be overriden.")
 
+    def set_tooltip(self, control=None):
+        """ Sets the tooltip for a specified toolkit control.
+
+        This method must be overriden by subclasses.  The tooltip_text
+        method can be used to get a suitable value for the tooltip
+        text.
+
+        Parameters
+        ----------
+        control : toolkit control
+            The toolkit control that is having the tooltip set.
+
+        Returns
+        -------
+        tooltip_set : bool
+            Whether or not a tooltip value could be set.
+        """
+        raise NotImplementedError("This method must be overriden.")
+
     def string_value(self, value, format_func=None):
         """ Returns the text representation of a specified object trait value.
 
@@ -405,6 +424,31 @@ class Editor(HasPrivateTraits):
             object = self.context_object
 
         return (object, name, partial(xgetattr, object, name))
+
+    def tooltip_text(self):
+        """ Get the text for a tooltip, checking various sources.
+
+        This checks for text from, in order:
+
+        - the editor's description trait
+        - the base trait's 'tooltip' metdata
+        - the base trait's 'desc' metadata
+
+        Returns
+        -------
+        text : str or None
+            The text for the tooltip, or None if no suitable text can
+            be found.
+        """
+        text = self.description
+        if not text:
+            trait = self.object.base_trait(self.name)
+            text = trait.tooltip
+            if text is None:
+                text = trait.desc
+                if text is not None:
+                    text = "Specifies " + text
+        return text
 
     # -- Utility context managers --------------------------------------------
 

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -176,9 +176,7 @@ class Editor(HasPrivateTraits):
     def set_tooltip_text(self, control, text):
         """ Sets the tooltip for a toolkit control to the provided text.
 
-        This method must be overriden by subclasses.  The tooltip_text
-        method can be used to get a suitable value for the tooltip
-        text.
+        This method must be overriden by subclasses.
 
         Parameters
         ----------

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -462,15 +462,21 @@ class Editor(HasPrivateTraits):
             The text for the tooltip, or None if no suitable text can
             be found.
         """
-        text = self.description
-        if not text:
-            trait = self.object.base_trait(self.name)
-            text = trait.tooltip
-            if text is None:
-                text = trait.desc
-                if text is not None:
-                    text = "Specifies " + text
-        return text
+
+        if self.description:
+            return self.description
+
+        base_trait = self.object.base_trait(self.name)
+
+        text = base_trait.tooltip
+        if text is not None:
+            return text
+
+        text = base_trait.desc
+        if text is not None:
+            return "Specifies " + text
+
+        return None
 
     # -- Utility context managers --------------------------------------------
 

--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -173,8 +173,8 @@ class Editor(HasPrivateTraits):
         """
         raise NotImplementedError("This method must be overriden.")
 
-    def set_tooltip(self, control=None):
-        """ Sets the tooltip for a specified toolkit control.
+    def set_tooltip_text(self, control, text):
+        """ Sets the tooltip for a toolkit control to the provided text.
 
         This method must be overriden by subclasses.  The tooltip_text
         method can be used to get a suitable value for the tooltip
@@ -182,13 +182,10 @@ class Editor(HasPrivateTraits):
 
         Parameters
         ----------
+        text : str
+            The text to use for the tooltip.
         control : toolkit control
             The toolkit control that is having the tooltip set.
-
-        Returns
-        -------
-        tooltip_set : bool
-            Whether or not a tooltip value could be set.
         """
         raise NotImplementedError("This method must be overriden.")
 
@@ -424,6 +421,33 @@ class Editor(HasPrivateTraits):
             object = self.context_object
 
         return (object, name, partial(xgetattr, object, name))
+
+    def set_tooltip(self, control=None):
+        """ Sets the tooltip for a specified toolkit control.
+
+        This uses the tooltip_text method to get the text to use.
+
+        Parameters
+        ----------
+        control : optional toolkit control
+            The toolkit control that is having the tooltip set.  If None
+            then the editor's control is used.
+
+        Returns
+        -------
+        tooltip_set : bool
+            Whether or not a tooltip value could be set.
+        """
+        text = self.tooltip_text()
+        if text is None:
+            return False
+
+        if control is None:
+            control = self.control
+
+        self.set_tooltip_text(control, text)
+
+        return True
 
     def tooltip_text(self):
         """ Get the text for a tooltip, checking various sources.

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -82,19 +82,10 @@ class Editor(UIEditor):
             control, self.description + " value error", str(excp)
         )
 
-    def set_tooltip(self, control=None):
+    def set_tooltip_text(self, control, text):
         """ Sets the tooltip for a specified control.
         """
-        text = self.tooltip_text()
-        if text is None:
-            return False
-
-        if control is None:
-            control = self.control
-
         control.setToolTip(text)
-
-        return True
 
     def _enabled_changed(self, enabled):
         """Handles the **enabled** state of the editor being changed.

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -85,20 +85,14 @@ class Editor(UIEditor):
     def set_tooltip(self, control=None):
         """ Sets the tooltip for a specified control.
         """
-        desc = self.description
-        if desc == "":
-            desc = self.object.base_trait(self.name).tooltip
-            if desc is None:
-                desc = self.object.base_trait(self.name).desc
-                if desc is None:
-                    return False
-
-                desc = "Specifies " + desc
+        text = self.tooltip_text()
+        if text is None:
+            return False
 
         if control is None:
             control = self.control
 
-        control.setToolTip(desc)
+        control.setToolTip(text)
 
         return True
 

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -510,6 +510,24 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
             editor.dispose()
             raise
 
+    def test_tooltip_other_control(self):
+        context = {
+            "object": UserObject(),
+        }
+        editor = create_editor(context=context, description="a tooltip")
+        editor.prepare(None)
+
+        # test tooltip text
+        try:
+            other_control = FakeControl()
+            set_tooltip_result = editor.set_tooltip(other_control)
+
+            self.assertTrue(set_tooltip_result)
+            self.assertEqual(other_control.tooltip, "a tooltip")
+        except Exception:
+            editor.dispose()
+            raise
+
     # Test synchronizing built-in trait values between factory
     # and editor.
 

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -36,6 +36,9 @@ class FakeControl(HasTraits):
     #: An event which also can be fired.
     control_event = Event()
 
+    #: The tooltip text for the control.
+    tooltip = Any()
+
 
 class StubEditorFactory(EditorFactory):
     """ A minimal editor factory
@@ -97,6 +100,7 @@ class StubEditor(Editor):
             self.control.on_trait_change(self.update_object, "control_event")
         else:
             self.control.on_trait_change(self.update_object, "control_value")
+        self.set_tooltip()
 
     def dispose(self):
         if self.is_event:
@@ -124,8 +128,8 @@ class StubEditor(Editor):
                 finally:
                     self._no_update = False
 
-    def set_tooltip(self, control=None):
-        pass
+    def set_tooltip_text(self, control, text):
+        control.tooltip = text
 
     def set_focus(self, parent):
         pass
@@ -420,7 +424,7 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
 
         editor.dispose()
 
-    def test_tooltip_text_default(self):
+    def test_tooltip_default(self):
         context = {
             "object": UserObject(),
         }
@@ -429,13 +433,18 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
 
         # test tooltip text
         try:
+            self.assertIsNone(editor.control.tooltip)
+
             tooltip_text = editor.tooltip_text()
             self.assertIsNone(tooltip_text)
+
+            set_tooltip_result = editor.set_tooltip()
+            self.assertFalse(set_tooltip_result)
         except Exception:
             editor.dispose()
             raise
 
-    def test_tooltip_text_with_description(self):
+    def test_tooltip_from_description(self):
         context = {
             "object": UserObject(),
         }
@@ -444,8 +453,13 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
 
         # test tooltip text
         try:
+            self.assertEqual(editor.control.tooltip, "a tooltip")
+
             tooltip_text = editor.tooltip_text()
             self.assertEqual(tooltip_text, "a tooltip")
+
+            set_tooltip_result = editor.set_tooltip()
+            self.assertTrue(set_tooltip_result)
         except Exception:
             editor.dispose()
             raise
@@ -459,8 +473,13 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
 
         # test tooltip text
         try:
+            self.assertEqual(editor.control.tooltip, "a tooltip")
+
             tooltip_text = editor.tooltip_text()
             self.assertEqual(tooltip_text, "a tooltip")
+
+            set_tooltip_result = editor.set_tooltip()
+            self.assertTrue(set_tooltip_result)
         except Exception:
             editor.dispose()
             raise
@@ -474,8 +493,19 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
 
         # test tooltip text
         try:
+            self.assertEqual(
+                editor.control.tooltip,
+                "Specifies a trait with desc metadata",
+            )
+
             tooltip_text = editor.tooltip_text()
-            self.assertEqual(tooltip_text, "Specifies a trait with desc metadata")
+            self.assertEqual(
+                tooltip_text,
+                "Specifies a trait with desc metadata",
+            )
+
+            set_tooltip_result = editor.set_tooltip()
+            self.assertTrue(set_tooltip_result)
         except Exception:
             editor.dispose()
             raise

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -124,6 +124,9 @@ class StubEditor(Editor):
                 finally:
                     self._no_update = False
 
+    def set_tooltip(self, control=None):
+        pass
+
     def set_focus(self, parent):
         pass
 
@@ -137,8 +140,14 @@ class UserObject(HasTraits):
     #: An auxiliary user value
     user_auxiliary = Any(10)
 
-    #: An list user value
+    #: A list user value
     user_list = List(["one", "two", "three"])
+
+    #: A trait with desc metadata.
+    user_desc = Any("test", desc="a trait with desc metadata")
+
+    #: A trait with tooltip metadata.
+    user_tooltip = Any("test", tooltip="a tooltip")
 
     #: An event user value
     user_event = Event()
@@ -153,6 +162,7 @@ def create_editor(
         name="user_value",
         factory=None,
         is_event=False,
+        description="",
 ):
     if context is None:
         user_object = UserObject()
@@ -176,6 +186,7 @@ def create_editor(
         name=name,
         factory=factory,
         object=user_object,
+        description=description,
     )
     return editor
 
@@ -408,6 +419,66 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
         self.assertEqual(value, "other_test")
 
         editor.dispose()
+
+    def test_tooltip_text_default(self):
+        context = {
+            "object": UserObject(),
+        }
+        editor = create_editor(context=context)
+        editor.prepare(None)
+
+        # test tooltip text
+        try:
+            tooltip_text = editor.tooltip_text()
+            self.assertIsNone(tooltip_text)
+        except Exception:
+            editor.dispose()
+            raise
+
+    def test_tooltip_text_with_description(self):
+        context = {
+            "object": UserObject(),
+        }
+        editor = create_editor(context=context, description="a tooltip")
+        editor.prepare(None)
+
+        # test tooltip text
+        try:
+            tooltip_text = editor.tooltip_text()
+            self.assertEqual(tooltip_text, "a tooltip")
+        except Exception:
+            editor.dispose()
+            raise
+
+    def test_tooltip_text_with_tooltip(self):
+        context = {
+            "object": UserObject(),
+        }
+        editor = create_editor(context=context, name='user_tooltip')
+        editor.prepare(None)
+
+        # test tooltip text
+        try:
+            tooltip_text = editor.tooltip_text()
+            self.assertEqual(tooltip_text, "a tooltip")
+        except Exception:
+            editor.dispose()
+            raise
+
+    def test_tooltip_text_with_desc(self):
+        context = {
+            "object": UserObject(),
+        }
+        editor = create_editor(context=context, name='user_desc')
+        editor.prepare(None)
+
+        # test tooltip text
+        try:
+            tooltip_text = editor.tooltip_text()
+            self.assertEqual(tooltip_text, "Specifies a trait with desc metadata")
+        except Exception:
+            editor.dispose()
+            raise
 
     # Test synchronizing built-in trait values between factory
     # and editor.

--- a/traitsui/wx/editor.py
+++ b/traitsui/wx/editor.py
@@ -79,20 +79,14 @@ class Editor(UIEditor):
     def set_tooltip(self, control=None):
         """ Sets the tooltip for a specified control.
         """
-        desc = self.description
-        if desc == "":
-            desc = self.object.base_trait(self.name).tooltip
-            if desc is None:
-                desc = self.object.base_trait(self.name).desc
-                if desc is None:
-                    return False
-
-                desc = "Specifies " + desc
+        text = self.tooltip_text()
+        if text is None:
+            return False
 
         if control is None:
             control = self.control
 
-        control.SetToolTip(desc)
+        control.SetToolTip(text)
 
         return True
 

--- a/traitsui/wx/editor.py
+++ b/traitsui/wx/editor.py
@@ -76,19 +76,10 @@ class Editor(UIEditor):
         dlg.ShowModal()
         dlg.Destroy()
 
-    def set_tooltip(self, control=None):
+    def set_tooltip_text(self, control, text):
         """ Sets the tooltip for a specified control.
         """
-        text = self.tooltip_text()
-        if text is None:
-            return False
-
-        if control is None:
-            control = self.control
-
         control.SetToolTip(text)
-
-        return True
 
     def _enabled_changed(self, enabled):
         """ Handles the **enabled** state of the editor being changed.


### PR DESCRIPTION
This is a refactor/cleanup that does a number of things:

- makes the tooltip methods a formal part of the base `Editor` interface.  Previously these were supplied by the base toolkit implementations of the Editor classes, so they were there but not documented.
- moves out the logic for finding the tooltip text into its own method (which could be overridden if needed)
- moves out the toolkit-specific code into its own abstract method and making `set_tooltip` a method on the base `Editor` class, removing all duplicated code
- adds tests

There are strategic code-generation reasons why I want this done, but hopefully it is useful enough to stand as a clean-up action.
