### PR TITLE
Update "super" usage in "traitsui.wx"

### DIFF
--- a/traitsui/wx/button_editor.py
+++ b/traitsui/wx/button_editor.py
@@ -73,7 +73,7 @@ class SimpleEditor(Editor):
         """ Disposes of the contents of an editor.
         """
         self.control.Unbind(wx.EVT_BUTTON)
-        super(SimpleEditor, self).dispose()
+        super().dispose()
 
 
 class CustomEditor(SimpleEditor):
@@ -116,4 +116,4 @@ class CustomEditor(SimpleEditor):
             self.update_object, "clicked", remove=True
         )
 
-        super(CustomEditor, self).dispose()
+        super().dispose()

--- a/traitsui/wx/check_list_editor.py
+++ b/traitsui/wx/check_list_editor.py
@@ -63,7 +63,7 @@ class SimpleEditor(EditorWithList):
             widget.
         """
         self.create_control(parent)
-        super(SimpleEditor, self).init(parent)
+        super().init(parent)
         self.set_tooltip()
 
     def dispose(self):

--- a/traitsui/wx/color_editor.py
+++ b/traitsui/wx/color_editor.py
@@ -350,7 +350,7 @@ class ReadonlyColorEditor(BaseReadonlyEditor):
         """ Updates the editor when the object trait changes externally to the
             editor.
         """
-        # super(ReadonlyColorEditor, self).update_editor()
+        # super().update_editor()
         self.control.SetValue(self.string_value(self.value))
         set_color(self)
 

--- a/traitsui/wx/compound_editor.py
+++ b/traitsui/wx/compound_editor.py
@@ -80,7 +80,7 @@ class CompoundEditor(Editor):
         for editor in self._editors:
             editor.dispose()
 
-        super(CompoundEditor, self).dispose()
+        super().dispose()
 
 
 class SimpleEditor(CompoundEditor):

--- a/traitsui/wx/date_editor.py
+++ b/traitsui/wx/date_editor.py
@@ -121,7 +121,7 @@ class wxMouseBoxCalendarCtrl(wx.adv.CalendarCtrl):
     """
 
     def __init__(self, *args, **kwargs):
-        super(wxMouseBoxCalendarCtrl, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.selecting = False
         self.box_selected = []
@@ -272,7 +272,7 @@ class MultiCalendarCtrl(wx.Panel):
         *args,
         **kwargs
     ):
-        super(MultiCalendarCtrl, self).__init__(parent, ID, *args, **kwargs)
+        super().__init__(parent, ID, *args, **kwargs)
 
         self.sizer = wx.BoxSizer()
         self.SetSizer(self.sizer)

--- a/traitsui/wx/dnd_editor.py
+++ b/traitsui/wx/dnd_editor.py
@@ -144,7 +144,7 @@ class SimpleEditor(Editor):
         control.Unbind(wx.EVT_MOTION)
         control.Unbind(wx.EVT_PAINT)
 
-        super(SimpleEditor, self).dispose()
+        super().dispose()
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
@@ -318,7 +318,7 @@ class FileDropSource(wx.DropSource):
             data_object.AddFile(file)
 
         # Create the drop source and begin the drag and drop operation:
-        super(FileDropSource, self).__init__(source)
+        super().__init__(source)
         self.SetData(data_object)
         self.result = self.DoDragDrop(True)
 

--- a/traitsui/wx/drop_editor.py
+++ b/traitsui/wx/drop_editor.py
@@ -49,7 +49,7 @@ class SimpleEditor(Editor):
             )
             self.set_tooltip()
         else:
-            super(SimpleEditor, self).init(parent)
+            super().init(parent)
         self.control.SetBackgroundColour(self.ok_color)
         self.control.SetDropTarget(PythonDropTarget(self))
 

--- a/traitsui/wx/editor.py
+++ b/traitsui/wx/editor.py
@@ -209,7 +209,7 @@ class EditorWithList(Editor):
             self._list_updated, self.list_name + "[]", remove=True
         )
 
-        super(EditorWithList, self).dispose()
+        super().dispose()
 
     def _list_updated(self):
         """ Handles the monitored trait being updated.
@@ -254,4 +254,4 @@ class EditorFromView(Editor):
         """
         self._ui.dispose()
 
-        super(EditorFromView, self).dispose()
+        super().dispose()

--- a/traitsui/wx/enum_editor.py
+++ b/traitsui/wx/enum_editor.py
@@ -130,7 +130,7 @@ class BaseEditor(Editor):
                 self._values_changed, "values", remove=True
             )
 
-        super(BaseEditor, self).dispose()
+        super().dispose()
 
 
 # -------------------------------------------------------------------------
@@ -146,7 +146,7 @@ class SimpleEditor(BaseEditor):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        super(SimpleEditor, self).init(parent)
+        super().init(parent)
 
         factory = self.factory
 
@@ -184,7 +184,7 @@ class SimpleEditor(BaseEditor):
 
         disconnect_no_id(self.control, wx.EVT_KILL_FOCUS)
 
-        super(SimpleEditor, self).dispose()
+        super().dispose()
 
     def update_object(self, event):
         """ Handles the user selecting a new value from the combo box.
@@ -322,7 +322,7 @@ class RadioEditor(BaseEditor):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        super(RadioEditor, self).init(parent)
+        super().init(parent)
 
         # Create a panel to hold all of the radio buttons:
         self.control = TraitsUIPanel(parent, -1)
@@ -418,7 +418,7 @@ class ListEditor(BaseEditor):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        super(ListEditor, self).init(parent)
+        super().init(parent)
 
         # Create a panel to hold all of the radio buttons:
         self.control = wx.ListBox(
@@ -437,7 +437,7 @@ class ListEditor(BaseEditor):
         """
         disconnect(self.control, wx.EVT_LISTBOX)
 
-        super(ListEditor, self).dispose()
+        super().dispose()
 
     def update_object(self, event):
         """ Handles the user selecting a list box item.

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -111,7 +111,7 @@ class SimpleEditor(SimpleTextEditor):
             panel.Unbind(wx.EVT_TEXT_ENTER, id=control.GetId())
             panel.Unbind(wx.EVT_TEXT, id=control.GetId())
 
-        super(SimpleEditor, self).dispose()
+        super().dispose()
 
     @observe("history:value")
     def _history_value_changed(self, event):
@@ -308,7 +308,7 @@ class CustomEditor(SimpleTextEditor):
         tree.Unbind(wx.EVT_TREE_SEL_CHANGED)
         tree.Unbind(wx.EVT_TREE_ITEM_ACTIVATED)
 
-        super(CustomEditor, self).dispose()
+        super().dispose()
 
     def update_object(self, event):
         """ Handles the user changing the contents of the edit control.

--- a/traitsui/wx/font_editor.py
+++ b/traitsui/wx/font_editor.py
@@ -151,7 +151,7 @@ class SimpleFontEditor(BaseSimpleEditor):
         """ Updates the editor when the object trait changes externally to the
             editor.
         """
-        super(SimpleFontEditor, self).update_editor()
+        super().update_editor()
         set_font(self)
 
     def string_value(self, font):
@@ -223,7 +223,7 @@ class CustomFontEditor(Editor):
         if self.factory.show_weight:
             disconnect(self._weight, wx.EVT_CHOICE)
 
-        super(CustomFontEditor, self).dispose()
+        super().dispose()
 
     def update_object_parts(self, event):
         """ Handles the user modifying one of the font components.
@@ -286,7 +286,7 @@ class TextFontEditor(BaseTextEditor):
         """ Updates the editor when the object trait changes external to the
             editor.
         """
-        super(TextFontEditor, self).update_editor()
+        super().update_editor()
         set_font(self)
 
     def string_value(self, font):
@@ -305,7 +305,7 @@ class ReadonlyFontEditor(BaseReadonlyEditor):
         """ Updates the editor when the object trait changes external to the
             editor.
         """
-        super(ReadonlyFontEditor, self).update_editor()
+        super().update_editor()
         set_font(self)
 
     def string_value(self, font):

--- a/traitsui/wx/helper.py
+++ b/traitsui/wx/helper.py
@@ -334,7 +334,7 @@ class ChildFocusOverride(wx.EvtHandler):
 
     def __init__(self, window):
         self.window = window
-        super(ChildFocusOverride, self).__init__()
+        super().__init__()
 
         # Make self the event handler for the window.
         window.PushEventHandler(self)
@@ -524,7 +524,7 @@ class PopupControl(HasPrivateTraits):
     def __init__(self, **traits):
         """ Initializes the object.
         """
-        super(PopupControl, self).__init__(**traits)
+        super().__init__(**traits)
 
         style = wx.SIMPLE_BORDER
         if self.resizable:
@@ -640,7 +640,7 @@ class Slider(wx.Slider):
     """
 
     def __init__(self, *args, **kw):
-        super(Slider, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         self.Bind(wx.EVT_ERASE_BACKGROUND, self._erase_background)
 

--- a/traitsui/wx/history_editor.py
+++ b/traitsui/wx/history_editor.py
@@ -58,7 +58,7 @@ class _HistoryEditor(Editor):
         self.history.dispose()
         self.history = None
 
-        super(_HistoryEditor, self).dispose()
+        super().dispose()
 
     @observe("history:value")
     def _value_changed(self, event):

--- a/traitsui/wx/image_enum_editor.py
+++ b/traitsui/wx/image_enum_editor.py
@@ -82,7 +82,7 @@ class SimpleEditor(ReadonlyEditor):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        super(SimpleEditor, self).init(parent)
+        super().init(parent)
         self.control.Selected(True)
         self.control.Handler(self.popup_editor)
         self.set_tooltip()
@@ -110,7 +110,7 @@ class CustomEditor(BaseEnumEditor):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        super(CustomEditor, self).init(parent)
+        super().init(parent)
 
         # Create the panel to hold the ImageControl buttons:
         self.control = TraitsUIPanel(parent, -1)

--- a/traitsui/wx/instance_editor.py
+++ b/traitsui/wx/instance_editor.py
@@ -199,7 +199,7 @@ class CustomEditor(Editor):
                 self.rebuild_items, "values_items", remove=True
             )
 
-        super(CustomEditor, self).dispose()
+        super().dispose()
 
     def create_editor(self, parent, sizer):
         """ Creates the editor control.
@@ -502,7 +502,7 @@ class SimpleEditor(CustomEditor):
             self._dialog_ui.dispose()
             self._dialog_ui = None
 
-        super(SimpleEditor, self).dispose()
+        super().dispose()
 
     def edit_instance(self, event):
         """ Edit the contents of the object trait when the user clicks the

--- a/traitsui/wx/key_binding_editor.py
+++ b/traitsui/wx/key_binding_editor.py
@@ -121,7 +121,7 @@ class KeyBindingCtrl(wx.Window):
         size=wx.DefaultSize,
     ):
 
-        super(KeyBindingCtrl, self).__init__(
+        super().__init__(
             parent, wid, pos, size, style=wx.CLIP_CHILDREN | wx.WANTS_CHARS
         )
         # Save the reference to the controlling editor object:

--- a/traitsui/wx/list_editor.py
+++ b/traitsui/wx/list_editor.py
@@ -139,7 +139,7 @@ class SimpleEditor(Editor):
         )
         self._dispose_items()
 
-        super(SimpleEditor, self).dispose()
+        super().dispose()
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
@@ -602,7 +602,7 @@ class NotebookEditor(Editor):
         )
         self.close_all()
 
-        super(NotebookEditor, self).dispose()
+        super().dispose()
 
     def add_controls(self, controls):
         """ Adds a group of new DockControls to the view.
@@ -753,9 +753,7 @@ class DockableListElement(DockableViewElement):
         """ Closes a DockControl.
         """
         if abort:
-            return super(DockableListElement, self).close_dock_control(
-                dock_control, False
-            )
+            return super().close_dock_control(dock_control, False)
 
         view_object = self.ui.context["object"]
         for i, value in enumerate(self.editor._uis):

--- a/traitsui/wx/list_str_editor.py
+++ b/traitsui/wx/list_str_editor.py
@@ -277,7 +277,7 @@ class _ListStrEditor(Editor):
         )
         self.on_trait_change(self._refresh, "adapter.+update", remove=True)
 
-        super(_ListStrEditor, self).dispose()
+        super().dispose()
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -249,7 +249,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         if self._error is None:
             self._error = True
             self.ui.errors += 1
-            super(SimpleSliderEditor, self).error(excp)
+            super().error(excp)
         self.set_error_state(True)
 
     def update_editor(self):
@@ -561,7 +561,7 @@ class LargeRangeSliderEditor(BaseRangeEditor):
         if self._error is None:
             self._error = True
             self.ui.errors += 1
-            super(LargeRangeSliderEditor, self).error(excp)
+            super().error(excp)
         self.set_error_state(True)
 
     def update_editor(self):
@@ -889,7 +889,7 @@ class RangeTextEditor(TextEditor):
         if self._error is None:
             self._error = True
             self.ui.errors += 1
-            super(RangeTextEditor, self).error(excp)
+            super().error(excp)
         self.set_error_state(True)
 
     def _low_changed(self, low):

--- a/traitsui/wx/rgb_color_editor.py
+++ b/traitsui/wx/rgb_color_editor.py
@@ -67,4 +67,4 @@ class ToolkitEditorFactory(BaseColorToolkitEditorFactory):
                 int(color[1] * 255.0),
                 int(color[2] * 255.0),
             )
-        return super(ToolkitEditorFactory, self).str_color(color)
+        return super().str_color(color)

--- a/traitsui/wx/scrubber_editor.py
+++ b/traitsui/wx/scrubber_editor.py
@@ -157,7 +157,7 @@ class _ScrubberEditor(Editor):
         # Disconnect the pop-up text event handlers:
         self._disconnect_text()
 
-        super(_ScrubberEditor, self).dispose()
+        super().dispose()
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the

--- a/traitsui/wx/set_editor.py
+++ b/traitsui/wx/set_editor.py
@@ -283,7 +283,7 @@ class SimpleEditor(Editor):
             self.update_editor, self.extended_name + "_items?", remove=True
         )
 
-        super(SimpleEditor, self).dispose()
+        super().dispose()
 
     def get_error_control(self):
         """ Returns the editor's control for indicating error status.

--- a/traitsui/wx/table_editor.py
+++ b/traitsui/wx/table_editor.py
@@ -473,7 +473,7 @@ class TableEditor(Editor, BaseTableEditor):
         # Break any links needed to allow garbage collection:
         self.grid = self.model = self.toolbar = None
 
-        super(TableEditor, self).dispose()
+        super().dispose()
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
@@ -1506,7 +1506,7 @@ class TableEditorToolbar(HasPrivateTraits):
     control = Any()
 
     def __init__(self, parent=None, **traits):
-        super(TableEditorToolbar, self).__init__(**traits)
+        super().__init__(**traits)
         editor = self.editor
         factory = editor.factory
         actions = []

--- a/traitsui/wx/table_model.py
+++ b/traitsui/wx/table_model.py
@@ -88,7 +88,7 @@ class TableModel(GridModel):
     def __init__(self, **traits):
         """ Initializes the object.
         """
-        super(TableModel, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Attach trait handlers to the list object:
         editor = self.editor

--- a/traitsui/wx/tabular_editor.py
+++ b/traitsui/wx/tabular_editor.py
@@ -427,7 +427,7 @@ class TabularEditor(Editor):
         self.on_trait_change(self._refresh, "adapter.+update", remove=True)
         self.on_trait_change(self._rebuild_all, "adapter.columns", remove=True)
 
-        super(TabularEditor, self).dispose()
+        super().dispose()
 
     def _update_changed(self, event):
         """ Handles the 'update' event being fired.
@@ -470,9 +470,7 @@ class TabularEditor(Editor):
         """
         self._update_visible = True
 
-        super(TabularEditor, self)._update_editor(
-            object, name, old_value, new_value
-        )
+        super()._update_editor(object, name, old_value, new_value)
 
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the

--- a/traitsui/wx/text_editor.py
+++ b/traitsui/wx/text_editor.py
@@ -178,7 +178,7 @@ class ReadonlyEditor(BaseReadonlyEditor):
         """ Finishes initializing the editor by creating the underlying toolkit
             widget.
         """
-        super(ReadonlyEditor, self).init(parent)
+        super().init(parent)
 
         if self.factory.view is not None:
             control = self.control
@@ -215,7 +215,7 @@ class ReadonlyEditor(BaseReadonlyEditor):
             control.Unbind(wx.EVT_LEFT_DOWN)
             control.Unbind(wx.EVT_LEFT_UP)
 
-        super(ReadonlyEditor, self).dispose()
+        super().dispose()
 
     # -- Private Methods ------------------------------------------------------
 

--- a/traitsui/wx/ui_live.py
+++ b/traitsui/wx/ui_live.py
@@ -383,7 +383,7 @@ class MouseMonitor(wx.Timer):
     """
 
     def __init__(self, ui):
-        super(MouseMonitor, self).__init__()
+        super().__init__()
         self.ui = ui
         kind = ui.view.kind
         self.is_activated = self.is_info = kind == "info"

--- a/traitsui/wx/ui_window.py
+++ b/traitsui/wx/ui_window.py
@@ -44,7 +44,7 @@ class UIWindow(HasPrivateTraits):
     def __init__(self, parent, **traits):
         """ Creates and initializes the window.
         """
-        super(UIWindow, self).__init__(**traits)
+        super().__init__(**traits)
         self.control = wx.Window(
             parent, -1, size=self.size, style=wx.FULL_REPAINT_ON_RESIZE
         )

--- a/traitsui/wx/view_application.py
+++ b/traitsui/wx/view_application.py
@@ -123,9 +123,9 @@ class ViewApplication(wx.App):
         self.args = args
 
         if redirect_filename.strip() != "":
-            super(ViewApplication, self).__init__(1, redirect_filename)
+            super().__init__(1, redirect_filename)
         else:
-            super(ViewApplication, self).__init__(0)
+            super().__init__(0)
 
         # Start the event loop in an IPython-conforming manner.
         try:


### PR DESCRIPTION
This PR updates the `super` usage in classes in `traitsui.wx` submodule. The update was done using automated regex-based search and replace. After the changes were made, each changes was individually checked to ensure that we were calling super with the right arguments before.

Ref https://github.com/enthought/traits/pull/1280. Also see related #1587 