### PR TITLE
Propagate UI errors to the UI's parent

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/instance_editor.py
@@ -9,10 +9,17 @@
 # Thanks for using Enthought open source!
 
 from traitsui.testing.tester.command import MouseClick
+from traitsui.testing.tester.locator import Index
+from traitsui.testing.tester.query import SelectedText
+from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
+    BaseSourceWithLocation
+)
 from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
     register_traitsui_ui_solvers,
 )
-from traitsui.testing.tester._ui_tester_registry.wx._interaction_helpers import mouse_click_button  # noqa
+from traitsui.testing.tester._ui_tester_registry.wx._interaction_helpers import (  # noqa
+    mouse_click_combobox_or_choice, mouse_click_button
+)
 from traitsui.wx.instance_editor import (
     CustomEditor,
     SimpleEditor
@@ -39,6 +46,41 @@ def _get_nested_ui_custom(target):
     return target._ui
 
 
+def _get_choice(target):
+    """ Obtains a nested choice within an Instance Editor.
+
+    Parameters
+    ----------
+    target : instance of CustomEditor
+    """
+    return target._choice
+
+
+def _click_choice_index(wrapper, _):
+    """ Perform a click on a choice based on the index. """
+    return mouse_click_combobox_or_choice(
+        control=_get_choice(wrapper._target.source),
+        index=wrapper._target.location.index,
+        delay=wrapper.delay,
+    )
+
+
+def _get_choice_text(wrapper, _):
+    """ Get the currently displayed text of a choice. """
+    control = _get_choice(wrapper._target)
+    return control.GetString(control.GetSelection())
+
+
+class _IndexedCustomEditor(BaseSourceWithLocation):
+    """ Wrapper class for CustomEditors with a selection.
+    """
+    source_class = CustomEditor
+    locator_class = Index
+    handlers = [
+        (MouseClick, _click_choice_index),
+    ]
+
+
 def register(registry):
     """ Register interactions for the given registry.
 
@@ -49,6 +91,8 @@ def register(registry):
     registry : TargetRegistry
         The registry being registered to.
     """
+    _IndexedCustomEditor.register(registry)
+
     registry.register_interaction(
         target_class=SimpleEditor,
         interaction_class=MouseClick,
@@ -57,4 +101,10 @@ def register(registry):
         )
     )
     register_traitsui_ui_solvers(registry, SimpleEditor, _get_nested_ui_simple)
+
+    registry.register_interaction(
+        target_class=CustomEditor,
+        interaction_class=SelectedText,
+        handler=_get_choice_text,
+    )
     register_traitsui_ui_solvers(registry, CustomEditor, _get_nested_ui_custom)

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -11,11 +11,7 @@
 import unittest
 
 from pyface.toolkit import toolkit_object
-<<<<<<< HEAD
-from traits.api import HasTraits, Instance, Str, String
-=======
-from traits.api import HasTraits, Instance, List, Str
->>>>>>> tests/more-instance-editor-tests
+from traits.api import HasTraits, Instance, List, Str, String
 from traitsui.api import InstanceEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
@@ -25,18 +21,13 @@ from traitsui.tests._tools import (
 
 from traitsui.testing.api import (
     DisplayedText,
-<<<<<<< HEAD
+    Index,
     IsEnabled,
     KeyClick,
     KeySequence,
     MouseClick,
-    TargetByName,
-=======
-    Index,
-    KeySequence,
-    MouseClick,
     SelectedText,
->>>>>>> tests/more-instance-editor-tests
+    TargetByName,
     UITester
 )
 

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -171,7 +171,9 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
         ui_tester = UITester()
         with ui_tester.create_ui(obj) as ui:
             something_ui = ui_tester.find_by_name(ui, "something")
-            some_string_field = something_ui.locate(TargetByName('some_string'))
+            some_string_field = something_ui.locate(
+                TargetByName('some_string')
+            )
             some_string_field.perform(KeySequence("abcd"))
             some_string_field.perform(KeyClick("Enter"))
 

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -303,8 +303,4 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             # change to a different selected that is not in an error state
             something_ui.locate(Index(1)).perform(MouseClick())
 
-            self.assertEqual(
-                instance_editor_ui.errors, ui.errors
-            )
             self.assertTrue(ok_button.inspect(IsEnabled()))
-

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -272,11 +272,10 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
 
     def test_propagate_errors_switch_selection(self):
         obj = ObjectWithValidatedList()
-        ui_tester = UITester(delay=1000)
+        ui_tester = UITester()
         with ui_tester.create_ui(obj, {'view': selection_view}) as ui:
             something_ui = ui_tester.find_by_name(ui, "inst")
 
-            something_ui.help()
             something_ui.locate(Index(0)).perform(MouseClick())
 
             some_string_field = something_ui.locate(

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -867,6 +867,10 @@ class UI(HasPrivateTraits):
         if self.parent:
             self.parent.errors = self.parent.errors - old + new
 
+    def _parent_changed(self, name, old, new):
+        old.errors -= self.errors
+        new.errors += self.errors
+
     def _updated_changed(self):
         if self.rebuild is not None:
             toolkit().rebuild_ui(self)

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -860,6 +860,10 @@ class UI(HasPrivateTraits):
 
     # -- Traits Event Handlers ------------------------------------------------
 
+    def _errors_changed(self, name, old, new):
+        if self.parent:
+            self.parent.errors = self.parent.errors - old + new
+
     def _updated_changed(self):
         if self.rebuild is not None:
             toolkit().rebuild_ui(self)

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -868,7 +868,8 @@ class UI(HasPrivateTraits):
             self.parent.errors = self.parent.errors - old + new
 
     def _parent_changed(self, name, old, new):
-        old.errors -= self.errors
+        if old:
+            old.errors -= self.errors
         new.errors += self.errors
 
     def _updated_changed(self):

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -239,6 +239,9 @@ class UI(HasPrivateTraits):
     def dispose(self, result=None, abort=False):
         """ Disposes of the contents of a user interface.
         """
+        if self.parent:
+            self.parent.errors -= self.errors
+
         if result is not None:
             self.result = result
 

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -239,7 +239,7 @@ class UI(HasPrivateTraits):
     def dispose(self, result=None, abort=False):
         """ Disposes of the contents of a user interface.
         """
-        if self.parent:
+        if self.parent is not None:
             self.parent.errors -= self.errors
 
         if result is not None:
@@ -868,9 +868,10 @@ class UI(HasPrivateTraits):
             self.parent.errors = self.parent.errors - old + new
 
     def _parent_changed(self, name, old, new):
-        if old:
+        if old is not None:
             old.errors -= self.errors
-        new.errors += self.errors
+        if new is not None:
+            new.errors += self.errors
 
     def _updated_changed(self):
         if self.rebuild is not None:


### PR DESCRIPTION
fixes #1501 

This is a couple line change which simply adds a listener to a UI's errors trait.  Whenever the errors change, this change is propagated up to the UI's parent's errors trait as well.

BEWARE: although this seems like the logical thing to do it is a change in behavior and we may risk breaking code that was dependent upon the parent UI not picking up on child UI errors for whatever reason.  
The scope of this changes impact should be investigated before merging



NOTE: I merged #1499 into this PR as I found myself wanting to write basically the same thing to write new tests. If changes are made to that PR we will want to pull those in here as well