### PR TITLE
Don't use html for a variable name when using html module from standard library

### DIFF
--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -13,6 +13,7 @@ import unittest
 from traits.api import HasTraits, Int, Str, Instance
 from traitsui.api import View, Item, Group
 from traitsui.menu import ToolBar, Action
+
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -11,9 +11,10 @@
 import unittest
 
 from traits.api import HasTraits, Int, Str, Instance
-from traitsui.api import View, Item, Group
+from traitsui.api import HelpButton, View, Item, Group
 from traitsui.menu import ToolBar, Action
 
+from traitsui.testing.api import MouseClick, UITester
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
@@ -40,6 +41,18 @@ class FooPanel(HasTraits):
 
     def _toolbar_default(self):
         return ToolBar(Action(name="Open file"))
+
+
+class HelpPanel(HasTraits):
+    my_int = Int(2, help='this is the help for my int')
+
+    def default_traits_view(self):
+        view = View(
+            Item(name="my_int"),
+            title="HelpPanel",
+            buttons=[HelpButton],
+        )
+        return view
 
 
 class FooDialog(HasTraits):
@@ -172,6 +185,14 @@ class TestUIPanel(unittest.TestCase):
             # No button
             self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
 
+    def test_show_help(self):
+        panel = HelpPanel()
+
+        tester = UITester()
+
+        with tester.create_ui(panel) as ui:
+            help_button = tester.find_by_id(ui, 'Help')
+            help_button.perform(MouseClick())
 
 @requires_toolkit([ToolkitName.qt])
 class TestPanelLayout(unittest.TestCase):

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -11,10 +11,8 @@
 import unittest
 
 from traits.api import HasTraits, Int, Str, Instance
-from traitsui.api import HelpButton, View, Item, Group
+from traitsui.api import View, Item, Group
 from traitsui.menu import ToolBar, Action
-
-from traitsui.testing.api import MouseClick, UITester
 from traitsui.tests._tools import (
     create_ui,
     requires_toolkit,
@@ -41,18 +39,6 @@ class FooPanel(HasTraits):
 
     def _toolbar_default(self):
         return ToolBar(Action(name="Open file"))
-
-
-class HelpPanel(HasTraits):
-    my_int = Int(2, help='this is the help for my int')
-
-    def default_traits_view(self):
-        view = View(
-            Item(name="my_int"),
-            title="HelpPanel",
-            buttons=[HelpButton],
-        )
-        return view
 
 
 class FooDialog(HasTraits):
@@ -184,14 +170,6 @@ class TestUIPanel(unittest.TestCase):
 
             # No button
             self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
-
-    # Regression test for enthought/traitsui#1538
-    def test_show_help(self):
-        panel = HelpPanel()
-        tester = UITester()
-        with tester.create_ui(panel) as ui:
-            help_button = tester.find_by_id(ui, 'Help')
-            help_button.perform(MouseClick())
 
 
 @requires_toolkit([ToolkitName.qt])

--- a/traitsui/qt4/tests/test_ui_panel.py
+++ b/traitsui/qt4/tests/test_ui_panel.py
@@ -185,14 +185,14 @@ class TestUIPanel(unittest.TestCase):
             # No button
             self.assertIsNone(ui.control.findChild(QtGui.QPushButton))
 
+    # Regression test for enthought/traitsui#1538
     def test_show_help(self):
         panel = HelpPanel()
-
         tester = UITester()
-
         with tester.create_ui(panel) as ui:
             help_button = tester.find_by_id(ui, 'Help')
             help_button.perform(MouseClick())
+
 
 @requires_toolkit([ToolkitName.qt])
 class TestPanelLayout(unittest.TestCase):

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1283,7 +1283,7 @@ class HTMLHelpWindow(QtGui.QDialog):
     """ Window for displaying Traits-based help text with HTML formatting.
     """
 
-    def __init__(self, parent, html, scale_dx, scale_dy):
+    def __init__(self, parent, html_content, scale_dx, scale_dy):
         """ Initializes the object.
         """
         # Local import to avoid a WebKit dependency when one isn't needed.
@@ -1298,7 +1298,7 @@ class HTMLHelpWindow(QtGui.QDialog):
         html_control.setSizePolicy(
             QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding
         )
-        html_control.setHtml(html)
+        html_control.setHtml(html_content)
         layout.addWidget(html_control)
 
         # Create the OK button

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1310,7 +1310,7 @@ class HTMLHelpWindow(QtGui.QDialog):
 
         # Position and show the dialog
         position_window(self, parent=parent)
-        self.show()
+        self.exec_()
 
 
 # -------------------------------------------------------------------------

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1310,7 +1310,7 @@ class HTMLHelpWindow(QtGui.QDialog):
 
         # Position and show the dialog
         position_window(self, parent=parent)
-        self.exec_()
+        self.show()
 
 
 # -------------------------------------------------------------------------

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -393,8 +393,8 @@ def show_help_popup(event):
     # of the object with the 'help' trait):
     help = getattr(control, "help", None)
     if help is not None:
-        html = template.item_html % (control.GetLabel(), help)
-        HTMLHelpWindow(control, html, 0.25, 0.13)
+        html_content = template.item_html % (control.GetLabel(), help)
+        HTMLHelpWindow(control, html_content, 0.25, 0.13)
 
 
 class _GroupSplitter(QtGui.QSplitter):

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -23,7 +23,7 @@
 """
 
 
-import html
+from html import escape
 import re
 
 from pyface.qt import QtCore, QtGui
@@ -365,7 +365,7 @@ def show_help(ui, button):
     group = ui._groups[ui._active_group]
     template = help_template()
     if group.help != "":
-        header = template.group_help % html.escape(group.help)
+        header = template.group_help % escape(group.help)
     else:
         header = template.no_group_help
     fields = []
@@ -374,8 +374,8 @@ def show_help(ui, button):
             fields.append(
                 template.item_help
                 % (
-                    html.escape(item.get_label(ui)),
-                    html.escape(item.get_help(ui)),
+                    escape(item.get_label(ui)),
+                    escape(item.get_help(ui)),
                 )
             )
     html_content = template.group_html % (header, "\n".join(fields))

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -378,8 +378,8 @@ def show_help(ui, button):
                     html.escape(item.get_help(ui)),
                 )
             )
-    html = template.group_html % (header, "\n".join(fields))
-    HTMLHelpWindow(button, html, 0.25, 0.33)
+    html_content = template.group_html % (header, "\n".join(fields))
+    HTMLHelpWindow(button, html_content, 0.25, 0.33)
 
 
 def show_help_popup(event):

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1283,7 +1283,7 @@ class HTMLHelpWindow(QtGui.QDialog):
     """ Window for displaying Traits-based help text with HTML formatting.
     """
 
-    def __init__(self, parent, html_content, scale_dx, scale_dy):
+    def __init__(self, parent, html, scale_dx, scale_dy):
         """ Initializes the object.
         """
         # Local import to avoid a WebKit dependency when one isn't needed.
@@ -1298,7 +1298,7 @@ class HTMLHelpWindow(QtGui.QDialog):
         html_control.setSizePolicy(
             QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding
         )
-        html_control.setHtml(html_content)
+        html_control.setHtml(html)
         layout.addWidget(html_control)
 
         # Create the OK button

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -25,11 +25,6 @@ from traitsui.tests._tools import (
     ToolkitName,
 )
 
-ModalDialogTester = toolkit_object(
-    "util.modal_dialog_tester:ModalDialogTester"
-)
-no_modal_dialog_tester = ModalDialogTester.__name__ == "Unimplemented"
-
 
 class ObjectWithNumber(HasTraits):
     number1 = Int()
@@ -77,7 +72,6 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
             pass
 
     # Regression test for enthought/traitsui#1538
-    @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_show_help(self):
         panel = HelpPanel()
         tester = UITester()

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -13,8 +13,6 @@
 
 import unittest
 
-from pyface.toolkit import toolkit_object
-from pyface.constant import OK
 from traits.api import HasTraits, Int
 from traitsui.api import HelpButton, HGroup, Item, spring, VGroup, View
 from traitsui.testing.api import MouseClick, UITester

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -80,13 +80,9 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_show_help(self):
         panel = HelpPanel()
-        tester = UITester()
+        tester = UITester(delay=1000)
         with tester.create_ui(panel) as ui:
             help_button = tester.find_by_id(ui, 'Help')
 
-            def click_help():
-                # should not fail
-                help_button.perform(MouseClick())
-
-            mdtester = ModalDialogTester(click_help)
-            mdtester.open_and_run(lambda x: x.click_button(OK))
+            # should not fail
+            help_button.perform(MouseClick())

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -13,6 +13,8 @@
 
 import unittest
 
+from pyface.toolkit import toolkit_object
+from pyface.constant import OK
 from traits.api import HasTraits, Int
 from traitsui.api import HelpButton, HGroup, Item, spring, VGroup, View
 from traitsui.testing.api import MouseClick, UITester
@@ -22,6 +24,11 @@ from traitsui.tests._tools import (
     requires_toolkit,
     ToolkitName,
 )
+
+ModalDialogTester = toolkit_object(
+    "util.modal_dialog_tester:ModalDialogTester"
+)
+no_modal_dialog_tester = ModalDialogTester.__name__ == "Unimplemented"
 
 
 class ObjectWithNumber(HasTraits):
@@ -70,11 +77,16 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
             pass
 
     # Regression test for enthought/traitsui#1538
+    @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_show_help(self):
         panel = HelpPanel()
         tester = UITester()
         with tester.create_ui(panel) as ui:
             help_button = tester.find_by_id(ui, 'Help')
 
-            # should not fail
-            help_button.perform(MouseClick())
+            def click_help():
+                # should not fail
+                help_button.perform(MouseClick())
+
+            mdtester = ModalDialogTester(click_help)
+            mdtester.open_and_run(lambda x: x.click_button(OK))

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -13,6 +13,8 @@
 
 import unittest
 
+from pyface.toolkit import toolkit_object
+from pyface.constant import OK
 from traits.api import HasTraits, Int
 from traitsui.api import HelpButton, HGroup, Item, spring, VGroup, View
 from traitsui.testing.api import MouseClick, UITester
@@ -22,6 +24,11 @@ from traitsui.tests._tools import (
     requires_toolkit,
     ToolkitName,
 )
+
+ModalDialogTester = toolkit_object(
+    "util.modal_dialog_tester:ModalDialogTester"
+)
+no_modal_dialog_tester = ModalDialogTester.__name__ == "Unimplemented"
 
 
 class ObjectWithNumber(HasTraits):
@@ -70,9 +77,16 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
             pass
 
     # Regression test for enthought/traitsui#1538
+    @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_show_help(self):
         panel = HelpPanel()
         tester = UITester()
         with tester.create_ui(panel) as ui:
             help_button = tester.find_by_id(ui, 'Help')
-            help_button.perform(MouseClick())
+
+            def click_help():
+                # should not fail
+                help_button.perform(MouseClick())
+
+            mdtester = ModalDialogTester(click_help)
+            mdtester.open_and_run(lambda x: x.click_button(OK))

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -77,6 +77,7 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
             pass
 
     # Regression test for enthought/traitsui#1538
+    @requires_toolkit([ToolkitName.qt])
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_show_help(self):
 

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -14,7 +14,8 @@
 import unittest
 
 from traits.api import HasTraits, Int
-from traitsui.api import HGroup, Item, spring, VGroup, View
+from traitsui.api import HelpButton, HGroup, Item, spring, VGroup, View
+from traitsui.testing.api import MouseClick, UITester
 from traitsui.tests._tools import (
     BaseTestMixin,
     create_ui,
@@ -27,6 +28,18 @@ class ObjectWithNumber(HasTraits):
     number1 = Int()
     number2 = Int()
     number3 = Int()
+
+
+class HelpPanel(HasTraits):
+    my_int = Int(2, help='this is the help for my int')
+
+    def default_traits_view(self):
+        view = View(
+            Item(name="my_int"),
+            title="HelpPanel",
+            buttons=[HelpButton],
+        )
+        return view
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
@@ -55,3 +68,11 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
         # This should not fail.
         with create_ui(obj1, dict(view=view)):
             pass
+
+    # Regression test for enthought/traitsui#1538
+    def test_show_help(self):
+        panel = HelpPanel()
+        tester = UITester()
+        with tester.create_ui(panel) as ui:
+            help_button = tester.find_by_id(ui, 'Help')
+            help_button.perform(MouseClick())

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -79,8 +79,15 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
     # Regression test for enthought/traitsui#1538
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_show_help(self):
+
+        # This help window is not actually modal, when opened it will be the
+        # active window not active modal widget
+        class MyTester(ModalDialogTester):
+            def get_dialog_widget(self):
+                return self._qt_app.activeWindow()
+
         panel = HelpPanel()
-        tester = UITester()
+        tester = UITester(auto_process_events=False)
         with tester.create_ui(panel) as ui:
             help_button = tester.find_by_id(ui, 'Help')
 
@@ -88,5 +95,5 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
                 # should not fail
                 help_button.perform(MouseClick())
 
-            mdtester = ModalDialogTester(click_help)
+            mdtester = MyTester(click_help)
             mdtester.open_and_run(lambda x: x.click_button(OK))

--- a/traitsui/tests/test_ui_panel.py
+++ b/traitsui/tests/test_ui_panel.py
@@ -80,7 +80,7 @@ class TestUIPanel(BaseTestMixin, unittest.TestCase):
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_show_help(self):
         panel = HelpPanel()
-        tester = UITester(delay=1000)
+        tester = UITester()
         with tester.create_ui(panel) as ui:
             help_button = tester.find_by_id(ui, 'Help')
 

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -1152,7 +1152,7 @@ class HTMLHelpWindow(wx.Frame):
     """ Window for displaying Traits-based help text with HTML formatting.
     """
 
-    def __init__(self, parent, html, scale_dx, scale_dy):
+    def __init__(self, parent, html_content, scale_dx, scale_dy):
         """ Initializes the object.
         """
         wx.Frame.__init__(self, parent, -1, "Help", style=wx.SIMPLE_BORDER)
@@ -1162,7 +1162,7 @@ class HTMLHelpWindow(wx.Frame):
         sizer = wx.BoxSizer(wx.VERTICAL)
         html_control = wh.HtmlWindow(self)
         html_control.SetBorders(2)
-        html_control.SetPage(html)
+        html_control.SetPage(html_content)
         sizer.Add(html_control, 1, wx.EXPAND)
         sizer.Add(wx.StaticLine(self, -1), 0, wx.EXPAND)
         b_sizer = wx.BoxSizer(wx.HORIZONTAL)

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -1152,7 +1152,7 @@ class HTMLHelpWindow(wx.Frame):
     """ Window for displaying Traits-based help text with HTML formatting.
     """
 
-    def __init__(self, parent, html_content, scale_dx, scale_dy):
+    def __init__(self, parent, html, scale_dx, scale_dy):
         """ Initializes the object.
         """
         wx.Frame.__init__(self, parent, -1, "Help", style=wx.SIMPLE_BORDER)
@@ -1162,7 +1162,7 @@ class HTMLHelpWindow(wx.Frame):
         sizer = wx.BoxSizer(wx.VERTICAL)
         html_control = wh.HtmlWindow(self)
         html_control.SetBorders(2)
-        html_control.SetPage(html_content)
+        html_control.SetPage(html)
         sizer.Add(html_control, 1, wx.EXPAND)
         sizer.Add(wx.StaticLine(self, -1), 0, wx.EXPAND)
         b_sizer = wx.BoxSizer(wx.HORIZONTAL)

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -399,8 +399,8 @@ def show_help(ui, button):
                 template.item_help
                 % (escape(item.get_label(ui)), escape(item.get_help(ui)))
             )
-    html = template.group_html % (header, "\n".join(fields))
-    HTMLHelpWindow(button, html, 0.25, 0.33)
+    html_content = template.group_html % (header, "\n".join(fields))
+    HTMLHelpWindow(button, html_content, 0.25, 0.33)
 
 
 def show_help_popup(event):
@@ -414,8 +414,8 @@ def show_help_popup(event):
     # of the object with the 'help' trait):
     help = getattr(control, "help", None)
     if help is not None:
-        html = template.item_html % (control.GetLabel(), help)
-        HTMLHelpWindow(control, html, 0.25, 0.13)
+        html_content = template.item_html % (control.GetLabel(), help)
+        HTMLHelpWindow(control, html_content, 0.25, 0.13)
 
 
 def fill_panel_for_group(
@@ -1152,7 +1152,7 @@ class HTMLHelpWindow(wx.Frame):
     """ Window for displaying Traits-based help text with HTML formatting.
     """
 
-    def __init__(self, parent, html, scale_dx, scale_dy):
+    def __init__(self, parent, html_content, scale_dx, scale_dy):
         """ Initializes the object.
         """
         wx.Frame.__init__(self, parent, -1, "Help", style=wx.SIMPLE_BORDER)
@@ -1162,7 +1162,7 @@ class HTMLHelpWindow(wx.Frame):
         sizer = wx.BoxSizer(wx.VERTICAL)
         html_control = wh.HtmlWindow(self)
         html_control.SetBorders(2)
-        html_control.SetPage(html)
+        html_control.SetPage(html_content)
         sizer.Add(html_control, 1, wx.EXPAND)
         sizer.Add(wx.StaticLine(self, -1), 0, wx.EXPAND)
         b_sizer = wx.BoxSizer(wx.HORIZONTAL)


### PR DESCRIPTION
fixes #1538 

Previously we were using the html module from the python standard library in a function, as well as defining a local variable `html` that held on to the html content to be used to create an `HTMLHelpWindow` instance.  This PR adds a very simple test to showcase the bug, and fixes it by giving the `html` variable a new name `html_content`.   Additionally, I changed the import statement to only import what we need from `html`.  Namely, `from html import escape`.  Either of these fixes would work alone (it may be overkill to do them both), but I figured it couldn't hurt.