### PR TITLE
Document enabled_when / visible_when better

### DIFF
--- a/docs/source/traitsui_user_manual/advanced_view.rst
+++ b/docs/source/traitsui_user_manual/advanced_view.rst
@@ -349,7 +349,15 @@ instead of wrapping it in a dictionary.
 
 When the ui() method is called from configure_traits() or edit_traits() on a
 HasTraits object, the relevant object is the HasTraits object whose method was
-called. For this reason, you do not need to specify the *context* argument in
+called. 
+
+.. NOTE::
+
+   There are some situations in which you may want to override the default
+   context used for a particular HasTraits class. To do this, simpy override the
+   :py:meth:`~.traits.has_traits.HasTraits.trait_context` method on the object.
+
+For this reason, you do not need to specify the *context* argument in
 most calls to configure_traits() or edit_traits(). However, when you call the
 ui() method on a View object, you *must* specify the *context* parameter, so
 that the ui() method receives references to the objects whose trait attributes

--- a/docs/source/traitsui_user_manual/view.rst
+++ b/docs/source/traitsui_user_manual/view.rst
@@ -244,9 +244,17 @@ Visibility and status
    :term:`Handler` (see :ref:`controlling-the-interface-the-handler`).
 
    enabled_when: str
-      Expression that determines whether the group can be edited.
+      Python expression that determines whether the group can be edited.
+      The expression will be evaluated any time a trait on an object in the
+      UI's context is changed. As a result, changes to nested traits that don't
+      also change a trait on some object in the context may not trigger the
+      expression to be evaluated.
    visible_when: str
-      Expression that determines visibility of group.
+      Python expression that determines visibility of group. The expression
+      will be evaluated any time a trait on an object in the UI's context is
+      changed. As a result, changes to nested traits that don't also change a
+      trait on some object in the context may not trigger the expression to be
+      evaluated.
    defined_when: str
       Expression that determines inclusion of group in parent.
    has_focus: bool
@@ -482,9 +490,17 @@ Visibility and status
    These attributes work similarly to the attributes of the same names on the Item class.
 
    enabled_when: str
-      Expression that determines whether the group can be edited.
+      Python expression that determines whether the group can be edited.
+      The expression will be evaluated any time a trait on an object in the
+      UI's context is changed. As a result, changes to nested traits that don't
+      also change a trait on some object in the context may not trigger the
+      expression to be evaluated.
    visible_when: str
-      Expression that determines visibility of group.
+      Python expression that determines visibility of group. The expression
+      will be evaluated any time a trait on an object in the UI's context is
+      changed. As a result, changes to nested traits that don't also change a
+      trait on some object in the context may not trigger the expression to be
+      evaluated.
    defined_when: str
       Expression that determines inclusion of group in parent.
 

--- a/docs/source/traitsui_user_manual/view.rst
+++ b/docs/source/traitsui_user_manual/view.rst
@@ -244,7 +244,7 @@ Visibility and status
    :term:`Handler` (see :ref:`controlling-the-interface-the-handler`).
 
    enabled_when: str
-      Expression that determines whether of group can be edited.
+      Expression that determines whether the group can be edited.
    visible_when: str
       Expression that determines visibility of group.
    defined_when: str
@@ -482,7 +482,7 @@ Visibility and status
    These attributes work similarly to the attributes of the same names on the Item class.
 
    enabled_when: str
-      Expression that determines whether of group can be edited.
+      Expression that determines whether the group can be edited.
    visible_when: str
       Expression that determines visibility of group.
    defined_when: str

--- a/traitsui/group.py
+++ b/traitsui/group.py
@@ -162,10 +162,10 @@ class Group(ViewSubElement):
     #: that any trait value on an object in the UI's context is changed.
     #: Therefore, you can use **visible_when** conditions to hide or show
     #: groups in response to user input. Be aware that this only applies to
-    #: traits in the UI's context. As a result, changes to nested traits may
-    #: not trigger the expression to be checked they don't also change a trait
-    #: on some object in the context. Additionally, the expression needs to be
-    #: a valid python expression given the context. i.e.
+    #: traits in the UI's context. As a result, changes to nested traits that
+    #: don't also change a trait on some object in the context may not
+    #: trigger the expression to be checked. Additionally, the expression needs
+    #: to be a valid python expression given the context. i.e.
     #: eval(visible_when, globals=globals(), locals=context) should succeed.
     visible_when = Str()
 
@@ -175,9 +175,9 @@ class Group(ViewSubElement):
     #: on an object in the UI's context is changed. Therefore, you can use
     #: **enabled_when** conditions to enable or disable groups in response to
     #: user input. Be aware that this only applies to traits in the UI's
-    #: context. As a result, changes to nested traits may not trigger the
-    #: expression to be checked they don't also change a trait on some object
-    #: in the context. Additionally, the expression needs to be a valid python
+    #: context. As a result, changes to nested traits that don't also change a
+    #: trait on some object in the context may not trigger the expression to be
+    #: checked. Additionally, the expression needs to be a valid python
     #: expression given the context. i.e.
     #: eval(enabled_when, globals=globals(), locals=context) should succeed.
     enabled_when = Str()

--- a/traitsui/group.py
+++ b/traitsui/group.py
@@ -159,16 +159,27 @@ class Group(ViewSubElement):
     #: the group and its items are not visible (and they disappear if they were
     #: previously visible). If the value evaluates to True, the group and items
     #: become visible. All **visible_when** conditions are checked each time
-    #: that any trait value is edited in the display. Therefore, you can use
-    #: **visible_when** conditions to hide or show groups in response to user
-    #: input.
+    #: that any trait value on an object in the UI's context is changed.
+    #: Therefore, you can use **visible_when** conditions to hide or show
+    #: groups in response to user input. Be aware that this only applies to
+    #: traits in the UI's context. As a result, changes to nested traits may
+    #: not trigger the expression to be checked they don't also change a trait
+    #: on some object in the context. Additionally, the expression needs to be
+    #: a valid python expression given the context. i.e.
+    #: eval(visible_when, globals=globals(), locals=context) should succeed.
     visible_when = Str()
 
     #: Pre-condition for enabling the group. If the expression evaluates to False,
     #: the group is disabled, that is, none of the widgets accept input. All
     #: **enabled_when** conditions are checked each time that any trait value
-    #: is edited in the display. Therefore, you can use **enabled_when**
-    #: conditions to enable or disable groups in response to user input.
+    #: on an object in the UI's context is changed. Therefore, you can use
+    #: **enabled_when** conditions to enable or disable groups in response to
+    #: user input. Be aware that this only applies to traits in the UI's
+    #: context. As a result, changes to nested traits may not trigger the
+    #: expression to be checked they don't also change a trait on some object
+    #: in the context. Additionally, the expression needs to be a valid python
+    #: expression given the context. i.e.
+    #: eval(enabled_when, globals=globals(), locals=context) should succeed.
     enabled_when = Str()
 
     #: Amount of padding (in pixels) to add around each item in the group. The

--- a/traitsui/item.py
+++ b/traitsui/item.py
@@ -180,8 +180,8 @@ class Item(ViewSubElement):
     #: on an object in the UI's context is changed. Therefore, you can use
     #: **visible_when** conditions to hide or show widgets in response to user
     #: input. Be aware that this only applies to traits in the UI's context. As
-    #: a result, changes to nested traits may not trigger the expression to be
-    #: checked they don't also change a trait on some object in the context.
+    #: a result, changes to nested traits that don't also change a trait on
+    #: some object in the context may not trigger the expression to be checked.
     #: Additionally, the expression needs to be a valid python expression given
     #: the context. i.e. eval(visible_when, globals=globals(), locals=context)
     #: should succeed.
@@ -193,9 +193,9 @@ class Item(ViewSubElement):
     #: on an object in the UI's context is changed. Therefore, you can use
     #: **enabled_when** conditions to enable or disable widgets in response to
     #: user input. Be aware that this only applies to traits in the UI's
-    #: context. As a result, changes to nested traits may not trigger the
-    #: expression to be checked they don't also change a trait on some object
-    #: in the context. Additionally, the expression needs to be a valid python
+    #: context. As a result, changes to nested traits that don't also change a
+    #: trait on some object in the context may not trigger the expression to be
+    #: checked. Additionally, the expression needs to be a valid python
     #: expression given the context. i.e.
     #: eval(enabled_when, globals=globals(), locals=context) should succeed.
     enabled_when = Str()

--- a/traitsui/item.py
+++ b/traitsui/item.py
@@ -177,15 +177,27 @@ class Item(ViewSubElement):
     #: the widget is not visible (and disappears if it was previously visible).
     #: If the value evaluates to True, the widget becomes visible. All
     #: **visible_when** conditions are checked each time that any trait value
-    #: is edited in the display. Therefore, you can use **visible_when**
-    #: conditions to hide or show widgets in response to user input.
+    #: on an object in the UI's context is changed. Therefore, you can use
+    #: **visible_when** conditions to hide or show widgets in response to user
+    #: input. Be aware that this only applies to traits in the UI's context. As
+    #: a result, changes to nested traits may not trigger the expression to be
+    #: checked they don't also change a trait on some object in the context.
+    #: Additionally, the expression needs to be a valid python expression given
+    #: the context. i.e. eval(visible_when, globals=globals(), locals=context)
+    #: should succeed.
     visible_when = Str()
 
     #: Pre-condition for enabling the item. If the expression evaluates to False,
     #: the widget is disabled, that is, it does not accept input. All
     #: **enabled_when** conditions are checked each time that any trait value
-    #: is edited in the display. Therefore, you can use **enabled_when**
-    #: conditions to enable or disable widgets in response to user input.
+    #: on an object in the UI's context is changed. Therefore, you can use
+    #: **enabled_when** conditions to enable or disable widgets in response to
+    #: user input. Be aware that this only applies to traits in the UI's
+    #: context. As a result, changes to nested traits may not trigger the
+    #: expression to be checked they don't also change a trait on some object
+    #: in the context. Additionally, the expression needs to be a valid python
+    #: expression given the context. i.e.
+    #: eval(enabled_when, globals=globals(), locals=context) should succeed.
     enabled_when = Str()
 
     #: Amount of extra space, in pixels, to add around the item. Values must be

--- a/traitsui/menu.py
+++ b/traitsui/menu.py
@@ -38,15 +38,27 @@ class Action(PyFaceAction):
     #: False, the action is not visible (and disappears if it was previously
     #: visible). If the value evaluates to True, the action becomes visible.
     #: All **visible_when** conditions are checked each time that any trait
-    #: value is edited in the display. Therefore, you can use **visible_when**
-    #: conditions to hide or show actions in response to user input.
+    #: value on an object in the UI's context is changed. Therefore, you can
+    #: use **visible_when** conditions to hide or show actions in response to
+    #: user input. Be aware that this only applies to traits in the UI's
+    #: context. As a result, changes to nested traits may not trigger the
+    #: expression to be checked they don't also change a trait on some object
+    #: in the context. Additionally, the expression needs to be a valid python
+    #: expression given the context. i.e.
+    #: eval(visible_when, globals=globals(), locals=context) should succeed.
     visible_when = Str()
 
     #: Pre-condition for enabling the action. If the expression evaluates to
     #: False, the action is disabled, that is, it cannot be selected. All
     #: **enabled_when** conditions are checked each time that any trait value
-    #: is edited in the display. Therefore, you can use **enabled_when**
-    #: conditions to enable or disable actions in response to user input.
+    #: on an object in the UI's context is changed. Therefore, you can use
+    #: **enabled_when** conditions to enable or disable actions in response to
+    #: user input. Be aware that this only applies to traits in the UI's
+    #: context. As a result, changes to nested traits may not trigger the
+    #: expression to be checked they don't also change a trait on some object
+    #: in the context. Additionally, the expression needs to be a valid python
+    #: expression given the context. i.e.
+    #: eval(visible_when, globals=globals(), locals=context) should succeed.
     enabled_when = Str()
 
     #: Boolean expression indicating when the action is displayed with a check

--- a/traitsui/menu.py
+++ b/traitsui/menu.py
@@ -41,9 +41,9 @@ class Action(PyFaceAction):
     #: value on an object in the UI's context is changed. Therefore, you can
     #: use **visible_when** conditions to hide or show actions in response to
     #: user input. Be aware that this only applies to traits in the UI's
-    #: context. As a result, changes to nested traits may not trigger the
-    #: expression to be checked they don't also change a trait on some object
-    #: in the context. Additionally, the expression needs to be a valid python
+    #: context. As a result, changes to nested traits that don't also change a
+    #: trait on some object in the context may not trigger the expression to be
+    #: checked. Additionally, the expression needs to be a valid python
     #: expression given the context. i.e.
     #: eval(visible_when, globals=globals(), locals=context) should succeed.
     visible_when = Str()
@@ -54,9 +54,9 @@ class Action(PyFaceAction):
     #: on an object in the UI's context is changed. Therefore, you can use
     #: **enabled_when** conditions to enable or disable actions in response to
     #: user input. Be aware that this only applies to traits in the UI's
-    #: context. As a result, changes to nested traits may not trigger the
-    #: expression to be checked they don't also change a trait on some object
-    #: in the context. Additionally, the expression needs to be a valid python
+    #: context. As a result, changes to nested traits that don't also change a
+    #: trait on some object in the context may not trigger the expression to be
+    #: checked. Additionally, the expression needs to be a valid python
     #: expression given the context. i.e.
     #: eval(visible_when, globals=globals(), locals=context) should succeed.
     enabled_when = Str()


### PR DESCRIPTION
closes #833 

This PR adds to the trait definition comments for `enabled_when` / `visible_when` to comment on some common points of confusion.  It also mentions in the view context section of the docs the HasTraits `trait_context` method to override the default context.