### PR TITLE
replace # with #: to document traits in traitsui.editors.*

### DIFF
--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -204,7 +204,7 @@ class SimpleEditor(Editor):
     #  Trait definitions:
     # -------------------------------------------------------------------------
 
-    # Is the editor read-only?
+    #: Is the editor read-only?
     readonly = Bool(False)
 
     def init(self, parent):

--- a/traitsui/editors/button_editor.py
+++ b/traitsui/editors/button_editor.py
@@ -32,37 +32,37 @@ class ToolkitEditorFactory(EditorFactory):
     #  Trait definitions:
     # -------------------------------------------------------------------------
 
-    # Value to set when the button is clicked
+    #: Value to set when the button is clicked
     value = Property()
 
-    # Optional label for the button
+    #: Optional label for the button
     label = Str()
 
-    # The name of the external object trait that the button label is synced to
+    #: The name of the external object trait that the button label is synced to
     label_value = Str()
 
-    # The name of the trait on the object that contains the list of possible
-    # values.  If this is set, then the value, label, and label_value traits
-    # are ignored; instead, they will be set from this list.  When this button
-    # is clicked, the value set will be the one selected from the drop-down.
+    #: The name of the trait on the object that contains the list of possible
+    #: values.  If this is set, then the value, label, and label_value traits
+    #: are ignored; instead, they will be set from this list.  When this button
+    #: is clicked, the value set will be the one selected from the drop-down.
     values_trait = Either(None, Str)
 
-    # (Optional) Image to display on the button
+    #: (Optional) Image to display on the button
     image = Image
 
-    # Extra padding to add to both the left and the right sides
+    #: Extra padding to add to both the left and the right sides
     width_padding = Range(0, 31, 7)
 
-    # Extra padding to add to both the top and the bottom sides
+    #: Extra padding to add to both the top and the bottom sides
     height_padding = Range(0, 31, 5)
 
-    # Presentation style
+    #: Presentation style
     style = Enum("button", "radio", "toolbar", "checkbox")
 
-    # Orientation of the text relative to the image
+    #: Orientation of the text relative to the image
     orientation = Enum("vertical", "horizontal")
 
-    # The optional view to display when the button is clicked:
+    #: The optional view to display when the button is clicked:
     view = AView
 
     # -------------------------------------------------------------------------

--- a/traitsui/editors/enum_editor.py
+++ b/traitsui/editors/enum_editor.py
@@ -25,10 +25,10 @@ from ..toolkit import toolkit_object
 #  Trait definitions:
 # -------------------------------------------------------------------------
 
-# Supported display modes for a custom style editor
+#: Supported display modes for a custom style editor
 Mode = Enum("radio", "list")
 
-# Supported display modes for a custom style editor
+#: Supported display modes for a custom style editor
 CompletionMode = Enum("inline", "popup")
 
 # -------------------------------------------------------------------------

--- a/traitsui/editors/file_editor.py
+++ b/traitsui/editors/file_editor.py
@@ -26,7 +26,7 @@ from .text_editor import ToolkitEditorFactory as EditorFactory
 #  Trait definitions:
 # -------------------------------------------------------------------------
 
-# Wildcard filter:
+#: Wildcard filter:
 filter_trait = List(Str)
 
 # -------------------------------------------------------------------------

--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -46,13 +46,13 @@ from ..helper import DockStyle
 #  Trait definitions:
 # -------------------------------------------------------------------------
 
-# Trait whose value is a BaseTraitHandler object
+#: Trait whose value is a BaseTraitHandler object
 handler_trait = Instance(BaseTraitHandler)
 
-# The visible number of rows displayed
+#: The visible number of rows displayed
 rows_trait = Range(1, 50, 5, desc="the number of list rows to display")
 
-# The visible number of columns displayed
+#: The visible number of columns displayed
 columns_trait = Range(1, 10, 1, desc="the number of list columns to display")
 
 editor_trait = Instance(EditorFactory)

--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -41,10 +41,10 @@ class _Identity(object):
 #  Trait definitions:
 # -------------------------------------------------------------------------
 
-# Mapping from user input text to other value
+#: Mapping from user input text to other value
 mapping_trait = Dict(Str, Any)
 
-# Function used to evaluate textual user input
+#: Function used to evaluate textual user input
 evaluate_trait = Any(_Identity())
 
 # -------------------------------------------------------------------------

--- a/traitsui/editors/tree_editor.py
+++ b/traitsui/editors/tree_editor.py
@@ -23,7 +23,7 @@ from ..helper import Orientation
 #  Trait definitions:
 # -------------------------------------------------------------------------
 
-# Size of each tree node icon
+#: Size of each tree node icon
 IconSize = Tuple((16, 16), Int, Int)
 
 


### PR DESCRIPTION
closes #1585 

This PR simply replaces comments using # with #: so that the traits get documented by the autogenerated api docs.