### PR TITLE
Qt InstanceEditor button should never be the default

### DIFF
--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -422,6 +422,7 @@ class SimpleEditor(CustomEditor):
         """ Creates the editor control (a button).
         """
         self._button = QtGui.QPushButton()
+        self._button.setAutoDefault(False)
         layout.addWidget(self._button)
         self._button.clicked.connect(self.edit_instance)
         # Make sure the editor is properly disposed if parent UI is closed


### PR DESCRIPTION
Fixes #1475.

Not sure how to test this apart from a manual check.