### PR TITLE
Convert on_trait_change decorators to observe

### DIFF
--- a/integrationtests/styled_date_editor_test.py
+++ b/integrationtests/styled_date_editor_test.py
@@ -13,7 +13,7 @@ from datetime import date
 from traits.etsconfig.api import ETSConfig
 ETSConfig.toolkit = 'qt4'
 
-from traits.api import Date, Dict, HasTraits, List, on_trait_change
+from traits.api import Date, Dict, HasTraits, List, observe
 from traitsui.api import View, Item, StyledDateEditor
 from traitsui.editors.styled_date_editor import CellFormat
 
@@ -54,8 +54,8 @@ class Foo(HasTraits):
                 2010, 6, 27), date(
                 2010, 6, 24)]
 
-    @on_trait_change("fast_dates,slow_dates")
-    def _update_dates_dict(self):
+    @observe("fast_dates,slow_dates")
+    def _update_dates_dict(self, event):
         self.dates["fast"] = self.fast_dates
         self.dates["slow"] = self.slow_dates
 

--- a/traitsui/editors/image_enum_editor.py
+++ b/traitsui/editors/image_enum_editor.py
@@ -56,10 +56,10 @@ class ToolkitEditorFactory(EditorFactory):
             have been set.
         """
         super(ToolkitEditorFactory, self).init()
-        self._update_path(event=None)
+        self._update_path()
 
     @observe("path, klass, module")
-    def _update_path(self, event):
+    def _update_path(self, event=None):
         """ Handles one of the items defining the path being updated.
         """
         if self.path != "":

--- a/traitsui/editors/image_enum_editor.py
+++ b/traitsui/editors/image_enum_editor.py
@@ -20,7 +20,7 @@ from os import getcwd
 
 from os.path import join, dirname, exists
 
-from traits.api import Module, Type, Str, on_trait_change
+from traits.api import Module, Type, Str, observe
 
 from .enum_editor import ToolkitEditorFactory as EditorFactory
 
@@ -56,10 +56,10 @@ class ToolkitEditorFactory(EditorFactory):
             have been set.
         """
         super(ToolkitEditorFactory, self).init()
-        self._update_path()
+        self._update_path(event=None)
 
-    @on_trait_change("path, klass, module")
-    def _update_path(self):
+    @observe("path, klass, module")
+    def _update_path(self, event):
         """ Handles one of the items defining the path being updated.
         """
         if self.path != "":

--- a/traitsui/editors/table_editor.py
+++ b/traitsui/editors/table_editor.py
@@ -27,7 +27,7 @@ from traits.api import (
     Callable,
     Range,
     Trait,
-    on_trait_change,
+    observe,
 )
 
 from ..editor_factory import EditorFactory
@@ -400,8 +400,8 @@ class ToolkitEditorFactory(EditorFactory):
     #  Event handlers:
     # -------------------------------------------------------------------------
 
-    @on_trait_change("filters[]")
-    def _update_filter_editor(self, object, name, old, new):
+    @observe("filters.items")
+    def _update_filter_editor(self, event):
         """ Handles the set of filters associated with the editor's factory
             being changed.
         """

--- a/traitsui/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
+++ b/traitsui/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
@@ -137,15 +137,17 @@ class Hotel(HasPrivateTraits):
     # Event handlers:
     @observe('guests.items')
     def _guests_modified(self, event):
+        # The entire guests list changed
         if isinstance(event.object, Hotel):
             for guest in event.new:
                 guest.hotel = self
+        # the contents of the guests list changed
         else:
             for guest in event.added:
                 guest.hotel = self
 
     def _add_guest_changed(self):
-        self.guests.append(Guest())
+        self.guests.append(Guest(hotel=self))
 
 #-- The Guest class ------------------------------------------------------
 

--- a/traitsui/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
+++ b/traitsui/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
@@ -70,7 +70,7 @@ from random \
 
 from traits.api \
     import HasPrivateTraits, Str, Enum, Range, List, Button, Instance, \
-    Property, cached_property, on_trait_change
+    Property, cached_property, observe
 
 from traitsui.api \
     import View, VGroup, HGroup, Item, ListEditor, spring
@@ -135,10 +135,14 @@ class Hotel(HasPrivateTraits):
                 min(int(60.00 / self.fuel_cost), 15))
 
     # Event handlers:
-    @on_trait_change('guests[]')
-    def _guests_modified(self, removed, added):
-        for guest in added:
-            guest.hotel = self
+    @observe('guests.items')
+    def _guests_modified(self, event):
+        if isinstance(event.object, Hotel):
+            for guest in event.new:
+                guest.hotel = self
+        else:
+            for guest in event.added:
+                guest.hotel = self
 
     def _add_guest_changed(self):
         self.guests.append(Guest())

--- a/traitsui/examples/demo/Advanced/String_list_ui_editor.py
+++ b/traitsui/examples/demo/Advanced/String_list_ui_editor.py
@@ -26,7 +26,7 @@ applications.
 """
 # Issue related to the demo warning: enthought/traitsui#960
 
-from traits.api import HasPrivateTraits, List, Str, Property, on_trait_change
+from traits.api import HasPrivateTraits, List, Str, Property, observe
 from traits.etsconfig.api import ETSConfig
 
 from traitsui.api import (
@@ -90,8 +90,8 @@ class _StringListEditor(UIEditor):
 
         return self.edit_traits(parent=parent, kind='subpanel')
 
-    @on_trait_change('selected')
-    def _selected_modified(self):
+    @observe('selected')
+    def _selected_modified(self, event):
         self.value = self.selected
 
 

--- a/traitsui/extras/saving.py
+++ b/traitsui/extras/saving.py
@@ -24,7 +24,7 @@ from traits.api import (
     Any,
     Int,
     Instance,
-    on_trait_change,
+    observe,
 )
 from ..api import Handler
 
@@ -223,8 +223,8 @@ class SaveHandler(Handler):
             ):
                 self.saveObject.save()
 
-    @on_trait_change("autosave, autosaveInterval, saveObject")
-    def _configure_timer(self):
+    @observe("autosave, autosaveInterval, saveObject")
+    def _configure_timer(self, event):
         """ Creates, replaces, or destroys the autosave timer.
         """
         if self._timer:

--- a/traitsui/key_bindings.py
+++ b/traitsui/key_bindings.py
@@ -23,7 +23,7 @@ from traits.api import (
     Property,
     Str,
     cached_property,
-    on_trait_change,
+    observe,
 )
 
 from .api import HGroup, Item, KeyBindingEditor, ListEditor, View, toolkit
@@ -254,12 +254,16 @@ class KeyBindings(HasPrivateTraits):
         if old is not None:
             old.border_size = 0
 
-    @on_trait_change("children[]")
-    def _children_modified(self, removed, added):
+    @observe("children.items")
+    def _children_modified(self, event):
         """ Handles child KeyBindings being added to the object.
         """
-        for item in added:
-            item.parent = self
+        if isinstance(event.object, KeyBinding):
+            for item in event.new:
+                item.parent = self
+        else:
+            for item in event.added:
+                item.parent = self
 
     # -- object Method Overrides ----------------------------------------------
 

--- a/traitsui/key_bindings.py
+++ b/traitsui/key_bindings.py
@@ -258,9 +258,11 @@ class KeyBindings(HasPrivateTraits):
     def _children_modified(self, event):
         """ Handles child KeyBindings being added to the object.
         """
+        # the full children list is changed
         if isinstance(event.object, KeyBinding):
             for item in event.new:
                 item.parent = self
+        # the contents of the children list are changed
         else:
             for item in event.added:
                 item.parent = self

--- a/traitsui/list_str_adapter.py
+++ b/traitsui/list_str_adapter.py
@@ -21,7 +21,7 @@ from traits.api import (
     Interface,
     List,
     Str,
-    on_trait_change,
+    observe,
     provides,
 )
 from .toolkit_traits import Color
@@ -350,8 +350,8 @@ class ListStrAdapter(HasPrivateTraits):
         self.cache[key] = handler
         return handler()
 
-    @on_trait_change("adapters.+update")
-    def _flush_cache(self):
+    @observe("adapters.items.+update")
+    def _flush_cache(self, event):
         """ Flushes the cache when any trait on any adapter changes.
         """
         self.cache = {}

--- a/traitsui/qt4/code_editor.py
+++ b/traitsui/qt4/code_editor.py
@@ -35,7 +35,7 @@ from traits.api import (
     Event,
     Bool,
     TraitError,
-    on_trait_change,
+    observe,
 )
 from traits.trait_base import SequenceTypes
 
@@ -320,8 +320,8 @@ class SourceEditor(Editor):
     def _squiggle_color_changed(self):
         pass
 
-    @on_trait_change("dim_lines, squiggle_lines")
-    def _style_document(self):
+    @observe("dim_lines, squiggle_lines")
+    def _style_document(self, event):
         self._widget.set_warn_lines(self.squiggle_lines)
 
 

--- a/traitsui/qt4/datetime_editor.py
+++ b/traitsui/qt4/datetime_editor.py
@@ -14,7 +14,7 @@
 
 from pyface.qt import QtGui, qt_api
 from pyface.qt.QtCore import QDateTime
-from traits.api import Datetime, on_trait_change
+from traits.api import Datetime, observe
 
 from .editor import Editor
 from .editor_factory import ReadonlyEditor as BaseReadonlyEditor
@@ -78,8 +78,8 @@ class SimpleEditor(Editor):
         except ValueError:
             pass
 
-    @on_trait_change('minimum_datetime')
-    def update_minimum_datetime(self):
+    @observe('minimum_datetime')
+    def update_minimum_datetime(self, event):
         # sanity checking of values
         if (self.minimum_datetime is not None
                 and self.maximum_datetime is not None
@@ -94,8 +94,8 @@ class SimpleEditor(Editor):
             else:
                 self.control.clearMinimumDateTime()
 
-    @on_trait_change('maximum_datetime')
-    def update_maximum_datetime(self):
+    @observe('maximum_datetime')
+    def update_maximum_datetime(self, event):
         # sanity checking of values
         if (self.minimum_datetime is not None
                 and self.maximum_datetime is not None

--- a/traitsui/qt4/datetime_editor.py
+++ b/traitsui/qt4/datetime_editor.py
@@ -40,8 +40,8 @@ class SimpleEditor(Editor):
 
         self.control = QtGui.QDateTimeEdit()
         self.control.dateTimeChanged.connect(self.update_object)
-        self.update_minimum_datetime()
-        self.update_maximum_datetime()
+        self.update_minimum_datetime(event=None)
+        self.update_maximum_datetime(event=None)
 
     def dispose(self):
         """ Disposes of the contents of an editor.

--- a/traitsui/qt4/datetime_editor.py
+++ b/traitsui/qt4/datetime_editor.py
@@ -40,8 +40,8 @@ class SimpleEditor(Editor):
 
         self.control = QtGui.QDateTimeEdit()
         self.control.dateTimeChanged.connect(self.update_object)
-        self.update_minimum_datetime(event=None)
-        self.update_maximum_datetime(event=None)
+        self.update_minimum_datetime()
+        self.update_maximum_datetime()
 
     def dispose(self):
         """ Disposes of the contents of an editor.
@@ -79,7 +79,7 @@ class SimpleEditor(Editor):
             pass
 
     @observe('minimum_datetime')
-    def update_minimum_datetime(self, event):
+    def update_minimum_datetime(self, event=None):
         # sanity checking of values
         if (self.minimum_datetime is not None
                 and self.maximum_datetime is not None
@@ -95,7 +95,7 @@ class SimpleEditor(Editor):
                 self.control.clearMinimumDateTime()
 
     @observe('maximum_datetime')
-    def update_maximum_datetime(self, event):
+    def update_maximum_datetime(self, event=None):
         # sanity checking of values
         if (self.minimum_datetime is not None
                 and self.maximum_datetime is not None

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -42,7 +42,7 @@ from traits.api import (
     Property,
     Str,
     cached_property,
-    on_trait_change,
+    observe,
 )
 
 from traitsui.api import (
@@ -1396,8 +1396,8 @@ class TableFilterEditor(HasTraits):
         else:
             self.selected_filter = None
 
-    @on_trait_change("selected_filter:name")
-    def _update_filter_list(self):
+    @observe("selected_filter:name")
+    def _update_filter_list(self, event):
         """ A hack to make the EnumEditor watching the list of filters refresh
             their text when the name of the selected filter changes.
         """

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -31,7 +31,7 @@ from traits.api import (
     Str,
     Either,
     cached_property,
-    on_trait_change,
+    observe,
     provides,
 )
 
@@ -749,8 +749,8 @@ class TabularAdapter(HasPrivateTraits):
 
         return None
 
-    @on_trait_change("columns,adapters.+update")
-    def _flush_cache(self):
+    @observe("columns,adapters.items.+update")
+    def _flush_cache(self, event):
         """ Flushes the cache when the columns or any trait on any adapter
             changes.
         """

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -29,7 +29,7 @@ from traits.api import (
     Property,
     Str,
     TraitError,
-    on_trait_change,
+    observe,
     property_depends_on,
 )
 
@@ -872,8 +872,8 @@ class UI(HasPrivateTraits):
         if self.control is not None:
             toolkit().set_icon(self)
 
-    @on_trait_change("parent, view, context")
-    def _pvc_changed(self):
+    @observe("parent, view, context")
+    def _pvc_changed(self, event):
         parent = self.parent
         if (parent is not None) and (self.key_bindings is not None):
             # If we don't have our own history, use our parent's:

--- a/traitsui/wx/code_editor.py
+++ b/traitsui/wx/code_editor.py
@@ -239,7 +239,7 @@ class SourceEditor(Editor):
             control.SetReadOnly(readonly)
             self._mark_lines_changed()
             self._selected_line_changed()
-            self._style_document(event=None)
+            self._style_document()
 
         self._locked = False
 
@@ -318,7 +318,7 @@ class SourceEditor(Editor):
         self.control.Refresh()
 
     @observe("dim_lines, squiggle_lines")
-    def _style_document(self, event):
+    def _style_document(self, event=None):
         """ Force the STC to fire a STC_STYLENEEDED event for the entire
             document.
         """

--- a/traitsui/wx/code_editor.py
+++ b/traitsui/wx/code_editor.py
@@ -16,7 +16,7 @@
 import wx
 import wx.stc as stc
 
-from traits.api import Str, List, Int, Event, Bool, TraitError, on_trait_change
+from traits.api import Str, List, Int, Event, Bool, TraitError, observe
 
 from traits.trait_base import SequenceTypes
 
@@ -239,7 +239,7 @@ class SourceEditor(Editor):
             control.SetReadOnly(readonly)
             self._mark_lines_changed()
             self._selected_line_changed()
-            self._style_document()
+            self._style_document(event=None)
 
         self._locked = False
 
@@ -317,8 +317,8 @@ class SourceEditor(Editor):
         self.control.IndicatorSetForeground(2, self.squiggle_color)
         self.control.Refresh()
 
-    @on_trait_change("dim_lines, squiggle_lines")
-    def _style_document(self):
+    @observe("dim_lines, squiggle_lines")
+    def _style_document(self, event):
         """ Force the STC to fire a STC_STYLENEEDED event for the entire
             document.
         """

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -16,7 +16,7 @@ import wx
 
 from os.path import abspath, split, splitext, isfile, exists
 
-from traits.api import List, Str, Event, Any, on_trait_change, TraitError
+from traits.api import List, Str, Event, Any, observe, TraitError
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
 # compatibility. The class has been moved to the
@@ -113,10 +113,11 @@ class SimpleEditor(SimpleTextEditor):
 
         super(SimpleEditor, self).dispose()
 
-    @on_trait_change("history:value")
-    def _history_value_changed(self, value):
+    @observe("history:value")
+    def _history_value_changed(self, event):
         """ Handles the history 'value' trait being changed.
         """
+        value = event.new
         if not self._no_update:
             self._update(value)
 
@@ -162,10 +163,11 @@ class SimpleEditor(SimpleTextEditor):
 
     # -- Traits Event Handlers ------------------------------------------------
 
-    @on_trait_change("popup:value")
-    def _popup_value_changed(self, file_name):
+    @observe("popup:value")
+    def _popup_value_changed(self, event):
         """ Handles the popup value being changed.
         """
+        file_name = event.new
         if self.factory.truncate_ext:
             file_name = splitext(file_name)[0]
 
@@ -174,8 +176,8 @@ class SimpleEditor(SimpleTextEditor):
         self.history.set_value(self.str_value)
         self._no_update = False
 
-    @on_trait_change("popup:closed")
-    def _popup_closed_changed(self):
+    @observe("popup:closed")
+    def _popup_closed_changed(self, event):
         """ Handles the popup control being closed.
         """
         self.popup = None

--- a/traitsui/wx/history_editor.py
+++ b/traitsui/wx/history_editor.py
@@ -13,7 +13,7 @@
 """
 
 
-from traits.api import Any, on_trait_change
+from traits.api import Any, observe
 
 from pyface.timer.api import do_later
 
@@ -60,8 +60,8 @@ class _HistoryEditor(Editor):
 
         super(_HistoryEditor, self).dispose()
 
-    @on_trait_change("history:value")
-    def _value_changed(self, value):
+    @observe("history:value")
+    def _value_changed(self, event):
         """ Handles the history object's 'value' trait being changed.
         """
         if not self._dont_update:

--- a/traitsui/wx/scrubber_editor.py
+++ b/traitsui/wx/scrubber_editor.py
@@ -134,7 +134,7 @@ class _ScrubberEditor(Editor):
 
         # Force a reset (in case low = high = None, which won't cause a
         # notification to fire):
-        self._reset_scrubber(event=None)
+        self._reset_scrubber()
 
     def dispose(self):
         """ Disposes of the contents of an editor.
@@ -200,7 +200,7 @@ class _ScrubberEditor(Editor):
     # -- Private Methods ------------------------------------------------------
 
     @observe("low, high")
-    def _reset_scrubber(self, event):
+    def _reset_scrubber(self, event=None):
         """ Sets the the current tooltip.
         """
         low, high = self.low, self.high

--- a/traitsui/wx/scrubber_editor.py
+++ b/traitsui/wx/scrubber_editor.py
@@ -23,7 +23,7 @@ from traits.api import (
     Str,
     Float,
     TraitError,
-    on_trait_change,
+    observe,
 )
 
 from traitsui.api import View, Item, EnumEditor
@@ -134,7 +134,7 @@ class _ScrubberEditor(Editor):
 
         # Force a reset (in case low = high = None, which won't cause a
         # notification to fire):
-        self._reset_scrubber()
+        self._reset_scrubber(event=None)
 
     def dispose(self):
         """ Disposes of the contents of an editor.
@@ -199,8 +199,8 @@ class _ScrubberEditor(Editor):
 
     # -- Private Methods ------------------------------------------------------
 
-    @on_trait_change("low, high")
-    def _reset_scrubber(self):
+    @observe("low, high")
+    def _reset_scrubber(self, event):
         """ Sets the the current tooltip.
         """
         low, high = self.low, self.high

--- a/traitsui/wx/table_model.py
+++ b/traitsui/wx/table_model.py
@@ -26,8 +26,9 @@ from traits.api import (
     Instance,
     Event,
     Bool,
-    on_trait_change,
+    observe,
 )
+from traits.observation.api import trait
 
 from traitsui.api import View, Item, Editor
 
@@ -216,8 +217,8 @@ class TableModel(GridModel):
 
     # -- Event Handlers -------------------------------------------------------
 
-    @on_trait_change("filter.+")
-    def _filter_modified(self):
+    @observe(trait("filter").match(lambda name, ctrait: True))
+    def _filter_modified(self, event):
         """ Handles the contents of the filter being changed.
         """
         self._filtered_cache = None


### PR DESCRIPTION
contributes to #1052 

This PR replaces all uses of `@on_trait_change` with the equivalent form using observe