### PR TITLE
fix a typo from on_trait_change to observe migration

### DIFF
--- a/traitsui/key_bindings.py
+++ b/traitsui/key_bindings.py
@@ -259,7 +259,7 @@ class KeyBindings(HasPrivateTraits):
         """ Handles child KeyBindings being added to the object.
         """
         # the full children list is changed
-        if isinstance(event.object, KeyBinding):
+        if isinstance(event.object, KeyBindings):
             for item in event.new:
                 item.parent = self
         # the contents of the children list are changed


### PR DESCRIPTION
In #1519 there was a typo that went unnoticed. The tests all still passed but in the test suite one could see the error
```
Exception occurred in traits notification handler for event object: TraitChangeEvent(object=<traitsui.key_bindings.KeyBindings object at 0x7f9344a73048>, name='children', old=[<traitsui.key_bindings.KeyBindings object at 0x7f935c6c6ca8>], new=[])
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traits/traits/observation/_trait_event_notifier.py", line 122, in __call__
    self.dispatcher(handler, event)
  File "/Users/aayres/Desktop/traits/traits/observation/observe.py", line 26, in dispatch_same
    handler(event)
  File "/Users/aayres/Desktop/traitsui/traitsui/key_bindings.py", line 267, in _children_modified
    for item in event.added:
AttributeError: 'TraitChangeEvent' object has no attribute 'added'
.Exception occurred in traits notification handler for event object: TraitChangeEvent(object=<traitsui.key_bindings.KeyBindings object at 0x7f9344ac13b8>, name='children', old=[<traitsui.key_bindings.KeyBindings object at 0x7f934532edb0>], new=[])
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traits/traits/observation/_trait_event_notifier.py", line 122, in __call__
    self.dispatcher(handler, event)
  File "/Users/aayres/Desktop/traits/traits/observation/observe.py", line 26, in dispatch_same
    handler(event)
  File "/Users/aayres/Desktop/traitsui/traitsui/key_bindings.py", line 267, in _children_modified
    for item in event.added:
AttributeError: 'TraitChangeEvent' object has no attribute 'added'
```

This was because the object is actually a `KeyBindings` not a `KeyBinding` so we ended up in the wrong conditional path.