### PR TITLE
[WIP] Allow TreeEditor to create new nodes for classes with required arugments

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1337,7 +1337,20 @@ class SimpleEditor(Editor):
         except TypeError:
             import inspect
             signature = inspect.signature(new_class.__init__)
-            print(signature)
+            arguments = {
+                param.name: param.default
+                for param in signature.parameters.values()
+                if param.name != 'self'
+            }
+            class_traits = new_class.class_traits()
+            for key in arguments:
+                if key in class_traits.keys():
+                    arguments[key] = class_traits[key].default
+                if arguments[key] == inspect._empty:
+                    # we don't know what to supply as a default
+                    raise 
+                    #arguments[key] = None
+            new_object = new_class(**arguments)
         if (not prompt) or new_object.edit_traits(
             parent=self.control, kind="livemodal"
         ).result:


### PR DESCRIPTION
fixes #1502 

The current solution is to first try to instantiate the class (ie. call `new_object = new_class()` like before) but to catch errors if this fails due to missing required arguments.  If we are dealing with `HasRequirdTraits` a `TraitError` will be raised and in this case, we simply look for the missing required traits and then create an instance of new_class using the defaults defined for those traits (via the `default` property of the `CTrait` object).  

I am still working on the case where we have a custom `__init__` method that is imposing the required attributes.  It is a bit more awkward, and I don't know how general we would want the solution to be.  What should be used for default values for attributes which aren't traits?  Should we try to guess, use a dumb default that might break things and ask the user to correct it somehow, or simply raise?
In general I feel like this use case is discouraged, but it could still occur. 


Also I have done manual testing by messing with the example code from the issue, but have not added a unit test for this currently.  It is a bit awkward to write a good test for currently...