### PR TITLE
Dont crash when failing to add item to list

### DIFF
--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -28,7 +28,7 @@ from pyface.qt import QtCore, QtGui
 
 from pyface.api import ImageResource
 
-from traits.api import Str, Any, Bool, Dict, Instance, List
+from traits.api import Str, Any, Bool, Dict, Instance, List, TraitError
 from traits.trait_base import user_name_for, xgetattr
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
@@ -311,7 +311,12 @@ class SimpleEditor(Editor):
         index += offset
         item_trait = self._trait_handler.item_trait
         value = item_trait.default_value_for(self.object, self.name)
-        self.value = list[:index] + [value] + list[index:]
+        try:
+            self.value = list[:index] + [value] + list[index:]
+        # if the default new item is invalid, we just don't add it to the list.
+        # traits will still give an error message, but we don't want to crash
+        except TraitError:
+            pass
         self.update_editor()
 
     def add_before(self):

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -316,7 +316,8 @@ class SimpleEditor(Editor):
         # if the default new item is invalid, we just don't add it to the list.
         # traits will still give an error message, but we don't want to crash
         except TraitError:
-            pass
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
         self.update_editor()
 
     def add_before(self):

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -11,7 +11,9 @@
 import unittest
 
 from pyface.toolkit import toolkit_object
-from traits.api import Directory, HasStrictTraits, Instance, Int, List, Str
+from traits.api import (
+    Directory, HasStrictTraits, Instance, Int, List, Str, TraitError
+)
 
 from traitsui.api import Item, ListEditor, View
 from traitsui.testing.api import (
@@ -181,7 +183,6 @@ class TestSimpleListEditor(unittest.TestCase):
     @requires_toolkit([ToolkitName.qt])
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_add_item_fails(self):
-        from traits.api import TraitError
 
         class Foo(HasStrictTraits):
             dirs = List(Directory(exists=True))

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -34,7 +34,6 @@ from traitsui.tests._tools import (
 ModalDialogTester = toolkit_object(
     "util.modal_dialog_tester:ModalDialogTester"
 )
-no_modal_dialog_tester = ModalDialogTester.__name__ == "Unimplemented"
 
 
 # 'Person' class:
@@ -181,7 +180,6 @@ class TestSimpleListEditor(unittest.TestCase):
 
     # regression test for enthought/traitsui#1154
     @requires_toolkit([ToolkitName.qt])
-    @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_add_item_fails(self):
 
         class Foo(HasStrictTraits):

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -200,7 +200,7 @@ class TestSimpleListEditor(unittest.TestCase):
 
             mdtester = ModalDialogTester(trigger_error)
             mdtester.open_and_run(lambda x: x.close())
-            # we want an error dialog to open, but don't want to raise a 
+            # we want an error dialog to open, but don't want to raise a
             # TraitError and crash the full application
             self.assertTrue(mdtester.dialog_was_opened)
             self.assertTrue(mdtester.result)


### PR DESCRIPTION
closes #1154 

This PR currently catches the TraitError to prevent the app from crashing.  If you run the short example given in the issue now and add a new item, you see an error dialog 
<img width="422" alt="Screen Shot 2021-03-26 at 1 57 17 PM" src="https://user-images.githubusercontent.com/36972686/112680299-33e82a80-8e3b-11eb-82cf-50d407d0f658.png">
like before, but clicking ok just returns you to thee original UI, without crashing.  It also adds a regression test.

There may be other changes we want to make down the road, but this is a good first step which resolves the major problem of the issue.