### PR TITLE
Document `entries` parameter not supported qt for FileEditor/DirectoryEditor

### DIFF
--- a/docs/source/traitsui_user_manual/factories_basic.rst
+++ b/docs/source/traitsui_user_manual/factories_basic.rst
@@ -591,10 +591,11 @@ the local system hierarchy. The styles of this editor are shown in Figure 31.
 
 The default version of the simply style displays a text box and a :guilabel:`Browse`
 button. Clicking :guilabel:`Browse` opens a platform-specific file selection dialog box.
-If you specify the *entries* keyword parameter with an integer value to the
+On the wx backend, if you specify the *entries* keyword parameter with an integer value to the
 factory function, the simple style is a combo box and a button labeled :guilabel:`...`.
 The user can type a file path in the combo box, or select one of *entries*
-previous values. Clicking the :guilabel:`...` button opens a browser panel similar to the
+previous values. Support for the *entries* parameter is yet to be implemented on
+the qt backend. Clicking the :guilabel:`...` button opens a browser panel similar to the
 custom style of editor. When the user selects a file in this browser, the panel
 collapses, and control is returned to the original editor widget, which is
 automatically populated with the new path string.

--- a/traitsui/editors/file_editor.py
+++ b/traitsui/editors/file_editor.py
@@ -65,7 +65,8 @@ class ToolkitEditorFactory(EditorFactory):
     enter_set = True
 
     #: The number of history entries to maintain:
-    #: FIXME: add support
+    #: FIXME: This is currently only supported on wx. Qt support needs to be
+    #: added
     entries = Int(10)
 
     #: The root path of the file tree view ('custom' style only, not supported

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -86,7 +86,7 @@ class SimpleEditor(SimpleTextEditor):
             pad = 8
 
         self._file_name = control
-        sizer.Add(control, 1, wx.EXPAND | wx.ALIGN_CENTER)
+        sizer.Add(control, 1, wx.EXPAND)
         sizer.Add(button, 0, wx.LEFT | wx.ALIGN_CENTER, pad)
         panel.Bind(wx.EVT_BUTTON, self.show_file_dialog, id=button.GetId())
         panel.SetDropTarget(FileDropTarget(self))


### PR DESCRIPTION
closes #1530 
Although we may want to have another issue open for adding qt support

This PR simply aims to better document the fact that the `entries` parameter for keeping a history of past entries on the FileEditor (and subsequently the DirectoryEditor) is only supported on the wx backend, but not on qt.  

In addition, this PR makes a fix (similar to the one made in #1067) to fix the `History_demo.py` on wx.  Now if one runs the demo in an environment with wx they can see what the history functionality is actually capable of.  