### PR TITLE
Fix RGBColor hex int to tuple color conversion

### DIFF
--- a/traitsui/null/rgb_color_trait.py
+++ b/traitsui/null/rgb_color_trait.py
@@ -49,7 +49,7 @@ def convert_to_color(object, name, value):
         num = int(value)
         return (
             (num / 0x10000) / 255.0,
-            ((num / 0x100) & 0xFF) / 255.0,
+            ((num // 0x100) & 0xFF) / 255.0,
             (num & 0xFF) / 255.0,
         )
     raise TraitError

--- a/traitsui/qt4/rgb_color_trait.py
+++ b/traitsui/qt4/rgb_color_trait.py
@@ -49,7 +49,7 @@ def convert_to_color(object, name, value):
     if isinstance(value, int):
         return (
             (value / 0x10000) / 255.0,
-            ((value // 0x100) & 0xFF) / 255.0,
+            ((value //\ 0x100) & 0xFF) / 255.0,
             (value & 0xFF) / 255.0,
         )
     raise TraitError

--- a/traitsui/qt4/rgb_color_trait.py
+++ b/traitsui/qt4/rgb_color_trait.py
@@ -49,7 +49,7 @@ def convert_to_color(object, name, value):
     if isinstance(value, int):
         return (
             (value / 0x10000) / 255.0,
-            ((value / 0x100) & 0xFF) / 255.0,
+            ((value // 0x100) & 0xFF) / 255.0,
             (value & 0xFF) / 255.0,
         )
     raise TraitError

--- a/traitsui/qt4/rgb_color_trait.py
+++ b/traitsui/qt4/rgb_color_trait.py
@@ -49,7 +49,7 @@ def convert_to_color(object, name, value):
     if isinstance(value, int):
         return (
             (value / 0x10000) / 255.0,
-            ((value //\ 0x100) & 0xFF) / 255.0,
+            ((value // 0x100) & 0xFF) / 255.0,
             (value & 0xFF) / 255.0,
         )
     raise TraitError

--- a/traitsui/tests/test_toolkit_traits.py
+++ b/traitsui/tests/test_toolkit_traits.py
@@ -1,0 +1,27 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+import unittest
+
+from traits.api import HasTraits
+
+from traitsui.toolkit_traits import RGBColor
+
+
+class HasRGBColor(HasTraits):
+    color = RGBColor()
+
+
+class TestRGBColor(unittest.TestCase):
+
+    # regression test for enthought/traitsui#1531
+    def test_hex_converion(self):
+        has_rgb_color = HasRGBColor()
+        has_rgb_color.color = 0x000000
+        self.assertEqual(has_rgb_color.color, (0.0, 0.0, 0.0))


### PR DESCRIPTION
fixes #1531

This PR simply replaces `/` with `//` to avoid trying to `&` a float with an int.  Note the wx version already had this.  It also adds a very simple regression test

Note that as mentioned https://github.com/enthought/traitsui/issues/1531#issuecomment-790573071 this function is effectively copied 3 separate times and we will ultimately want to unify them in one place.  However, the wx version has an additional check for `wx.Colour` inputs, so they are not exactly the same.  This very simple PR fixes the bug, the architecture / code organization issue can be addressed separately.