### PR TITLE
Dynamic otc to observe1

### DIFF
--- a/traitsui/editors/shell_editor.py
+++ b/traitsui/editors/shell_editor.py
@@ -56,11 +56,11 @@ class _ShellEditor(Editor):
         if locals is None:
             object = self.object
             shell.bind("self", object)
-            shell.on_trait_change(
+            shell.observe(
                 self.update_object, "command_executed", dispatch="ui"
             )
             if not isinstance(value, dict):
-                object.on_trait_change(self.update_any, dispatch="ui")
+                object.observe(self.update_any, dispatch="ui")
             else:
                 self._base_locals = locals = {}
                 for name in self._shell.interpreter().locals.keys():
@@ -120,24 +120,24 @@ class _ShellEditor(Editor):
                 for name, value in dic.items():
                     locals[name] = value
 
-    def update_any(self, object, name, old, new):
+    def update_any(self, event):
         """ Updates the editor when the object trait changes externally to the
             editor.
         """
         locals = self._shell.interpreter().locals
         if self._base_locals is None:
-            locals[name] = new
+            locals[event.name] = event.new
         else:
-            self.value[name] = new
+            self.value[event.name] = event.new
 
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
-        self._shell.on_trait_change(
-            self.update_object, "command_executed", remove=True
+        self._shell.observe(
+            self.update_object, "command_executed", remove=True, dispatch="ui"
         )
         if self._base_locals is None:
-            self.object.on_trait_change(self.update_any, remove=True)
+            self.object.observe(self.update_any, remove=True, dispatch="ui")
 
         super(_ShellEditor, self).dispose()
 

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -64,7 +64,7 @@ class SimpleEditor(Editor):
             self.control.toolButtonStyle = QtCore.Qt.ToolButtonTextOnly
             self.control.setText(self.string_value(label))
             self.object.observe(
-                self._update_menu, self.factory.values_trait + ":items"
+                self._update_menu, self.factory.values_trait + ".items"
             )
             self._menu = QtGui.QMenu()
             self._update_menu()
@@ -93,7 +93,7 @@ class SimpleEditor(Editor):
         if self.factory.values_trait:
             self.object.observe(
                 self._update_menu,
-                self.factory.values_trait + ":items",
+                self.factory.values_trait + ".items",
                 remove=True,
             )
 

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -64,7 +64,7 @@ class SimpleEditor(Editor):
             self.control.toolButtonStyle = QtCore.Qt.ToolButtonTextOnly
             self.control.setText(self.string_value(label))
             self.object.observe(
-                self._update_menu, self.factory.values_trait + ".items"
+                self._update_menu, self.factory.values_trait + ":items"
             )
             self._menu = QtGui.QMenu()
             self._update_menu()
@@ -93,7 +93,7 @@ class SimpleEditor(Editor):
         if self.factory.values_trait:
             self.object.observe(
                 self._update_menu,
-                self.factory.values_trait + ".items",
+                self.factory.values_trait + ":items",
                 remove=True,
             )
 

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -63,11 +63,8 @@ class SimpleEditor(Editor):
             self.control = QtGui.QToolButton()
             self.control.toolButtonStyle = QtCore.Qt.ToolButtonTextOnly
             self.control.setText(self.string_value(label))
-            self.object.on_trait_change(
-                self._update_menu, self.factory.values_trait
-            )
-            self.object.on_trait_change(
-                self._update_menu, self.factory.values_trait + "_items"
+            self.object.observe(
+                self._update_menu, self.factory.values_trait + ".items"
             )
             self._menu = QtGui.QMenu()
             self._update_menu()
@@ -94,14 +91,9 @@ class SimpleEditor(Editor):
         """
 
         if self.factory.values_trait:
-            self.object.on_trait_change(
+            self.object.observe(
                 self._update_menu,
-                self.factory.values_trait,
-                remove=True,
-            )
-            self.object.on_trait_change(
-                self._update_menu,
-                self.factory.values_trait + "_items",
+                self.factory.values_trait + ".items",
                 remove=True,
             )
 
@@ -112,7 +104,7 @@ class SimpleEditor(Editor):
     def _label_changed(self, label):
         self.control.setText(self.string_value(label))
 
-    def _update_menu(self):
+    def _update_menu(self, event=None):
         self._menu.blockSignals(True)
         self._menu.clear()
         for item in getattr(self.object, self.factory.values_trait):

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -98,13 +98,13 @@ class BaseEditor(Editor):
                 factory.name
             )
             self.values_changed()
-            self._object.on_trait_change(
+            self._object.observe(
                 self._values_changed, " " + self._name, dispatch="ui"
             )
         else:
             self._value = lambda: self.factory.values
             self.values_changed()
-            factory.on_trait_change(
+            factory.observe(
                 self._values_changed, "values", dispatch="ui"
             )
 
@@ -112,12 +112,15 @@ class BaseEditor(Editor):
         """ Disposes of the contents of an editor.
         """
         if self._object is not None:
-            self._object.on_trait_change(
-                self._values_changed, " " + self._name, remove=True
+            self._object.observe(
+                self._values_changed,
+                " " + self._name,
+                remove=True,
+                dispatch="ui"
             )
         else:
-            self.factory.on_trait_change(
-                self._values_changed, "values", remove=True
+            self.factory.observe(
+                self._values_changed, "values", remove=True, dispatch="ui"
             )
 
         super(BaseEditor, self).dispose()
@@ -145,7 +148,7 @@ class BaseEditor(Editor):
 
     # Trait change handlers --------------------------------------------------
 
-    def _values_changed(self):
+    def _values_changed(self, event=None):
         """ Handles the underlying object model's enumeration set or factory's
             values being changed.
         """

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -111,7 +111,7 @@ class CustomEditor(Editor):
 
             if factory.name != "":
                 self._object.observe(
-                    self.rebuild_items, self._name + ":items", dispatch="ui"
+                    self.rebuild_items, self._name + ".items", dispatch="ui"
                 )
 
             factory.observe(
@@ -351,7 +351,7 @@ class CustomEditor(Editor):
             if self._object is not None:
                 self._object.observe(
                     self.rebuild_items,
-                    self._name + ":items",
+                    self._name + ".items",
                     remove=True,
                     dispatch="ui"
                 )

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -111,7 +111,7 @@ class CustomEditor(Editor):
 
             if factory.name != "":
                 self._object.observe(
-                    self.rebuild_items, self._name + ".items", dispatch="ui"
+                    self.rebuild_items, self._name + ":items", dispatch="ui"
                 )
 
             factory.on_trait_change(
@@ -350,7 +350,7 @@ class CustomEditor(Editor):
         if self._choice is not None:
             if self._object is not None:
                 self._object.observe(
-                    self.rebuild_items, self._name + ".items", remove=True
+                    self.rebuild_items, self._name + ":items", remove=True
                 )
 
             self.factory.observe(

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -110,18 +110,12 @@ class CustomEditor(Editor):
             self.set_tooltip(self._choice)
 
             if factory.name != "":
-                self._object.on_trait_change(
-                    self.rebuild_items, self._name, dispatch="ui"
-                )
-                self._object.on_trait_change(
-                    self.rebuild_items, self._name + "_items", dispatch="ui"
+                self._object.observe(
+                    self.rebuild_items, self._name + ".items", dispatch="ui"
                 )
 
             factory.on_trait_change(
-                self.rebuild_items, "values", dispatch="ui"
-            )
-            factory.on_trait_change(
-                self.rebuild_items, "values_items", dispatch="ui"
+                self.rebuild_items, "values.items", dispatch="ui"
             )
 
             self.rebuild_items()
@@ -199,7 +193,7 @@ class CustomEditor(Editor):
 
         return items
 
-    def rebuild_items(self):
+    def rebuild_items(self, event=None):
         """ Rebuilds the object selector list.
         """
         # Clear the current cached values:
@@ -355,18 +349,12 @@ class CustomEditor(Editor):
 
         if self._choice is not None:
             if self._object is not None:
-                self._object.on_trait_change(
-                    self.rebuild_items, self._name, remove=True
-                )
-                self._object.on_trait_change(
-                    self.rebuild_items, self._name + "_items", remove=True
+                self._object.observe(
+                    self.rebuild_items, self._name + ".items", remove=True
                 )
 
-            self.factory.on_trait_change(
-                self.rebuild_items, "values", remove=True
-            )
-            self.factory.on_trait_change(
-                self.rebuild_items, "values_items", remove=True
+            self.factory.observe(
+                self.rebuild_items, "values.items", remove=True
             )
 
         super(CustomEditor, self).dispose()

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -114,7 +114,7 @@ class CustomEditor(Editor):
                     self.rebuild_items, self._name + ":items", dispatch="ui"
                 )
 
-            factory.on_trait_change(
+            factory.observe(
                 self.rebuild_items, "values.items", dispatch="ui"
             )
 
@@ -350,11 +350,14 @@ class CustomEditor(Editor):
         if self._choice is not None:
             if self._object is not None:
                 self._object.observe(
-                    self.rebuild_items, self._name + ":items", remove=True
+                    self.rebuild_items,
+                    self._name + ":items",
+                    remove=True,
+                    dispatch="ui"
                 )
 
             self.factory.observe(
-                self.rebuild_items, "values.items", remove=True
+                self.rebuild_items, "values.items", remove=True, dispatch="ui"
             )
 
         super(CustomEditor, self).dispose()

--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -170,8 +170,8 @@ class _ListStrEditor(Editor):
 
         # Make sure we listen for 'items' changes as well as complete list
         # replacements:
-        self.context_object.on_trait_change(
-            self.update_editor, self.extended_name + "_items", dispatch="ui"
+        self.context_object.observe(
+            self.update_editor, self.extended_name + ".items", dispatch="ui"
         )
 
         # Create the mapping from user supplied images to QIcons:
@@ -179,7 +179,7 @@ class _ListStrEditor(Editor):
             self._add_image(image_resource)
 
         # Refresh the editor whenever the adapter changes:
-        self.on_trait_change(
+        self.observe(
             self.refresh_editor, "adapter.+update", dispatch="ui"
         )
 
@@ -191,13 +191,15 @@ class _ListStrEditor(Editor):
         """
         self.model.beginResetModel()
         self.model.endResetModel()
-
-        self.context_object.on_trait_change(
-            self.update_editor, self.extended_name + "_items", remove=True
+        self.context_object.observe(
+            self.update_editor,
+            self.extended_name + ".items",
+            remove=True,
+            dispatch="ui"
         )
 
-        self.on_trait_change(
-            self.refresh_editor, "adapter.+update", remove=True
+        self.observe(
+            self.refresh_editor, "adapter.+update", remove=True, dispatch="ui"
         )
         if self._header_view is not None:
             self._header_view.setModel(None)
@@ -207,7 +209,7 @@ class _ListStrEditor(Editor):
 
         super(Editor, self).dispose()
 
-    def update_editor(self):
+    def update_editor(self, event=None):
         """ Updates the editor when the object trait changes externally to the
             editor.
         """
@@ -224,7 +226,7 @@ class _ListStrEditor(Editor):
     #  ListStrEditor interface:
     # -------------------------------------------------------------------------
 
-    def refresh_editor(self):
+    def refresh_editor(self, event=None):
         """ Requests that the underlying list widget to redraw itself.
         """
         self.list_view.viewport().update()

--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -171,7 +171,7 @@ class _ListStrEditor(Editor):
         # Make sure we listen for 'items' changes as well as complete list
         # replacements:
         self.context_object.observe(
-            self.update_editor, self.extended_name + ":items", dispatch="ui"
+            self.update_editor, self.extended_name + ".items", dispatch="ui"
         )
 
         # Create the mapping from user supplied images to QIcons:
@@ -193,7 +193,7 @@ class _ListStrEditor(Editor):
         self.model.endResetModel()
         self.context_object.observe(
             self.update_editor,
-            self.extended_name + ":items",
+            self.extended_name + ".items",
             remove=True,
             dispatch="ui"
         )

--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -171,7 +171,7 @@ class _ListStrEditor(Editor):
         # Make sure we listen for 'items' changes as well as complete list
         # replacements:
         self.context_object.observe(
-            self.update_editor, self.extended_name + ".items", dispatch="ui"
+            self.update_editor, self.extended_name + ":items", dispatch="ui"
         )
 
         # Create the mapping from user supplied images to QIcons:
@@ -193,7 +193,7 @@ class _ListStrEditor(Editor):
         self.model.endResetModel()
         self.context_object.observe(
             self.update_editor,
-            self.extended_name + ".items",
+            self.extended_name + ":items",
             remove=True,
             dispatch="ui"
         )


### PR DESCRIPTION
contributes to #1052 

This PR updates a few editors to use dynamic `observe` instead of `on_trait_change`. More similar PRs to follow 