### PR TITLE
manually set the text format to plain text in error

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -316,7 +316,7 @@ def test(runtime, toolkit, environment):
 
     parameters["integrationtests"] = os.path.abspath("integrationtests")
     commands = [
-        "edm run -e {environment} -- python -W default -m coverage run -p -m unittest discover -v traitsui",
+        "edm run -e {environment} -- python -X faulthandler -W default -m coverage run -p -m unittest discover -v traitsui",
         # coverage run prevents local images to be loaded for demo examples
         # which are not defined in Python packages. Run with python directly
         # instead.

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -24,7 +24,7 @@
 """
 
 
-from pyface.qt import QtGui
+from pyface.qt import QtCore, QtGui
 
 from traits.api import HasTraits, Instance, Str, Callable
 
@@ -78,9 +78,16 @@ class Editor(UIEditor):
         else:
             control = self.control
 
-        QtGui.QMessageBox.information(
-            control, self.description + " value error", str(excp)
+        message_box = QtGui.QMessageBox(
+            QtGui.QMessageBox.Information,
+            self.description + " value error",
+            str(excp),
+            buttons=QtGui.QMessageBox.Ok,
+            parent=control
         )
+        message_box.setTextFormat(QtCore.Qt.PlainText)
+        message_box.setEscapeButton(QtGui.QMessageBox.Ok)
+        message_box.exec_()
 
     def set_tooltip_text(self, control, text):
         """ Sets the tooltip for a specified control.

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -937,7 +937,10 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
     # regression test for enthought/traitsui#1543
     @requires_toolkit([ToolkitName.qt])
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
-    @unittest.skipIf(is_mac_os, "There is a separate issue on OSX")
+    @unittest.skipIf(
+        is_mac_os,
+        "There is a separate issue on OSX. See enthought/traitsui#1550"
+    )
     def test_editor_error_msg(self):
         from pyface.qt import QtGui
 

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -921,6 +921,7 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
     def test_editor_error_msg(self):
         from pyface.toolkit import toolkit_object
         from pyface.constant import OK
+        from pyface.qt import QtGui
         from traits.api import HasTraits, Range
 
         from traitsui.testing.api import (
@@ -949,7 +950,25 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
             def trigger_error():
                 x_range_textbox.perform(KeyClick('Enter'))
 
+            def check_and_close(mdtester):
+                try:
+                    with mdtester.capture_error():
+                        print(mdtester.get_dialog_widget())
+                        self.assertTrue(
+                            mdtester.has_widget(
+                                text="The 'x' trait of a Foo instance must be "
+                                     "0.0 < a floating point number <= 1.0, "
+                                     "but a value of 0.0 <class 'float'> was "
+                                     "specified.",
+                                type_=QtGui.QMessageBox,
+                            )
+                        )
+
+                finally:
+                    mdtester.close(accept=True)
+                    self.assertTrue(mdtester.dialog_was_opened)
+
 
             mdtester = ModalDialogTester(trigger_error)
-            mdtester.open_and_run(lambda x: x.click_button(OK))
+            mdtester.open_and_run(check_and_close)
             self.assertTrue(mdtester.dialog_was_opened)

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -10,7 +10,10 @@
 
 import unittest
 
-from traits.api import Any, Bool, Event, Float, HasTraits, Int, List, Undefined
+from pyface.toolkit import toolkit_object
+from traits.api import (
+    Any, Bool, Event, Float, HasTraits, Int, List, Range, Undefined
+)
 from traits.trait_base import xgetattr
 
 from traitsui.context_value import ContextValue, CVFloat, CVInt
@@ -18,9 +21,22 @@ from traitsui.editor import Editor
 from traitsui.editor_factory import EditorFactory
 from traitsui.handler import default_handler
 from traitsui.ui import UI
-from traitsui.tests._tools import (
-    BaseTestMixin, GuiTestAssistant, no_gui_test_assistant
+from traitsui.testing.api import (
+    KeyClick, KeySequence, Textbox, UITester
 )
+from traitsui.tests._tools import (
+    BaseTestMixin,
+    GuiTestAssistant,
+    is_mac_os,
+    no_gui_test_assistant,
+    requires_toolkit,
+    ToolkitName,
+)
+
+ModalDialogTester = toolkit_object(
+    "util.modal_dialog_tester:ModalDialogTester"
+)
+no_modal_dialog_tester = ModalDialogTester.__name__ == "Unimplemented"
 
 
 class FakeControl(HasTraits):
@@ -918,18 +934,12 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
         with self.assertTraitDoesNotChange(user_object, "user_auxiliary"):
             editor.auxiliary_value = 14
 
+    # regression test for enthought/traitsui#1543
+    @requires_toolkit([ToolkitName.qt])
+    @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
+    @unittest.skipIf(is_mac_os, "There is a separate issue on OSX")
     def test_editor_error_msg(self):
-        from pyface.toolkit import toolkit_object
         from pyface.qt import QtGui
-        from traits.api import HasTraits, Range
-
-        from traitsui.testing.api import (
-             KeyClick, KeySequence, Textbox, UITester
-        )
-
-        ModalDialogTester = toolkit_object(
-            "util.modal_dialog_tester:ModalDialogTester"
-        )
 
         class Foo(HasTraits):
             x = Range(low=0.0, high=1.0, value=0.5, exclude_low=True)

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -920,12 +920,11 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
 
     def test_editor_error_msg(self):
         from pyface.toolkit import toolkit_object
-        from pyface.constant import OK
         from pyface.qt import QtGui
         from traits.api import HasTraits, Range
 
         from traitsui.testing.api import (
-             KeyClick, KeySequence, MouseClick, Textbox, UITester
+             KeyClick, KeySequence, Textbox, UITester
         )
 
         ModalDialogTester = toolkit_object(
@@ -953,7 +952,6 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
             def check_and_close(mdtester):
                 try:
                     with mdtester.capture_error():
-                        print(mdtester.get_dialog_widget())
                         self.assertTrue(
                             mdtester.has_widget(
                                 text="The 'x' trait of a Foo instance must be "
@@ -963,11 +961,9 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
                                 type_=QtGui.QMessageBox,
                             )
                         )
-
                 finally:
                     mdtester.close(accept=True)
                     self.assertTrue(mdtester.dialog_was_opened)
-
 
             mdtester = ModalDialogTester(trigger_error)
             mdtester.open_and_run(check_and_close)

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -917,3 +917,39 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
 
         with self.assertTraitDoesNotChange(user_object, "user_auxiliary"):
             editor.auxiliary_value = 14
+
+    def test_editor_error_msg(self):
+        from pyface.toolkit import toolkit_object
+        from pyface.constant import OK
+        from traits.api import HasTraits, Range
+
+        from traitsui.testing.api import (
+             KeyClick, KeySequence, MouseClick, Textbox, UITester
+        )
+
+        ModalDialogTester = toolkit_object(
+            "util.modal_dialog_tester:ModalDialogTester"
+        )
+
+        class Foo(HasTraits):
+            x = Range(low=0.0, high=1.0, value=0.5, exclude_low=True)
+
+        foo = Foo()
+        tester = UITester()
+        with tester.create_ui(foo) as ui:
+
+            x_range = tester.find_by_name(ui, "x")
+            x_range_textbox = x_range.locate(Textbox())
+
+            for _ in range(3):
+                x_range_textbox.perform(KeyClick('Backspace'))
+
+            x_range_textbox.perform(KeySequence('0.0'))
+
+            def trigger_error():
+                x_range_textbox.perform(KeyClick('Enter'))
+
+
+            mdtester = ModalDialogTester(trigger_error)
+            mdtester.open_and_run(lambda x: x.click_button(OK))
+            self.assertTrue(mdtester.dialog_was_opened)


### PR DESCRIPTION
fixes #1543

Note I am observing a segfault when I set the slider to 0 in the example given in the issue and then close the information dialog (this occurs both with and without the changes of this PR)
Im not sure why we weren't previously using `information` from the `pyface.api` here (see: https://github.com/enthought/pyface/blob/65813858730a61f25618e98669bcc5347d44935a/pyface/message_dialog.py#L15-L43)

In any case, now in order to call `setTextFormat` we would not be ably to use pyface directly anyway / we can no longer call the static function `QtGui.QMessageBox.information`.

This is what I currently see if I set the slider to 0.0:
<img width="441" alt="Screen Shot 2021-03-19 at 3 19 51 PM" src="https://user-images.githubusercontent.com/36972686/111837968-a77fba00-88c6-11eb-8f17-284309402c97.png">

As opposed to this from before:

<img width="447" alt="Screen Shot 2021-03-19 at 3 21 01 PM" src="https://user-images.githubusercontent.com/36972686/111838016-b8c8c680-88c6-11eb-8c00-91a6962287ce.png">

I am unsure why 2 dialogs show up (this is probably a separate bug?)


A test for this would likely require UITester + ModalDialogTester to look at the displayed text in the created modal dialog. I will investigate this now
