### PR TITLE
Undo/Redo cleanup

### DIFF
--- a/docs/source/traitsui_user_manual/handler.rst
+++ b/docs/source/traitsui_user_manual/handler.rst
@@ -584,6 +584,31 @@ created, as in the following code::
            # ...,
            toolbar = ToolBar(my_action))
 
+
+.. _undo_redo
+
+Undo and Redo
+-------------
+
+TraitsUI provides basic undo/redo functionality via the UI object's history
+trait.  This is created automatically for Views other than subpanels whenever
+the View has a menubar or an "Undo" or "Revert" button.  This system is
+largely independent of the Pyface undo/redo functionality, although that may
+change in the future.
+
+The primary hook into the undo/redo system is via the do_undoable method of
+the UI object, which calls a provided callable while capturing all changes to
+traits that are being viewed that occur as side-effects of the callable.
+Undo and redo actions then simply reset the values of all of those traits to
+the appropriate before and after values.  This works well for simple cases
+where traits are not heavily interdependent, but may break down in situations
+where there are complex dependencies.
+
+The do_undoable method used called when the value property of an Editor is
+set or when any Action is performed, including Actions associated with complex
+editors that provide context menus.
+
+
 .. rubric:: Footnotes
 
 .. [11] Except those implemented via the **enabled_when**, **visible_when**,

--- a/docs/source/traitsui_user_manual/handler.rst
+++ b/docs/source/traitsui_user_manual/handler.rst
@@ -585,31 +585,39 @@ created, as in the following code::
            toolbar = ToolBar(my_action))
 
 
-.. _undo_redo
+.. _undo_redo:
 
 Undo and Redo
 -------------
 
-TraitsUI provides basic undo/redo functionality via the UI object's history
-trait.  This is created automatically for Views other than subpanels whenever
-the View has a menubar or an "Undo" or "Revert" button.  This system is
-largely independent of the Pyface undo/redo functionality, although that may
-change in the future.
+TraitsUI provides basic undo/redo functionality via the |UI| object's history
+trait.  This is created automatically for |View| objects other than subpanels
+whenever the |View| has a menubar or an "Undo" or "Revert" button.  This
+system is largely independent of the
+`Pyface undo/redo functionality <https://docs.enthought.com/pyface/undo.html>`_,
+although that may change in the future.
 
-The primary hook into the undo/redo system is via the do_undoable method of
-the UI object, which calls a provided callable while capturing all changes to
-traits that are being viewed that occur as side-effects of the callable.
-Undo and redo actions then simply reset the values of all of those traits to
-the appropriate before and after values.  This works well for simple cases
-where traits are not heavily interdependent, but may break down in situations
-where there are complex dependencies.
+The primary hook into the undo/redo system is via the |do_undoable| method of
+the |UI| object, which calls the supplied callable while capturing all changes
+to traits that are being viewed while the callable is running.  Undo and redo
+actions then simply reset the values of all of those traits to the appropriate
+before or after values.  This works well for simple cases where traits are not
+heavily interdependent, but may break down in situations where there are
+complex dependencies.
 
-The do_undoable method used called when the value property of an Editor is
-set or when any Action is performed, including Actions associated with complex
-editors that provide context menus.
+The |do_undoable| method is called when the value property of an |Editor| is
+set or when any |Action| is performed, including actions associated with
+complex editors that provide context menus.
 
 
 .. rubric:: Footnotes
 
 .. [11] Except those implemented via the **enabled_when**, **visible_when**,
    and **defined_when** attributes of Items and Groups.
+
+
+.. |Action| replace:: :py:class:`~traitsui.menu.Action`
+.. |Editor| replace:: :py:class:`~traitsui.editor.Editor`
+.. |UI| replace:: :py:class:`~traitsui.ui.UI`
+.. |View| replace:: :py:class:`~traitsui.view.View`
+.. |do_undoable| replace:: :py:meth:`~traitsui.ui.UI.do_undoable`

--- a/traitsui/tests/test_undo.py
+++ b/traitsui/tests/test_undo.py
@@ -1039,6 +1039,62 @@ class TestUndoHistory(UnittestTools, unittest.TestCase):
         self.assertFalse(history.can_undo)
         self.assertFalse(history.can_redo)
 
+    def test_extend(self):
+        history = UndoHistory()
+        example = SimpleExample(str_value='foo', value=10)
+        undo_item = UndoItem(
+            object=example,
+            name='value',
+            old_value=0,
+            new_value=10,
+        )
+
+        history.add(
+            UndoItem(
+                object=example,
+                name='str_value',
+                old_value='foo',
+                new_value='bar',
+            )
+        )
+
+        with self.assertTraitDoesNotChange(history, 'undoable'):
+            with self.assertTraitDoesNotChange(history, 'redoable'):
+                history.extend(undo_item)
+
+        self.assertEqual(history.now, 1)
+        self.assertTrue(history.can_undo)
+        self.assertFalse(history.can_redo)
+
+    def test_extend_merge(self):
+        history = UndoHistory()
+        example = SimpleExample(str_value='foo', value=10)
+        undo_item = UndoItem(
+            object=example,
+            name='str_value',
+            old_value='foo',
+            new_value='baz',
+        )
+
+        history.add(
+            UndoItem(
+                object=example,
+                name='str_value',
+                old_value='foo',
+                new_value='bar',
+            )
+        )
+
+        with self.assertTraitDoesNotChange(history, 'undoable'):
+            with self.assertTraitDoesNotChange(history, 'redoable'):
+                history.extend(undo_item)
+
+        self.assertEqual(history.now, 1)
+        self.assertTrue(history.can_undo)
+        self.assertFalse(history.can_redo)
+        # XXX this is testing private state to ensure merge happened
+        self.assertEqual(len(history.history[0]), 1)
+
 
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
 class TestEditorUndo(BaseTestMixin, GuiTestAssistant, unittest.TestCase):

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -26,7 +26,7 @@ from traits.api import (
     Str,
     Trait,
 )
-from pyface.undo.api import AbstractCommand, CommandStack
+from pyface.undo.api import AbstractCommand
 
 
 NumericTypes = (int, float, complex)

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -41,10 +41,16 @@ class AbstractUndoItem(AbstractCommand):
     provide the ICommand interface.
     """
 
+    #: A simple default name.
+    name = "Edit"
+
     def do(self):
-        """ Do the change for the first time.
+        """ Does nothing.
+        
+        All undo items log events after they have happened, so by default
+        they do not do anything when added to the history.
         """
-        self.redo()
+        pass
 
     def undo(self):
         """ Undoes the change.
@@ -59,6 +65,12 @@ class AbstractUndoItem(AbstractCommand):
     def merge(self, other):
         """ Merges two undo items if possible.
         """
+        import warnings
+        warnings.warn(
+            "'merge_undo' is deprecated and will be removed in TraitsUI 8, "
+            "use 'merge' instead",
+            DeprecationWarning,
+        )
         return self.merge_undo(other)
 
     def merge_undo(self, undo_item):
@@ -354,6 +366,10 @@ class UndoHistory(HasStrictTraits):
                     self.redoable = False
                 return
 
+        # This does nothing for AbstractUndoItems, but is needed for generic
+        # ICommand instances.
+        undo_item.do()
+        
         self.history[now:] = [[undo_item]]
         self.now += 1
         if self.now == 1:

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -41,6 +41,11 @@ class AbstractUndoItem(AbstractCommand):
     provide the ICommand interface.
     """
 
+    def do(self):
+        """ Do the change for the first time.
+        """
+        self.redo()
+
     def undo(self):
         """ Undoes the change.
         """
@@ -135,7 +140,7 @@ class UndoItem(AbstractUndoItem):
             t1 = type(v1)
             if isinstance(v2, t1):
 
-                if isinstance(t1, str):
+                if isinstance(v1, str):
                     # Merge two undo items if they have new values which are
                     # strings which only differ by one character (corresponding
                     # to a single character insertion, deletion or replacement


### PR DESCRIPTION
This PR does a number of things:
- adds comprehensive tests for most of the classes in traits.undo
- makes `AbstractUndoItem` inherit from `AbstractCommand` (the interfaces were almost identical)
  - updates the code so that it uses the `AbstractCommand` interface which permits the use of arbitrary Pyface commands in the TraitsUI history interface.
  - add backward compatibility shims so in the event that third parties are using the `AbstractUndoItem` API then everything should still work.
  - recommends removal of the `AbstractUndoItem.merge_undo` method in TraitUI 8 (in fact we can probably remove `AbstractUndoItem` as well.
- fixes #1506
- fixes #1509
- adds some stub documentation about how the Undo/Redo system works.

This PR should be backward compatible, so can be included in the next minor release.

This is a safe first step for #1060.