### PR TITLE
Support testing with simple FileEditor (without dialog)

### DIFF
--- a/docs/source/traitsui_user_manual/testing/references/examples.rst
+++ b/docs/source/traitsui_user_manual/testing/references/examples.rst
@@ -11,6 +11,7 @@ Editors
 - :github-demo:`ButtonEditor <Standard_Editors/tests/test_ButtonEditor_simple_demo.py>`
 - :github-demo:`CheckListEditor <Standard_Editors/tests/test_CheckListEditor_simple_demo.py>`
 - :github-demo:`EnumEditor <Standard_Editors/tests/test_EnumEditor_demo.py>`
+- :github-demo:`FileEditor <Standard_Editors/tests/test_FileEditor_demo.py>`
 - :github-demo:`InstanceEditor <Standard_Editors/tests/test_InstanceEditor_demo.py>`
 - :github-demo:`ListEditor <Standard_Editors/tests/test_ListEditor_demo.py>`
 - :github-demo:`ListEditor (notebook) <Advanced/tests/test_List_editor_notebook_selection_demo.py>`

--- a/traitsui/examples/demo/Standard_Editors/FileEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/FileEditor_demo.py
@@ -41,7 +41,7 @@ class FileEditorDemo(HasTraits):
 
     # Display specification (one Item per editor style):
     file_group = Group(
-        Item('file_name', style='simple', label='Simple'),
+        Item('file_name', style='simple', label='Simple', id='simple_file'),
         Item('_'),
         Item('file_name', style='custom', label='Custom'),
         Item('_'),

--- a/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
@@ -1,0 +1,61 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+This example demonstrates how to test interacting with a textbox created
+using FileEditor.
+
+The GUI being tested is written in the demo under the same name (minus the
+preceding 'test') in the outer directory.
+"""
+
+import os
+import runpy
+import unittest
+
+from traitsui.testing.api import (
+    DisplayedText, KeyClick, KeySequence,  UITester
+)
+
+#: Filename of the demo script
+FILENAME = "FileEditor_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestFileEditorDemo(unittest.TestCase):
+
+    def test_run_demo(self):
+        demo = runpy.run_path(DEMO_PATH)["demo"]
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            # simple FileEditor
+            simple_file_field = tester.find_by_id(ui, "simple_file")
+
+            # Modify the value on the GUI
+            # The path does not exist, whic is allowed by the trait.
+            # The custom FileEditor will ignore nonexisting file path.
+            simple_file_field.perform(KeySequence("some_path"))
+            simple_file_field.perform(KeyClick("Enter"))
+            self.assertEqual(demo.file_name, "some_path")
+
+            # Modify the value on the object
+            demo.file_name = FILENAME
+            self.assertEqual(
+                simple_file_field.inspect(DisplayedText()), FILENAME
+            )
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestFileEditorDemo)
+)

--- a/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
@@ -54,6 +54,10 @@ class TestFileEditorDemo(unittest.TestCase):
                 simple_file_field.inspect(DisplayedText()), FILENAME
             )
 
+            # On wx, an assertion error occurs upon disposing the UI.
+            # That error is linked to the custom FileEditor.
+            # See enthought/traitsui#752
+
 
 # Run the test(s)
 unittest.TextTestRunner().run(

--- a/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
@@ -21,7 +21,7 @@ import runpy
 import unittest
 
 from traitsui.testing.api import (
-    DisplayedText, KeyClick, KeySequence,  UITester
+    DisplayedText, KeyClick, KeySequence, UITester
 )
 
 #: Filename of the demo script

--- a/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_FileEditor_demo.py
@@ -42,7 +42,7 @@ class TestFileEditorDemo(unittest.TestCase):
             simple_file_field = tester.find_by_id(ui, "simple_file")
 
             # Modify the value on the GUI
-            # The path does not exist, whic is allowed by the trait.
+            # The path does not exist, which is allowed by the trait.
             # The custom FileEditor will ignore nonexisting file path.
             simple_file_field.perform(KeySequence("some_path"))
             simple_file_field.perform(KeyClick("Enter"))

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/file_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/file_editor.py
@@ -1,0 +1,32 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traitsui.testing.tester._ui_tester_registry.qt4._registry_helper import (
+    register_editable_textbox_handlers,
+)
+from traitsui.qt4.file_editor import SimpleEditor
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+
+    register_editable_textbox_handlers(
+        registry=registry,
+        target_class=SimpleEditor,
+        widget_getter=lambda wrapper: wrapper._target._file_name,
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -15,6 +15,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     check_list_editor,
     editor_factory,
     enum_editor,
+    file_editor,
     font_editor,
     instance_editor,
     list_editor,
@@ -47,6 +48,9 @@ def get_default_registries():
 
     # EnumEditor
     enum_editor.register(registry)
+
+    # FileEditor
+    file_editor.register(registry)
 
     # FontEditor
     font_editor.register(registry)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/file_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/file_editor.py
@@ -1,0 +1,31 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traitsui.wx.file_editor import SimpleEditor
+from traitsui.testing.tester._ui_tester_registry.wx._registry_helper import (
+    register_editable_textbox_handlers,
+)
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    register_editable_textbox_handlers(
+        registry=registry,
+        target_class=SimpleEditor,
+        widget_getter=lambda wrapper: wrapper._target._file_name,
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -15,6 +15,7 @@ from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
     check_list_editor,
     editor_factory,
     enum_editor,
+    file_editor,
     font_editor,
     instance_editor,
     list_editor,
@@ -47,6 +48,9 @@ def get_default_registries():
 
     # EnumEditor
     enum_editor.register(registry)
+
+    # FileEditor
+    file_editor.register(registry)
 
     # FontEditor
     font_editor.register(registry)

--- a/traitsui/tests/editors/test_file_editor.py
+++ b/traitsui/tests/editors/test_file_editor.py
@@ -14,11 +14,10 @@ from traits.api import Event, File, HasTraits
 from traitsui.api import FileEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
-    create_ui,
     requires_toolkit,
-    reraise_exceptions,
     ToolkitName,
 )
+from traitsui.testing.api import DisplayedText, KeyClick, KeySequence, UITester
 
 
 class FileModel(HasTraits):
@@ -27,11 +26,11 @@ class FileModel(HasTraits):
 
     reload_event = Event()
 
+    existing_filepath = File(exists=True)
 
-# Run this against wx too when enthought/traitsui#752 is also fixed.
-@requires_toolkit([ToolkitName.qt])
-class TestFileEditor(BaseTestMixin, unittest.TestCase):
-    """ Test FileEditor. """
+
+class TestSimpleFileEditor(BaseTestMixin, unittest.TestCase):
+    """ Test FileEditor (simple style). """
 
     def setUp(self):
         BaseTestMixin.setUp(self)
@@ -39,20 +38,81 @@ class TestFileEditor(BaseTestMixin, unittest.TestCase):
     def tearDown(self):
         BaseTestMixin.tearDown(self)
 
-    def check_init_and_dispose(self, style):
-        # Test init and dispose by opening and closing the UI
-        view = View(Item("filepath", editor=FileEditor(), style=style))
+    def test_simple_editor_set_text_to_nonexisting_path(self):
+        # Test setting the editor to a nonexisting filepath
+        # e.g. use case for creating a new file.
+        view = View(Item("filepath", editor=FileEditor()))
         obj = FileModel()
-        with reraise_exceptions(), \
-                create_ui(obj, dict(view=view)):
-            pass
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            filepath_field = tester.find_by_name(ui, "filepath")
 
-    def test_simple_editor_init_and_dispose(self):
-        # This may fail if run against wx, see enthought/traitsui#889
-        self.check_init_and_dispose("simple")
+            filepath_field.perform(KeySequence("some_file.txt"))
+            filepath_field.perform(KeyClick("Enter"))
+
+            self.assertEqual(obj.filepath, "some_file.txt")
+
+    def test_simple_editor_display_path(self):
+        # Test the filepath widget is updated to show path
+        view = View(Item("filepath", editor=FileEditor()))
+        obj = FileModel()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            filepath_field = tester.find_by_name(ui, "filepath")
+            self.assertEqual(filepath_field.inspect(DisplayedText()), "")
+
+            obj.filepath = "some_file.txt"
+            self.assertEqual(
+                filepath_field.inspect(DisplayedText()), "some_file.txt"
+            )
+
+    def test_simple_editor_auto_set_text(self):
+        # Test with auto_set set to True.
+        view = View(Item("filepath", editor=FileEditor(auto_set=True)))
+        obj = FileModel()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            filepath_field = tester.find_by_name(ui, "filepath")
+            filepath_field.perform(KeySequence("some_file.txt"))
+            self.assertEqual(obj.filepath, "some_file.txt")
+
+    def test_simple_editor_reset_text_if_validation_error(self):
+        # Test when the trait validates file existence.
+        view = View(Item("existing_filepath", editor=FileEditor()))
+        obj = FileModel()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            filepath_field = tester.find_by_name(ui, "existing_filepath")
+
+            # when
+            filepath_field.perform(KeySequence("some_file.txt"))
+            filepath_field.perform(KeyClick("Enter"))
+
+            # then
+            # the file does not exist, the trait is not set.
+            self.assertEqual(obj.existing_filepath, "")
+
+            # the widget is synchronized to the trait value.
+            self.assertEqual(filepath_field.inspect(DisplayedText()), "")
+
+
+# Run this against wx too when enthought/traitsui#752 is also fixed.
+@requires_toolkit([ToolkitName.qt])
+class TestCustomFileEditor(BaseTestMixin, unittest.TestCase):
+    """ Test FileEditor (custom style). """
+
+    def setUp(self):
+        BaseTestMixin.setUp(self)
+
+    def tearDown(self):
+        BaseTestMixin.tearDown(self)
 
     def test_custom_editor_init_and_dispose(self):
-        self.check_init_and_dispose("custom")
+        # Test init and dispose by opening and closing the UI
+        view = View(Item("filepath", editor=FileEditor(), style="custom"))
+        obj = FileModel()
+        with UITester().create_ui(obj, dict(view=view)):
+            pass
 
     def test_custom_editor_reload_changed_after_dispose(self):
         # Test firing reload event on the model after the UI is disposed.
@@ -64,8 +124,7 @@ class TestFileEditor(BaseTestMixin, unittest.TestCase):
             ),
         )
         obj = FileModel()
-        with reraise_exceptions():
-            with create_ui(obj, dict(view=view)):
-                pass
-            # should not fail.
-            obj.reload_event = True
+        with UITester().create_ui(obj, dict(view=view)):
+            pass
+        # should not fail.
+        obj.reload_event = True

--- a/traitsui/tests/editors/test_file_editor.py
+++ b/traitsui/tests/editors/test_file_editor.py
@@ -39,6 +39,8 @@ class TestSimpleFileEditor(BaseTestMixin, unittest.TestCase):
     def tearDown(self):
         BaseTestMixin.tearDown(self)
 
+    # Behavior on wx may not be quite the same on other platforms.
+    @requires_toolkit([ToolkitName.qt])
     def test_simple_editor_set_text_to_nonexisting_path(self):
         # Test setting the editor to a nonexisting filepath
         # e.g. use case for creating a new file.
@@ -67,6 +69,8 @@ class TestSimpleFileEditor(BaseTestMixin, unittest.TestCase):
                 filepath_field.inspect(DisplayedText()), "some_file.txt"
             )
 
+    # Behavior on wx may not be quite the same on other platforms.
+    @requires_toolkit([ToolkitName.qt])
     def test_simple_editor_auto_set_text(self):
         # Test with auto_set set to True.
         view = View(Item("filepath", editor=FileEditor(auto_set=True)))

--- a/traitsui/tests/editors/test_file_editor.py
+++ b/traitsui/tests/editors/test_file_editor.py
@@ -29,6 +29,7 @@ class FileModel(HasTraits):
     existing_filepath = File(exists=True)
 
 
+@requires_toolkit([ToolkitName.qt, ToolkitName.wx])
 class TestSimpleFileEditor(BaseTestMixin, unittest.TestCase):
     """ Test FileEditor (simple style). """
 


### PR DESCRIPTION
This PR adds testing support for the simple FileEditor via its text widget.

- `DisplayedText`, `KeyClick`, `KeySequence` can now be used for testing with a simple FileEditor
- A test for the FileEditor demo example is added, and an entry is added to the documentation.

This is motivated by an observation of a similar extension being made in a downstream project. One will extend using the `_file_name` attribute on the editor, acknowledging that such extension relies on implementation details of the editor. If the testing support is implemented in traitsui, then the support can be maintained along with those implementation details.

In the context of testing an application, it is often sufficient to set a file path via the text widget instead of via the file modal dialog.

This goes some way towards solving #1339. It also extends TraitsUI's own test coverage for the simple FileEditor.

Observations:
- The smoke tests for wx FileEditor used to fail, but not any more since #889 was solved.
- The `entries` trait on the FileEditor factory is only supported by wx. If set on wx, the simple FileEditor will have a combo box instead of a text widget. The simple FileEditor on wx is effectively two editors in one. That branch is not tested here.
- On the demo, if one sets an existing file path for the simple FileEditor, the custom FileEditor will normalize the file path.  So if one sets a relative path to the simple FileEditor, they will get an absolute path back unless the custom FileEditor is removed. That's because in the demo, multiple editors are tied to the same trait.
- The test for the FileEditor demo fails on wx due to #752. The presence of the custom FileEditor caused it. If the custom FileEditor was removed, the test will pass for wx.