### PR TITLE
Update new test_editor_error_msg

### DIFF
--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -942,13 +942,13 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
         "There is a separate issue on OSX. See enthought/traitsui#1550"
     )
     def test_editor_error_msg(self):
-        from pyface.qt import QtGui
+        from pyface.qt import QtCore, QtGui
 
         class Foo(HasTraits):
             x = Range(low=0.0, high=1.0, value=0.5, exclude_low=True)
 
         foo = Foo()
-        tester = UITester()
+        tester = UITester(auto_process_events=False)
         with tester.create_ui(foo) as ui:
 
             x_range = tester.find_by_name(ui, "x")
@@ -973,6 +973,10 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
                                      "specified.",
                                 type_=QtGui.QMessageBox,
                             )
+                        )
+                        self.assertEqual(
+                            mdtester.get_dialog_widget().textFormat(),
+                            QtCore.Qt.PlainText
                         )
                 finally:
                     mdtester.close(accept=True)


### PR DESCRIPTION
_Hopefully_ fixes #1551 

The intermittent test failure first appeared in pr #1546, and after my realization on #1540 I am suspect of `auto_process_events` on UITester being relevant here as well (although this is still more of a hunch than a well understood solution).  This PR sets auto_process_events=False (the test still runs as expected with ModalDialogTester taking the full event processing responsibility, so even if this was not the cause of 1551 this change is still viable).

In addition, looking back at the test from 1546 and looking more closely at the code in ModalDialogTester, I realize that the `text` arg in `has_widget` corresponds to the text the widget holds which is the same value regardless of the format (it was not corresponding to the text actually displayed by the widget) so the previous test wasn't really hitting the core issue.  I added an assert statement explicitly checking the `textFormat` matches what it was set to.  