### PR TITLE
Expose `clearButtonEnabled` for Qt TextEditor

### DIFF
--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -74,9 +74,9 @@ class ToolkitEditorFactory(EditorFactory):
     #: Is multi-line text allowed?
     multi_line = Bool(True)
 
-    #: Is editor readonly (will use custom / default editor appearance with readonly flag set to true)
-    #: in contrasrt with readonly style for item when completely another edito
-    #: is used
+    #: Is editor readonly (will use custom / default editor appearance with
+    #: readonly flag set to true) in contrasrt with readonly style for item
+    #: when completely another editor is used
     read_only = Bool(False)
 
     #: Is user input unreadable? (e.g., for a password)
@@ -98,7 +98,9 @@ class ToolkitEditorFactory(EditorFactory):
     placeholder = Str()
 
     #: Whether or not to display a clear button for the text.  This only works
-    #: in the qt>=5.2 backend for simple/text styles of the editor.
+    #: in the qt>=5.2 backend for simple/text styles of the editor.  Note this
+    #: trait is currently provisional and may be replaced in the future by a
+    #: more general feature.
     cancel_button = Bool(False)
 
     # -------------------------------------------------------------------------

--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -97,6 +97,10 @@ class ToolkitEditorFactory(EditorFactory):
     #: Grayed-out placeholder text to be displayed when the editor is empty.
     placeholder = Str()
 
+    #: Whether or not to display a clear button for the text.  This only works
+    #: in the qt>=5.2 backend for simple/text styles of the editor.
+    clear_button = Bool(False)
+
     # -------------------------------------------------------------------------
     #  Traits view definition:
     # -------------------------------------------------------------------------

--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -75,7 +75,7 @@ class ToolkitEditorFactory(EditorFactory):
     multi_line = Bool(True)
 
     #: Is editor readonly (will use custom / default editor appearance with
-    #: readonly flag set to true) in contrasrt with readonly style for item
+    #: readonly flag set to true) in contrast with readonly style for item
     #: when completely another editor is used
     read_only = Bool(False)
 

--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -99,7 +99,7 @@ class ToolkitEditorFactory(EditorFactory):
 
     #: Whether or not to display a clear button for the text.  This only works
     #: in the qt>=5.2 backend for simple/text styles of the editor.
-    clear_button = Bool(False)
+    cancel_button = Bool(False)
 
     # -------------------------------------------------------------------------
     #  Traits view definition:

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -110,7 +110,7 @@ class SimpleEditor(Editor):
 
         if wtype is not QtGui.QTextEdit and QtCore.__version_info__ >= (5, 2):
             # setClearButtonEnabled is introduced to QLineEdit since Qt 5.2
-            control.setClearButtonEnabled(self.factory.clear_button)
+            control.setClearButtonEnabled(self.factory.cancel_button)
 
         self.control = control
         # default horizontal policy is Expand, set this to Minimum

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -108,6 +108,10 @@ class SimpleEditor(Editor):
             # setPlaceholderText is introduced to QTextEdit since Qt 5.2
             control.setPlaceholderText(placeholder)
 
+        if wtype is not QtGui.QTextEdit and QtCore.__version_info__ >= (5, 2):
+            # setClearButtonEnabled is introduced to QLineEdit since Qt 5.2
+            control.setClearButtonEnabled(self.factory.clear_button)
+
         self.control = control
         # default horizontal policy is Expand, set this to Minimum
         if not (self.item.resizable) and not self.item.springy:

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -148,7 +148,7 @@ class TestTextEditorQt(
             try:
                 clear_button = name_editor.control.isClearButtonEnabled()
             except AttributeError:
-                # placeholderText is introduced to QTextEdit since Qt 5.2
+                # isClearButtonEnabled is introduced to QLineEdit since Qt 5.2
                 pass
             else:
                 self.assertTrue(clear_button)

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -133,6 +133,26 @@ class TestTextEditorQt(
             else:
                 self.assertEqual(placeholder, "Enter name")
 
+    def test_clear_button(self):
+        foo = Foo()
+        view = View(
+            Item(
+                name="name",
+                style="simple",
+                editor=TextEditor(clear_button=True),
+            )
+        )
+        tester = UITester()
+        with tester.create_ui(foo, dict(view=view)) as ui:
+            name_editor, = ui.get_editors("name")
+            try:
+                clear_button = name_editor.control.isClearButtonEnabled()
+            except AttributeError:
+                # placeholderText is introduced to QTextEdit since Qt 5.2
+                pass
+            else:
+                self.assertTrue(clear_button)
+
 
 # We should be able to run this test case against wx.
 # Not running them now to avoid test interaction. See enthought/traitsui#752

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -146,7 +146,7 @@ class TestTextEditorQt(
         with tester.create_ui(foo, dict(view=view)) as ui:
             name_editor, = ui.get_editors("name")
             # isClearButtonEnabled is introduced to QLineEdit since Qt 5.2
-            if hasattr(name_editor.contorl, isClearButtonEnabled):
+            if hasattr(name_editor.control, 'isClearButtonEnabled'):
                 self.assertTrue(name_editor.control.isClearButtonEnabled())
 
 

--- a/traitsui/tests/editors/test_text_editor.py
+++ b/traitsui/tests/editors/test_text_editor.py
@@ -133,25 +133,21 @@ class TestTextEditorQt(
             else:
                 self.assertEqual(placeholder, "Enter name")
 
-    def test_clear_button(self):
+    def test_cancel_button(self):
         foo = Foo()
         view = View(
             Item(
                 name="name",
                 style="simple",
-                editor=TextEditor(clear_button=True),
+                editor=TextEditor(cancel_button=True),
             )
         )
         tester = UITester()
         with tester.create_ui(foo, dict(view=view)) as ui:
             name_editor, = ui.get_editors("name")
-            try:
-                clear_button = name_editor.control.isClearButtonEnabled()
-            except AttributeError:
-                # isClearButtonEnabled is introduced to QLineEdit since Qt 5.2
-                pass
-            else:
-                self.assertTrue(clear_button)
+            # isClearButtonEnabled is introduced to QLineEdit since Qt 5.2
+            if hasattr(name_editor.contorl, isClearButtonEnabled):
+                self.assertTrue(name_editor.control.isClearButtonEnabled())
 
 
 # We should be able to run this test case against wx.


### PR DESCRIPTION
fixes #1514 

This PR adds a `clear_button` boolean trait on the `TextEditor` `ToolkitEditorFactory`, and uses it to call `setClearButtonEnable` if we are working with a `QLineEdit` on qt>=5.2.  It also adds a simple test to check it gets enabled as expected, and I separately modified the `TextEditor_demo.py` to confirm the changes worked as expected (changes not included in this PR).

I have only just started looking into the scope of adding something similar for wx / for a QTextEdit (used for the custom style of the `TextEditor`). For now, just adding the functionality for `QLineEdit`s on qt>=5.2 is only a couple line change.