### PR TITLE
Use "str.capitalize" directly instead of an alias

### DIFF
--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -45,11 +45,6 @@ from .editor import EditorWithList
 
 logger = logging.getLogger(__name__)
 
-
-# default formatting function (would import from string, but not in Python 3)
-capitalize = lambda s: s.capitalize()
-
-
 # -------------------------------------------------------------------------
 #  'SimpleEditor' class:
 # -------------------------------------------------------------------------
@@ -95,7 +90,7 @@ class SimpleEditor(EditorWithList):
         """
         sv = self.string_value
         if (len(values) > 0) and isinstance(values[0], str):
-            values = [(x, sv(x, capitalize)) for x in values]
+            values = [(x, sv(x, str.capitalize)) for x in values]
         self.values = valid_values = [x[0] for x in values]
         self.names = [x[1] for x in values]
 

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -40,11 +40,6 @@ from traitsui.helper import enum_values_changed
 from .constants import OKColor, ErrorColor
 from .editor import Editor
 
-
-# default formatting function (would import from string, but not in Python 3)
-capitalize = lambda s: s.capitalize()
-
-
 completion_mode_map = {
     "popup": QtGui.QCompleter.PopupCompletion,
     "inline": QtGui.QCompleter.InlineCompletion,
@@ -409,7 +404,7 @@ class RadioEditor(BaseEditor):
     def create_button(self, name):
         """ Returns the QAbstractButton used for the radio button.
         """
-        label = self.string_value(name, capitalize)
+        label = self.string_value(name, str.capitalize)
         return QtGui.QRadioButton(label)
 
     #  Signal handlers -------------------------------------------------------

--- a/traitsui/wx/check_list_editor.py
+++ b/traitsui/wx/check_list_editor.py
@@ -34,11 +34,6 @@ from functools import reduce
 
 logger = logging.getLogger(__name__)
 
-
-# default formatting function (would import from string, but not in Python 3)
-capitalize = lambda s: s.capitalize()
-
-
 # -------------------------------------------------------------------------
 #  'SimpleEditor' class:
 # -------------------------------------------------------------------------
@@ -83,7 +78,7 @@ class SimpleEditor(EditorWithList):
         """
         sv = self.string_value
         if (len(values) > 0) and isinstance(values[0], str):
-            values = [(x, sv(x, capitalize)) for x in values]
+            values = [(x, sv(x, str.capitalize)) for x in values]
         self.values = valid_values = [x[0] for x in values]
         self.names = [x[1] for x in values]
 

--- a/traitsui/wx/enum_editor.py
+++ b/traitsui/wx/enum_editor.py
@@ -35,11 +35,6 @@ from .helper import (
 )
 from functools import reduce
 
-
-# default formatting function (would import from string, but not in Python 3)
-capitalize = lambda s: s.capitalize()
-
-
 # -------------------------------------------------------------------------
 #  'BaseEditor' class:
 # -------------------------------------------------------------------------
@@ -390,7 +385,7 @@ class RadioEditor(BaseEditor):
             for j in range(cols):
                 if n > 0:
                     name = label = names[index]
-                    label = self.string_value(label, capitalize)
+                    label = self.string_value(label, str.capitalize)
                     control = wx.RadioButton(panel, -1, label, style=style)
                     control.value = mapping[name]
                     style = 0


### PR DESCRIPTION
`str.capitalize('abc')` is the same as `'abc'.capitalize()`

closes #768 

these changes were introduced in https://github.com/enthought/traitsui/pull/234

Note that the original issue was planned for traitsui 7.1.0. Ref https://github.com/enthought/traitsui/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22Release+7.1%22