### PR TITLE
Replace use of depends_on in Traits Properties with observe

### DIFF
--- a/ets-demo/etsdemo/app.py
+++ b/ets-demo/etsdemo/app.py
@@ -369,7 +369,7 @@ class DemoFileBase(DemoTreeNodeObject):
     parent = Any()
 
     #: Name of file system path to this file:
-    path = Property(depends_on='parent.path,name')
+    path = Property(observe='parent.path,name')
 
     #: Name of the file:
     name = Str()
@@ -384,7 +384,7 @@ class DemoFileBase(DemoTreeNodeObject):
     description = HTML()
 
     #: The base URL for links:
-    base_url = Property(depends_on='path')
+    base_url = Property(observe='path')
 
     #: The css file for this node.
     css_filename = Str("default.css")
@@ -533,13 +533,13 @@ class DemoPath(DemoTreeNodeObject):
     parent = Any()
 
     #: Name of file system path to this package:
-    path = Property(depends_on='parent.path,name')
+    path = Property(observe='parent.path,name')
 
     #: Description of what the demo does:
-    description = Property(HTML, depends_on="path,css_filename")
+    description = Property(HTML, observe="path,css_filename")
 
     #: The base URL for links:
-    base_url = Property(depends_on='path')
+    base_url = Property(observe='path')
 
     #: The css file for this node.
     css_filename = Str("default.css")

--- a/examples/tutorials/traitsui_4.0/buttons.py
+++ b/examples/tutorials/traitsui_4.0/buttons.py
@@ -59,7 +59,7 @@ class Adder(HasTraits):
 
     value_1 = Float()
     value_2 = Float()
-    sum = Property(depends_on=['value_1', 'value_2'])
+    sum = Property(observe=['value_1', 'value_2'])
 
     view = View(
         Item('value_1'),

--- a/examples/tutorials/traitsui_4.0/items.py
+++ b/examples/tutorials/traitsui_4.0/items.py
@@ -158,7 +158,7 @@ class LeagueModelView(ModelView):
     got_hit = Button('Got a Hit')
 
     # The total number of hits
-    total_hits = Property(observe='model.teams.players.hits')
+    total_hits = Property(depends_on='model.teams.players.hits')
 
     @cached_property
     def _get_total_hits(self):

--- a/examples/tutorials/traitsui_4.0/items.py
+++ b/examples/tutorials/traitsui_4.0/items.py
@@ -121,7 +121,7 @@ class Team(HasTraits):
     players = List(Player)
 
     # The number of players on the team:
-    num_players = Property(depends_on='players')
+    num_players = Property(observe='players')
 
     def _get_num_players(self):
         """ Implementation of the 'num_players' property.
@@ -158,7 +158,7 @@ class LeagueModelView(ModelView):
     got_hit = Button('Got a Hit')
 
     # The total number of hits
-    total_hits = Property(depends_on='model.teams.players.hits')
+    total_hits = Property(observe='model.teams.players.hits')
 
     @cached_property
     def _get_total_hits(self):

--- a/integrationtests/ui/text_editor_invalid.py
+++ b/integrationtests/ui/text_editor_invalid.py
@@ -25,7 +25,7 @@ from traitsui.api import TextEditor
 class Person(HasTraits):
     name = Str()
 
-    invalid = Property(Bool, depends_on='name')
+    invalid = Property(Bool, observe='name')
 
     def _get_invalid(self):
         # Name is valid iff it doesn't consist entirely of whitespace.

--- a/traitsui/dock_window_theme.py
+++ b/traitsui/dock_window_theme.py
@@ -63,10 +63,10 @@ class DockWindowTheme(HasPrivateTraits):
     horizontal_drag = ATheme
 
     #: The bitmap for the 'tab_inactive_edge' image:
-    tab_inactive_edge_bitmap = Property(depends_on="tab_inactive_edge")
+    tab_inactive_edge_bitmap = Property(observe="tab_inactive_edge")
 
     #: The bitmap for the 'tab_hover_edge' image:
-    tab_hover_edge_bitmap = Property(depends_on="tab_hover_edge")
+    tab_hover_edge_bitmap = Property(observe="tab_hover_edge")
 
     # -- Property Implementations ---------------------------------------------
 

--- a/traitsui/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
+++ b/traitsui/examples/demo/Advanced/Dynamic_range_trait_and_editor.py
@@ -50,7 +50,7 @@ Notes:
 
 - As with most traits code and examples, observe how much of the code is
   'declarative' versus 'imperative'. Note also the use of properties and
-  'depends_on' metadata, as well as 'cached_property' and 'on_trait_change'
+  'observe' metadata, as well as 'cached_property' and 'on_trait_change'
   method decorators.
 
 - Try dragging the guest tabs around so that you can see multiple guests
@@ -87,7 +87,7 @@ class Hotel(HasPrivateTraits):
     fuel_cost = Range(2.00, 10.00, 4.00)
 
     # The current minimum temparature allowed by the hotel:
-    min_temperature = Property(depends_on='season, fuel_cost')
+    min_temperature = Property(observe='season, fuel_cost')
 
     # The guests currently staying at the hotel:
     guests = List  # ( Instance( 'Guest' ) )
@@ -158,7 +158,7 @@ class Guest(HasPrivateTraits):
     plan = Enum('Flop house', 'Cheap', 'Cozy', 'Deluxe')
 
     # The maximum temperature allowed by the guest's plan:
-    max_temperature = Property(depends_on='plan')
+    max_temperature = Property(observe='plan')
 
     # The current room temperature as set by the guest:
     temperature = Range('hotel.min_temperature', 'max_temperature')

--- a/traitsui/examples/demo/Advanced/Property_List_demo.py
+++ b/traitsui/examples/demo/Advanced/Property_List_demo.py
@@ -16,7 +16,7 @@ interface, such as with the **TableEditor**.
 Most of the demo is just the machinery to set up the example. The key thing to
 note is the declaration of the *people* trait:
 
-    people = Property( List, depends_on = 'ticker' )
+    people = Property( List, observe = 'ticker' )
 
 In this case, by defining the **Property** as having a value of type
 **List**, you are ensuring that the computed value of the property will be
@@ -25,7 +25,7 @@ value is indeed a list, also guarantees that it will be converted to a
 **TraitListObject**, which is necessary for correct interaction with various
 Traits UI editors in a user interface.
 
-Note also the use of the *depends_on* metadata to trigger a trait property
+Note also the use of the *observe* metadata to trigger a trait property
 change whenever the *ticker* trait changes (in this case, it is changed
 every three seconds by a background thread).
 
@@ -69,7 +69,7 @@ class PropertyListDemo(HasPrivateTraits):
     ticker = Event()
 
     # The property being display in the TableEditor:
-    people = Property(List, depends_on='ticker')
+    people = Property(List, observe='ticker')
 
     # Tiny hack to allow starting the background thread easily:
     begin = Int()

--- a/traitsui/examples/demo/Advanced/Settable_cached_property.py
+++ b/traitsui/examples/demo/Advanced/Settable_cached_property.py
@@ -82,8 +82,8 @@ class SettableCachedProperty(HasTraits):
 
     a = Range(1, 10)
     b = Range(1, 10)
-    c = Property(Int, depends_on=['a', 'b'])
-    d = Property(depends_on='c')
+    c = Property(Int, observe=['a', 'b'])
+    d = Property(observe='c')
 
     view = View(
         Item('a'),

--- a/traitsui/examples/demo/Advanced/Statusbar_demo.py
+++ b/traitsui/examples/demo/Advanced/Statusbar_demo.py
@@ -42,7 +42,7 @@ class TextEditor(HasPrivateTraits):
     text = Str()
 
     # The current length of the text being edited:
-    length = Property(depends_on='text')
+    length = Property(observe='text')
 
     # The current time:
     time = Str()

--- a/traitsui/examples/demo/Advanced/Tabular_editor_demo.py
+++ b/traitsui/examples/demo/Advanced/Tabular_editor_demo.py
@@ -135,7 +135,7 @@ class Person(HasTraits):
 
     # surname is displayed in qt-only row label:
     surname = Property(fget=lambda self: self.name.split()[-1],
-                       depends_on='name')
+                       observe='name')
 
 
 # -- MarriedPerson Class Definition ---------------------------------------

--- a/traitsui/examples/demo/Applications/converter.py
+++ b/traitsui/examples/demo/Applications/converter.py
@@ -61,8 +61,8 @@ class Converter(HasStrictTraits):
     # Trait definitions:
     input_amount = CFloat(12.0, desc="the input quantity")
     input_units = Units('inches', desc="the input quantity's units")
-    output_amount = Property(depends_on=['input_amount', 'input_units',
-                                         'output_units'],
+    output_amount = Property(observe=['input_amount', 'input_units',
+                                      'output_units'],
                              desc="the output quantity")
     output_units = Units('feet', desc="the output quantity's units")
 

--- a/traitsui/examples/demo/Standard_Editors/CSVListEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/CSVListEditor_demo.py
@@ -54,7 +54,7 @@ class CSVListEditorDemo(HasTraits):
     sort1 = Button("Sort first list")
 
     # This will be str(self.list1).
-    list1str = Property(Str, depends_on='list1')
+    list1str = Property(Str, observe='list1')
 
     traits_view = View(
         HGroup(

--- a/traitsui/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
+++ b/traitsui/examples/demo/Standard_Editors/File_Dialog/File_Open_with_Custom_Extension.py
@@ -41,7 +41,7 @@ class LineCountInfo(MFileDialogModel):
     """
 
     # The number of text lines in the currently selected file:
-    lines = Property(depends_on='file_name')
+    lines = Property(observe='file_name')
 
     # -- Traits View Definitions ----------------------------------------------
 

--- a/traitsui/examples/demo/Standard_Editors/TitleEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/TitleEditor_demo.py
@@ -50,7 +50,7 @@ class TitleEditorDemo(HasTraits):
     title_2 = Str('Type into the text field below to change this title')
 
     # A title driven by the result of a calculation:
-    title_3 = Property(depends_on='value')
+    title_3 = Property(observe='value')
 
     # The number used to drive the calculation:
     value = Float()

--- a/traitsui/extras/_demo_legacy.py
+++ b/traitsui/extras/_demo_legacy.py
@@ -373,7 +373,7 @@ class DemoFileBase(DemoTreeNodeObject):
     parent = Any()
 
     #: Name of file system path to this file:
-    path = Property(depends_on='parent.path,name')
+    path = Property(observe='parent.path,name')
 
     #: Name of the file:
     name = Str()
@@ -388,7 +388,7 @@ class DemoFileBase(DemoTreeNodeObject):
     description = HTML()
 
     #: The base URL for links:
-    base_url = Property(depends_on='path')
+    base_url = Property(observe='path')
 
     #: The css file for this node.
     css_filename = Str("default.css")
@@ -548,13 +548,13 @@ class DemoPath(DemoTreeNodeObject):
     parent = Any()
 
     #: Name of file system path to this package:
-    path = Property(depends_on='parent.path,name')
+    path = Property(observe='parent.path,name')
 
     #: Description of what the demo does:
-    description = Property(HTML, depends_on="path,css_filename")
+    description = Property(HTML, observe="path,css_filename")
 
     #: The base URL for links:
-    base_url = Property(depends_on='path')
+    base_url = Property(observe='path')
 
     #: The css file for this node.
     css_filename = Str("default.css")

--- a/traitsui/file_dialog.py
+++ b/traitsui/file_dialog.py
@@ -165,16 +165,16 @@ class FileInfo(MFileDialogModel):
     """
 
     #: The size of the file:
-    size = Property(depends_on="file_name")
+    size = Property(observe="file_name")
 
     #: Last file access time:
-    atime = Property(depends_on="file_name")
+    atime = Property(observe="file_name")
 
     #: List file modification time:
-    mtime = Property(depends_on="file_name")
+    mtime = Property(observe="file_name")
 
     #: File creation time (or last metadata change time):
-    ctime = Property(depends_on="file_name")
+    ctime = Property(observe="file_name")
 
     # -- Traits View Definitions ----------------------------------------------
 
@@ -231,7 +231,7 @@ class TextInfo(MFileDialogModel):
     """
 
     #: The file's text content:
-    text = Property(depends_on="file_name")
+    text = Property(observe="file_name")
 
     # -- Traits View Definitions ----------------------------------------------
 
@@ -264,13 +264,13 @@ class ImageInfo(MFileDialogModel):
     """
 
     #: The ImageResource object for the current file:
-    image = Property(depends_on="file_name")
+    image = Property(observe="file_name")
 
     #: The width of the current image:
-    width = Property(depends_on="image")
+    width = Property(observe="image")
 
     #: The height of the current image:
-    height = Property(depends_on="image")
+    height = Property(observe="image")
 
     # -- Traits View Definitions ----------------------------------------------
 
@@ -479,10 +479,10 @@ class OpenFileDialog(Handler):
     is_save_file = Bool(False)
 
     #: Is the currently specified file name valid?
-    is_valid_file = Property(depends_on="file_name")
+    is_valid_file = Property(observe="file_name")
 
     #: Can a directory be created now?
-    can_create_dir = Property(depends_on="file_name")
+    can_create_dir = Property(observe="file_name")
 
     #: The OK, Cancel and create directory buttons:
     ok = Button("OK")

--- a/traitsui/group.py
+++ b/traitsui/group.py
@@ -179,10 +179,10 @@ class Group(ViewSubElement):
     padding = Padding
 
     #: Requested width of the group (calculated from widths of contents)
-    width = Property(Float, depends_on="content")
+    width = Property(Float, observe="content")
 
     #: Requested height of the group (calculated from heights of contents)
-    height = Property(Float, depends_on="content")
+    height = Property(Float, observe="content")
 
     def __init__(self, *values, **traits):
         """ Initializes the group object.

--- a/traitsui/key_bindings.py
+++ b/traitsui/key_bindings.py
@@ -106,7 +106,7 @@ class KeyBindings(HasPrivateTraits):
     parent = Instance("KeyBindings", transient=True)
 
     #: The root of the KeyBindings tree this object is part of:
-    root = Property(depends_on="parent")
+    root = Property(observe="parent")
 
     #: The child KeyBindings of this object (if any):
     children = List(transient=True)

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -118,9 +118,9 @@ class TableEditor(Editor, BaseTableEditor):
     selected = Any()
 
     #: The current selected row
-    selected_row = Property(Any, depends_on="selected")
+    selected_row = Property(Any, observe="selected")
 
-    selected_indices = Property(Any, depends_on="selected")
+    selected_indices = Property(Any, observe="selected")
 
     #: Current filter object (should be a TableFilter or callable or None):
     filter = Any()
@@ -1281,7 +1281,7 @@ class TableFilterEditor(HasTraits):
     filters = List(TableFilter)
 
     #: The list of available templates from which filters can be created
-    templates = Property(List(TableFilter), depends_on="filters")
+    templates = Property(List(TableFilter), observe="filters")
 
     #: The currently selected filter template
     selected_template = Instance(TableFilter)
@@ -1290,7 +1290,7 @@ class TableFilterEditor(HasTraits):
     selected_filter = Instance(TableFilter, allow_none=True)
 
     #: The view to use for the current filter
-    selected_filter_view = Property(depends_on="selected_filter")
+    selected_filter_view = Property(observe="selected_filter")
 
     #: Buttons for add/removing filters
     add_button = Button("New")

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -224,21 +224,21 @@ class TabularAdapter(HasPrivateTraits):
 
     #: The mapping from column indices to column identifiers (defined by the
     #: :py:attr:`columns` trait).
-    column_map = Property(depends_on="columns")
+    column_map = Property(observe="columns")
 
     #: The mapping from column indices to column labels (defined by the
     #: :py:attr:`columns` trait).
-    label_map = Property(depends_on="columns")
+    label_map = Property(observe="columns")
 
     #: The name of the trait on a row item containing the value to use
     #: as a row label. If ``None``, the label will be the empty string.
     row_label_name = Either(None, Str)
 
     #: For each adapter, specifies the column indices the adapter handles.
-    adapter_column_indices = Property(depends_on="adapters,columns")
+    adapter_column_indices = Property(observe="adapters,columns")
 
     #: For each adapter, specifies the mapping from column index to column id.
-    adapter_column_map = Property(depends_on="adapters,columns")
+    adapter_column_map = Property(observe="adapters,columns")
 
     # -------------------------------------------------------------------------
     # TabularAdapter interface

--- a/traitsui/tests/test_ui.py
+++ b/traitsui/tests/test_ui.py
@@ -60,7 +60,7 @@ class MaybeInvalidTrait(HasTraits):
 
     name = Str()
 
-    name_is_invalid = Property(depends_on="name")
+    name_is_invalid = Property(observe="name")
 
     traits_view = View(
         Item("name", invalid="name_is_invalid")

--- a/traitsui/theme.py
+++ b/traitsui/theme.py
@@ -43,7 +43,7 @@ class Theme(HasPrivateTraits):
     label_color = Property()
 
     #: The image slice used to draw the theme (Wx only)
-    image_slice = Property(depends_on="image")
+    image_slice = Property(observe="image")
 
     # -- Constructor ----------------------------------------------------------
 

--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -108,10 +108,10 @@ class TreeNode(HasPrivateTraits):
     node_for = List(Any)
 
     #: Tuple of object classes that the node applies to
-    node_for_class = Property(depends_on="node_for")
+    node_for_class = Property(observe="node_for")
 
     #: List of object interfaces that the node applies to
-    node_for_interface = Property(depends_on="node_for")
+    node_for_interface = Property(observe="node_for")
 
     #: Function for formatting the label
     formatter = Callable()

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -93,7 +93,7 @@ class UI(HasPrivateTraits):
     history = Any()
 
     #: The KeyBindings object (if any) for this UI:
-    key_bindings = Property(depends_on=["view._key_bindings", "context"])
+    key_bindings = Property(observe=["view._key_bindings", "context"])
 
     #: The unique ID for this UI for persistence
     id = Str()

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -94,12 +94,7 @@ class UI(HasPrivateTraits):
     history = Any()
 
     #: The KeyBindings object (if any) for this UI:
-    key_bindings = Property(
-        observe=[
-            trait("view._key_bindings", optional=True),
-            "context",
-        ]
-    )
+    key_bindings = Property(depends_on=["view._key_bindings", "context"])
 
     #: The unique ID for this UI for persistence
     id = Str()

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -32,6 +32,7 @@ from traits.api import (
     on_trait_change,
     property_depends_on,
 )
+from traits.observation.api import trait
 
 from traits.trait_base import traits_home, is_str
 
@@ -93,7 +94,12 @@ class UI(HasPrivateTraits):
     history = Any()
 
     #: The KeyBindings object (if any) for this UI:
-    key_bindings = Property(observe=["view._key_bindings", "context"])
+    key_bindings = Property(
+        observe=[
+            trait("view._key_bindings", optional=True),
+            "context",
+        ]
+    )
 
     #: The unique ID for this UI for persistence
     id = Str()


### PR DESCRIPTION
This PR replaces the use of `depends_on` metadata on Traits Properties with the use of `observe` metadata. Contributes towards #1052 