### PR TITLE
Add 'default': True to the eam metadata

### DIFF
--- a/.github/workflows/test-etsdemo.yml
+++ b/.github/workflows/test-etsdemo.yml
@@ -42,3 +42,4 @@ jobs:
         with:
           run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
           working-directory: ets-demo
+          shell: bash

--- a/.github/workflows/test-etsdemo.yml
+++ b/.github/workflows/test-etsdemo.yml
@@ -42,4 +42,3 @@ jobs:
         with:
           run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
           working-directory: ets-demo
-          shell: bash

--- a/.github/workflows/test-etsdemo.yml
+++ b/.github/workflows/test-etsdemo.yml
@@ -15,7 +15,7 @@ jobs:
   test-etsdemo:
     strategy:
       matrix:
-        os: [ubuntu-16.04]
+        os: [ubuntu-latest]
         toolkit: ['pyqt5', 'pyside2']
     runs-on: ${{ matrix.os }}
     steps:

--- a/ets-demo/etsdemo/info.py
+++ b/ets-demo/etsdemo/info.py
@@ -31,4 +31,5 @@ def info():
                 "icon": ICON,
             },
         ],
+        "default": True,
     }

--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -194,7 +194,7 @@ def install(runtime, toolkit, environment, editable):
     # pip install pyside2, because we don't have it in EDM yet
     if toolkit == 'pyside2':
         commands.append(
-            "edm run -e {environment} -- pip install pyside2"
+            "edm run -e {environment} -- pip install pyside2==5.14"
         )
     elif toolkit == 'wx':
         if sys.platform != 'linux':

--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -194,7 +194,7 @@ def install(runtime, toolkit, environment, editable):
     # pip install pyside2, because we don't have it in EDM yet
     if toolkit == 'pyside2':
         commands.append(
-            "edm run -e {environment} -- pip install pyside2==5.14"
+            "edm run -e {environment} -- pip install pyside2"
         )
     elif toolkit == 'wx':
         if sys.platform != 'linux':

--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -194,7 +194,7 @@ def install(runtime, toolkit, environment, editable):
     # pip install pyside2, because we don't have it in EDM yet
     if toolkit == 'pyside2':
         commands.append(
-            "edm run -e {environment} -- pip install pyside2==5.11"
+            "edm run -e {environment} -- pip install pyside2"
         )
     elif toolkit == 'wx':
         if sys.platform != 'linux':


### PR DESCRIPTION
This PR simply sets default to true in the eam metadata so that one can run the application from the command line through edm 