### PR TITLE
StartStyling API changed for new Wx version

### DIFF
--- a/traitsui/wx/code_editor.py
+++ b/traitsui/wx/code_editor.py
@@ -355,17 +355,17 @@ class SourceEditor(Editor):
 
             if line + 1 in self.dim_lines:
                 # Set styling mask to only style text bits, not indicator bits
-                self.control.StartStyling(position, 0x1F)
+                self.control.StartStyling(position)
                 self.control.SetStyling(style_length, self._dim_style_number)
             elif self.lexer == stc.STC_LEX_NULL:
-                self.control.StartStyling(position, 0x1F)
+                self.control.StartStyling(position)
                 self.control.SetStyling(style_length, stc.STC_STYLE_DEFAULT)
 
             if line + 1 in self.squiggle_lines:
-                self.control.StartStyling(position, stc.STC_INDIC2_MASK)
+                self.control.StartStyling(position)
                 self.control.SetStyling(style_length, stc.STC_INDIC2_MASK)
             else:
-                self.control.StartStyling(position, stc.STC_INDIC2_MASK)
+                self.control.StartStyling(position)
                 self.control.SetStyling(style_length, stc.STC_STYLE_DEFAULT)
 
     def error(self, excp):


### PR DESCRIPTION
fixes #1535 

Ref https://wxpython.org/Phoenix/docs/html/wx.stc.StyledTextCtrl.html#wx.stc.StyledTextCtrl.StartStyling