### PR TITLE
Extend / document secret TreeNode api for passing tuples into `add` list trait

### DIFF
--- a/traitsui/examples/demo/Advanced/Tree_editor_required_traits_demo.py
+++ b/traitsui/examples/demo/Advanced/Tree_editor_required_traits_demo.py
@@ -1,0 +1,154 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+This is a modified version of the Standard_Editors/TreeEditor_demo.py in which
+the `Employee` class is now a subclass of HasRequiredTraits.  Thus, to create a
+new `TreeNode` for `Employee`, to create the associated `Employee` object we
+can not simply do `Employee()`. Luckily the `TreeNode` API provides a means for
+specifying a callable that returns a created instance when we want to add a new
+node. To do so we can simply pass a tuple of the for (klass, prompt, factorry)
+as an item the `add` list trait for a TreeNode. klass is the class of object we
+want to be addable, prompt is a boolean indicating whether or not we want to
+prompt the user to specify traits after we instantiate the object before it is
+added to the tree, and factory is the previously described callable that must
+return an instance of klass.
+"""
+
+from traits.api import HasRequiredTraits, HasTraits, Str, Regex, List, Instance
+
+from traitsui.api import Item, View, TreeEditor, TreeNode
+
+
+class Employee(HasRequiredTraits):
+    """ Defines a company employee. """
+
+    name = Str('<unknown>')
+    title = Str()
+    phone = Regex(regex=r'\d\d\d-\d\d\d\d')
+
+    def default_title(self):
+        self.title = 'Senior Engineer'
+
+
+def create_default_employee():
+    return Employee(name="Dilbert", title="Engineer", phone="999-8212")
+
+
+class Department(HasTraits):
+    """ Defines a department with employees. """
+
+    name = Str('<unknown>')
+    employees = List(Employee)
+
+
+class Company(HasTraits):
+    """ Defines a company with departments and employees. """
+
+    name = Str('<unknown>')
+    departments = List(Department)
+    employees = List(Employee)
+
+
+# Create an empty view for objects that have no data to display:
+no_view = View()
+
+# Define the TreeEditor used to display the hierarchy:
+tree_editor = TreeEditor(
+    nodes=[
+        # The first node specified is the top level one
+        TreeNode(
+            node_for=[Company],
+            auto_open=True,
+            # child nodes are
+            children='',
+            label='name',  # label with Company name
+            view=View(['name'])
+        ),
+        TreeNode(
+            node_for=[Company],
+            auto_open=True,
+            children='departments',
+            label='=Departments',  # constant label
+            view=no_view,
+            add=[Department],
+         ),
+        TreeNode(
+            node_for=[Company],
+            auto_open=True,
+            children='employees',
+            label='=Employees',   # constant label
+            view=no_view,
+            add=[(Employee, True, create_default_employee)]
+        ),
+        TreeNode(
+            node_for=[Department],
+            auto_open=True,
+            children='employees',
+            label='name',   # label with Department name
+            view=View(['name']),
+            add=[(Employee, True, create_default_employee)]
+        ),
+        TreeNode(
+            node_for=[Employee],
+            auto_open=True,
+            label='name',   # label with Employee name
+            view=View(['name', 'title', 'phone'])
+        )
+    ]
+)
+
+
+class Partner(HasTraits):
+    """ Defines a business partner."""
+
+    name = Str('<unknown>')
+    company = Instance(Company)
+
+    traits_view = View(
+        Item(name='company', editor=tree_editor, show_label=False),
+        title='Company Structure',
+        buttons=['OK'],
+        resizable=True,
+        style='custom',
+        width=.3,
+        height=500
+    )
+
+
+# Create an example data structure:
+jason = Employee(name='Jason', title='Senior Engineer', phone='536-1057')
+mike = Employee(name='Mike', title='Senior Engineer', phone='536-1057')
+dave = Employee(name='Dave', title='Senior Developer', phone='536-1057')
+martin = Employee(name='Martin', title='Senior Engineer', phone='536-1057')
+duncan = Employee(name='Duncan', title='Consultant', phone='526-1057')
+
+# Create the demo:
+demo = Partner(
+    name='Enthought, Inc.',
+    company=Company(
+        name='Enthought',
+        employees=[dave, martin, duncan, jason, mike],
+        departments=[
+            Department(
+                name='Business',
+                employees=[jason, mike]
+            ),
+            Department(
+                name='Scientific',
+                employees=[dave, martin, duncan]
+            )
+        ]
+    )
+)
+
+# Run the demo (if invoked from the command line):
+if __name__ == '__main__':
+    demo.configure_traits()

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1059,7 +1059,9 @@ class SimpleEditor(Editor):
         for klass in add:
             prompt = False
             if isinstance(klass, tuple):
-                klass, prompt = klass
+                klass, prompt, *factory_list = klass
+                if factory_list:
+                    factory = factory_list[0]
             add_node = self._node_for_class(klass)
             if add_node is None:
                 continue
@@ -1067,7 +1069,8 @@ class SimpleEditor(Editor):
             name = add_node.get_name(object)
             if name == "":
                 name = class_name
-            factory = klass
+            if not factory:
+                factory = klass
             def perform_add(object):
                 self._menu_new_node(factory, prompt)
             items.append(Action(name=name, on_perform=perform_add))

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1318,13 +1318,7 @@ class SimpleEditor(Editor):
         """
         node, object, nid = self._data
         self._data = None
-        try:
-            new_object = factory()
-        except:
-            from traitsui.api import raise_to_debug
-            raise_to_debug()
-            return
-
+        new_object = factory()
         if (not prompt) or new_object.edit_traits(
             parent=self.control, kind="livemodal"
         ).result:

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1060,9 +1060,10 @@ class SimpleEditor(Editor):
             prompt = False
             factory = None
             if isinstance(klass, tuple):
-                klass, prompt, *factory_list = klass
-                if factory_list:
-                    factory = factory_list[0]
+                if len(klass) == 2:
+                    klass, prompt = klass
+                elif len(klass) == 3:
+                    klass, prompt, factory = klass
             add_node = self._node_for_class(klass)
             if add_node is None:
                 continue

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1058,6 +1058,7 @@ class SimpleEditor(Editor):
 
         for klass in add:
             prompt = False
+            factory = None
             if isinstance(klass, tuple):
                 klass, prompt, *factory_list = klass
                 if factory_list:

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -1071,7 +1071,7 @@ class SimpleEditor(Editor):
             name = add_node.get_name(object)
             if name == "":
                 name = class_name
-            if not factory:
+            if factory is None:
                 factory = klass
             def perform_add(object):
                 self._menu_new_node(factory, prompt)

--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -98,7 +98,10 @@ class TreeNode(HasPrivateTraits):
     #: Automatically close sibling tree nodes?
     auto_close = Bool(False)
 
-    #: List of object classes than can be added or copied
+    #: List of object classes than can be added or copied. Elements of the list
+    #: can be 2-tuples in which case the first item is the object class that
+    #: can be added and the second is a boolean indicating whether or not to
+    #: prompt the user for specific input of traits when adding the object.
     add = List(Any)
 
     #: List of object classes that can be moved

--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -99,9 +99,16 @@ class TreeNode(HasPrivateTraits):
     auto_close = Bool(False)
 
     #: List of object classes than can be added or copied. Elements of the list
-    #: can be 2-tuples in which case the first item is the object class that
-    #: can be added and the second is a boolean indicating whether or not to
-    #: prompt the user for specific input of traits when adding the object.
+    #: can be either:
+    #: - the klass itself that can be added or copied
+    #: - 2-tuples of the form (klass, prompt) in which case klass is as above
+    #:   and prompt is a boolean indicating whether or not to prompt the user
+    #:   to specify trait values after instantiation when adding the object.
+    #: - 3-tuples of the form (klass, prompt, factory) in which case klass and
+    #:   prompt are as above.  factory is a callable that is expected to return
+    #:   an instance of klass.  Useful if klass has required traits. Otherwise
+    #:   added object is created by simply instantiating klass()
+    #:   ref: enthought/traits#1502
     add = List(Any)
 
     #: List of object classes that can be moved

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -1247,9 +1247,10 @@ class SimpleEditor(Editor):
             prompt = False
             factory = None
             if isinstance(klass, tuple):
-                klass, prompt, *factory_list = klass
-                if factory_list:
-                    factory = factory_list[0]
+                if len(klass) == 2:
+                    klass, prompt = klass
+                elif len(klass) == 3:
+                    klass, prompt, factory = klass
             add_node = self._node_for_class(klass)
             if add_node is None:
                 continue

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -1246,7 +1246,9 @@ class SimpleEditor(Editor):
         for klass in add:
             prompt = False
             if isinstance(klass, tuple):
-                klass, prompt = klass
+                klass, prompt, *factory_list = klass
+                if factory_list:
+                    factory = factory_list[0]
             add_node = self._node_for_class(klass)
             if add_node is None:
                 continue
@@ -1254,7 +1256,8 @@ class SimpleEditor(Editor):
             name = add_node.get_name(object)
             if name == "":
                 name = class_name
-            factory = klass
+            if not factory:
+                factory = klass
             def perform_add(object):
                 self._menu_new_node(factory, prompt)
             items.append(Action(name=name, on_perform=perform_add))

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -1245,6 +1245,7 @@ class SimpleEditor(Editor):
 
         for klass in add:
             prompt = False
+            factory = None
             if isinstance(klass, tuple):
                 klass, prompt, *factory_list = klass
                 if factory_list:

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -1564,13 +1564,7 @@ class SimpleEditor(Editor):
         """
         node, object, nid = self._data
         self._data = None
-        try:
-            new_object = factory()
-        except:
-            from traitsui.api import raise_to_debug
-            raise_to_debug()
-            return
-
+        new_object = factory()
         if (not prompt) or new_object.edit_traits(
             parent=self.control, kind="livemodal"
         ).result:


### PR DESCRIPTION
closes #1502 

This is part 2 from this comment: https://github.com/enthought/traitsui/pull/1518#issuecomment-776682726 which follows up the changes made in #1524.

Previously there was already a _secret_ part of the `TreeNode` api in which users could pass in a 2-tuple as an element in the list supplied for the `add` trait of a `TreeNode`.  The first element of the tuple would be used as the klass to be added, and the second was a `prompt` boolean, which when true would call `edit_traits` on the new object before fully adding it to the tree to prompt the user to change traits if they want to.  I did not see this actually documented anywhere, but from the code I believe that was the idea (and testing locally that is what happens).
In this PR I simply extend that secret api to now also potentially accept a 3-tuple, where the last tuple element in a factory callable that when called produces an instance of klass.  I did not enforce, but I imagine in such cases there is a high probability of us wanting `prompt=True`.  I've documented the old and new secret options on the add trait so that it shows up in the api docs.  Further I've added a demo showcasing the functionality.  The added demo is exactly the example code given in the original issue, modified to use this new functionality.

The specific tuple checking is a little weird and maybe we want to refactor / re-engineer how we go about doing this.  This was just a first stab at a solution that made use of something already pretty much in place in the api, so it was pretty easy to introduce.

Another important thing to note: I made the change to now be loud in `_menu_new_node` if `factory()` fails because users have a means for doing the right thing now.  We may not want to do this though to avoid breaking existing code / forcing them to do the new thing.  i.e. before they have a `HasRequiredTraits` class and trying to add a new node does nothing (doesn't fail though) to now trying to do that leads to failure.  Forcing them to pass a 3-tuple with factory now.
Actually as I am writing this I am realizing it is probably too early to start being loud there... But also if we are not loud people may never notice the new functionality and never switch...?  
I am happy to include or remove this change as a reviewer sees fit, I am not sure what the correct approach is.  I _imagine_ we are going to want to stay quiet about it at least for now.


Also, this PR still needs a test!  I am unsure of how to best do this as UI Tester still doesn't support TreeEditor and IDK if I should be explicitly testing the individual private methods that were changed... 🤔 