### PR TITLE
Dynamic otc to observe 2

### DIFF
--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -402,7 +402,6 @@ class BaseDialog(BasePanel):
 
         def set_status_text(event):
             text = event.new
-            if control:
-                control.setText(text)
+            control.setText(text)
 
         return set_status_text

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -105,19 +105,22 @@ class BasePanel(_BasePanel):
 
         return button
 
-    def _on_undoable(self, state):
+    def _on_undoable(self, event):
         """Handles a change to the "undoable" state of the undo history
         """
+        state = event.new
         self.undo.setEnabled(state)
 
-    def _on_redoable(self, state):
+    def _on_redoable(self, event):
         """Handles a change to the "redoable" state of the undo history.
         """
+        state = event.new
         self.redo.setEnabled(state)
 
-    def _on_revertable(self, state):
+    def _on_revertable(self, event):
         """ Handles a change to the "revert" state.
         """
+        state = event.new
         self.revert.setEnabled(state)
 
 
@@ -330,9 +333,9 @@ class BaseDialog(BasePanel):
 
         self.control.setWindowIcon(icon.create_icon())
 
-    def _on_error(self, errors):
+    def _on_error(self, event):
         """Handles editing errors."""
-
+        errors = event.new
         self.ok.setEnabled(errors == 0)
 
     def _add_menubar(self):

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -390,7 +390,7 @@ class BaseDialog(BasePanel):
                     name = name[col + 1 :]
                 obj = self.ui.context[obj]
                 set_text = self._set_status_text(item_control)
-                obj.on_trait_change(set_text, name, dispatch="ui")
+                obj.observe(set_text, name, dispatch="ui")
                 listeners.append((obj, set_text, name))
 
             self.control._mw.setStatusBar(control)
@@ -400,7 +400,8 @@ class BaseDialog(BasePanel):
         """ Helper function for _add_statusbar.
         """
 
-        def set_status_text(text):
+        def set_status_text(event):
+            text = event.new
             control.setText(text)
 
         return set_status_text

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -402,6 +402,7 @@ class BaseDialog(BasePanel):
 
         def set_status_text(event):
             text = event.new
-            control.setText(text)
+            if control:
+                control.setText(text)
 
         return set_status_text

--- a/traitsui/qt4/ui_live.py
+++ b/traitsui/qt4/ui_live.py
@@ -92,14 +92,14 @@ class _LiveWindow(BaseDialog):
 
         if self.control is not None:
             if history is not None:
-                history.on_trait_change(
-                    self._on_undoable, "undoable", remove=True
+                history.observe(
+                    self._on_undoable, "undoable", remove=True, dispatch="ui"
                 )
-                history.on_trait_change(
-                    self._on_redoable, "redoable", remove=True
+                history.observe(
+                    self._on_redoable, "redoable", remove=True, dispatch="ui"
                 )
-                history.on_trait_change(
-                    self._on_revertable, "undoable", remove=True
+                history.observe(
+                    self._on_revertable, "undoable", remove=True, dispatch="ui"
                 )
 
             ui.reset()
@@ -158,7 +158,7 @@ class _LiveWindow(BaseDialog):
                         False,
                         default=default,
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_undoable, "undoable", dispatch="ui"
                     )
                     if history.can_undo:
@@ -172,7 +172,7 @@ class _LiveWindow(BaseDialog):
                         False,
                         "Redo",
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_redoable, "redoable", dispatch="ui"
                     )
                     if history.can_redo:
@@ -187,7 +187,7 @@ class _LiveWindow(BaseDialog):
                         False,
                         default=default,
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_revertable, "undoable", dispatch="ui"
                     )
                     if history.can_undo:
@@ -201,7 +201,7 @@ class _LiveWindow(BaseDialog):
                         self.control.accept,
                         default=default,
                     )
-                    ui.on_trait_change(self._on_error, "errors", dispatch="ui")
+                    ui.observe(self._on_error, "errors", dispatch="ui")
 
                 elif self.is_button(button, "Cancel"):
                     self.add_button(

--- a/traitsui/qt4/ui_modal.py
+++ b/traitsui/qt4/ui_modal.py
@@ -133,7 +133,7 @@ class _ModalDialog(BaseDialog):
                         enabled=apply,
                         default=default,
                     )
-                    ui.on_trait_change(
+                    ui.observe(
                         self._on_applyable, "modified", dispatch="ui"
                     )
 
@@ -155,7 +155,7 @@ class _ModalDialog(BaseDialog):
                         self.control.accept,
                         default=default,
                     )
-                    ui.on_trait_change(self._on_error, "errors", dispatch="ui")
+                    ui.observe(self._on_error, "errors", dispatch="ui")
 
                 elif self.is_button(button, "Cancel"):
                     self.add_button(
@@ -242,9 +242,10 @@ class _ModalDialog(BaseDialog):
         ui.handler.apply(ui.info)
         ui.modified = False
 
-    def _on_applyable(self, state):
+    def _on_applyable(self, event):
         """Handles a change to the "modified" state of the user interface .
         """
+        state = event.new
         self.apply.setEnabled(state)
 
     def _on_revert(self):

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -107,10 +107,14 @@ class _Panel(BasePanel):
 
         # Reset any existing history listeners.
         if history is not None:
-            history.on_trait_change(self._on_undoable, "undoable", remove=True)
-            history.on_trait_change(self._on_redoable, "redoable", remove=True)
-            history.on_trait_change(
-                self._on_revertable, "undoable", remove=True
+            history.observe(
+                self._on_undoable, "undoable", remove=True, dispatch="ui"
+            )
+            history.observe(
+                self._on_redoable, "redoable", remove=True, dispatch="ui"
+            )
+            history.observe(
+                self._on_revertable, "undoable", remove=True, dispatch="ui"
             )
 
         # Determine if we need any buttons or an 'undo' history.
@@ -197,10 +201,10 @@ class _Panel(BasePanel):
                         self.redo = self.add_button(
                             button, bbox, role, self._on_redo, False, "Redo"
                         )
-                        history.on_trait_change(
+                        history.observe(
                             self._on_undoable, "undoable", dispatch="ui"
                         )
-                        history.on_trait_change(
+                        history.observe(
                             self._on_redoable, "redoable", dispatch="ui"
                         )
                     elif self.is_button(button, "Revert"):
@@ -208,7 +212,7 @@ class _Panel(BasePanel):
                         self.revert = self.add_button(
                             button, bbox, role, self._on_revert, False
                         )
-                        history.on_trait_change(
+                        history.observe(
                             self._on_revertable, "undoable", dispatch="ui"
                         )
                     elif self.is_button(button, "Help"):

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -317,7 +317,7 @@ class UI(HasPrivateTraits):
 
         # Remove any statusbar listeners that have been set up:
         for object, handler, name in self._statusbar:
-            object.on_trait_change(handler, name, remove=True)
+            object.observe(handler, name, remove=True, dispatch="ui")
 
         del self._statusbar[:]
 

--- a/traitsui/wx/ui_base.py
+++ b/traitsui/wx/ui_base.py
@@ -132,7 +132,7 @@ class BaseDialog(_BasePanel):
                     object = name[:col]
                     name = name[col + 1 :]
                 object = context[object]
-                object.on_trait_change(set_text, name, dispatch="ui")
+                object.observe(set_text, name, dispatch="ui")
                 listeners.append((object, set_text, name))
 
             control.SetStatusWidths(widths)
@@ -140,7 +140,8 @@ class BaseDialog(_BasePanel):
             ui._statusbar = listeners
 
     def _set_status_text(self, control, i):
-        def set_status_text(text):
+        def set_status_text(event):
+            text = event.new
             control.SetStatusText(text, i)
 
         return set_status_text

--- a/traitsui/wx/ui_live.py
+++ b/traitsui/wx/ui_live.py
@@ -102,14 +102,14 @@ class LiveWindow(BaseDialog):
         window = ui.control
         if window is not None:
             if history is not None:
-                history.on_trait_change(
-                    self._on_undoable, "undoable", remove=True
+                history.observe(
+                    self._on_undoable, "undoable", remove=True, dispatch="ui"
                 )
-                history.on_trait_change(
-                    self._on_redoable, "redoable", remove=True
+                history.observe(
+                    self._on_redoable, "redoable", remove=True, dispatch="ui"
                 )
-                history.on_trait_change(
-                    self._on_revertable, "undoable", remove=True
+                history.observe(
+                    self._on_revertable, "undoable", remove=True, dispatch="ui"
                 )
             window.SetSizer(None)
             ui.reset()
@@ -235,10 +235,10 @@ class LiveWindow(BaseDialog):
                     self.redo = self.add_button(
                         button, b_sizer, self._on_redo, False, "Redo"
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_undoable, "undoable", dispatch="ui"
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_redoable, "redoable", dispatch="ui"
                     )
                     if history.can_undo:
@@ -255,7 +255,7 @@ class LiveWindow(BaseDialog):
                         False,
                         default=default,
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_revertable, "undoable", dispatch="ui"
                     )
                     if history.can_undo:
@@ -265,7 +265,7 @@ class LiveWindow(BaseDialog):
                     self.ok = self.add_button(
                         button, b_sizer, self._on_ok, default=default
                     )
-                    ui.on_trait_change(self._on_error, "errors", dispatch="ui")
+                    ui.observe(self._on_error, "errors", dispatch="ui")
 
                 elif self.is_button(button, "Cancel"):
                     self.add_button(
@@ -352,24 +352,28 @@ class LiveWindow(BaseDialog):
             self._on_revert(event)
             self.close(wx.ID_CANCEL)
 
-    def _on_error(self, errors):
+    def _on_error(self, event):
         """ Handles editing errors.
         """
+        errors = event.new
         self.ok.Enable(errors == 0)
 
-    def _on_undoable(self, state):
+    def _on_undoable(self, event):
         """ Handles a change to the "undoable" state of the undo history
         """
+        state = event.new
         self.undo.Enable(state)
 
-    def _on_redoable(self, state):
+    def _on_redoable(self, event):
         """ Handles a change to the "redoable state of the undo history.
         """
+        state = event.new
         self.redo.Enable(state)
 
-    def _on_revertable(self, state):
+    def _on_revertable(self, event):
         """ Handles a change to the "revert" state.
         """
+        state = event.new
         self.revert.Enable(state)
 
 

--- a/traitsui/wx/ui_modal.py
+++ b/traitsui/wx/ui_modal.py
@@ -163,7 +163,7 @@ class ModalDialog(BaseDialog):
                     self.apply = self.add_button(
                         button, b_sizer, self._on_apply, apply, default=default
                     )
-                    ui.on_trait_change(
+                    ui.observe(
                         self._on_applyable, "modified", dispatch="ui"
                     )
 
@@ -180,7 +180,7 @@ class ModalDialog(BaseDialog):
                     self.ok = self.add_button(
                         button, b_sizer, self._on_ok, default=default
                     )
-                    ui.on_trait_change(self._on_error, "errors", dispatch="ui")
+                    ui.observe(self._on_error, "errors", dispatch="ui")
 
                 elif self.is_button(button, "Cancel"):
                     self.add_button(
@@ -294,12 +294,14 @@ class ModalDialog(BaseDialog):
         ui.handler.revert(ui.info)
         ui.modified = False
 
-    def _on_applyable(self, state):
+    def _on_applyable(self, event):
         """ Handles a change to the "modified" state of the user interface .
         """
+        state = event.new
         self.apply.Enable(state)
 
-    def _on_error(self, errors):
+    def _on_error(self, event):
         """ Handles editing errors.
         """
+        errors = event.new
         self.ok.Enable(errors == 0)

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -119,10 +119,14 @@ class Panel(BaseDialog):
         # Reset any existing history listeners:
         history = ui.history
         if history is not None:
-            history.on_trait_change(self._on_undoable, "undoable", remove=True)
-            history.on_trait_change(self._on_redoable, "redoable", remove=True)
-            history.on_trait_change(
-                self._on_revertable, "undoable", remove=True
+            history.observe(
+                self._on_undoable, "undoable", remove=True, dispatch="ui"
+            )
+            history.observe(
+                self._on_redoable, "redoable", remove=True, dispatch="ui"
+            )
+            history.observe(
+                self._on_revertable, "undoable", remove=True, dispatch="ui"
             )
 
         # Determine if we need any buttons or an 'undo' history:
@@ -191,17 +195,17 @@ class Panel(BaseDialog):
                     self.redo = self.add_button(
                         button, b_sizer, self._on_redo, False, "Redo"
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_undoable, "undoable", dispatch="ui"
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_redoable, "redoable", dispatch="ui"
                     )
                 elif self.is_button(button, "Revert"):
                     self.revert = self.add_button(
                         button, b_sizer, self._on_revert, False
                     )
-                    history.on_trait_change(
+                    history.observe(
                         self._on_revertable, "undoable", dispatch="ui"
                     )
                 elif self.is_button(button, "Help"):
@@ -213,19 +217,22 @@ class Panel(BaseDialog):
 
         cpanel.SetSizerAndFit(sw_sizer)
 
-    def _on_undoable(self, state):
+    def _on_undoable(self, event):
         """ Handles a change to the "undoable" state of the undo history.
         """
+        state = event.new
         self.undo.Enable(state)
 
-    def _on_redoable(self, state):
+    def _on_redoable(self, event):
         """ Handles a change to the "redoable" state of the undo history.
         """
+        state = event.new
         self.redo.Enable(state)
 
-    def _on_revertable(self, state):
+    def _on_revertable(self, event):
         """ Handles a change to the "revert" state.
         """
+        state = event.new
         self.revert.Enable(state)
 
     def add_toolbar(self, sizer):


### PR DESCRIPTION
contributes to #1052

This PR updates a few files to use dynamic `observe` instead of `on_trait_change`. More similar PRs to follow