### PR TITLE
Use "PrefixList" from traits >= 6.1

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     __version__ = "not-built"
 
-__requires__ = ["traits>=6.0.0", "pyface>=7.1.0"]
+__requires__ = ["traits>=6.1.0", "pyface>=7.1.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],

--- a/traitsui/helper.py
+++ b/traitsui/helper.py
@@ -177,17 +177,3 @@ def compute_column_widths(available_space, requested, min_widths, user_widths):
 # -------------------------------------------------------------------------
 
 SequenceTypes = (tuple, list)
-
-
-# -------------------------------------------------------------------------
-#  Wrapper for TraitPrefixList deprecation:
-# -------------------------------------------------------------------------
-
-try:
-    from traits.api import PrefixList
-except ImportError:
-    def PrefixList(list_, default_value=None, **kwargs):
-        from traits.api import Trait, TraitPrefixList
-        if default_value is None:
-            default_value = list_[0]
-        return Trait(default_value, TraitPrefixList(list_), **kwargs)

--- a/traitsui/ui_traits.py
+++ b/traitsui/ui_traits.py
@@ -30,13 +30,14 @@ from traits.api import (
     Float,
     HasStrictTraits,
     List,
+    PrefixList,
     Range,
     Str,
     TraitError,
     TraitType,
 )
 
-from .helper import PrefixList, SequenceTypes
+from .helper import SequenceTypes
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/view.py
+++ b/traitsui/view.py
@@ -24,6 +24,7 @@ from traits.api import (
     Float,
     Instance,
     List,
+    PrefixList,
     Str,
     Trait,
 )
@@ -52,8 +53,6 @@ from .group import Group
 from .item import Item
 
 from .include import Include
-
-from .helper import PrefixList
 
 # -------------------------------------------------------------------------
 #  Trait definitions:


### PR DESCRIPTION
This PR relies on `traits.api` directly for `PrefixList` instead of relying on a compatibility layer to support traits 6.0. We bump the traits dependency to `>=6.1`. Note that we would have relied on `>=6.1` anyway because of the on triat change -> observe changes.

Note that the compat layer was introduced in https://github.com/enthought/traitsui/pull/1053/ and fixes #1296

Note that the original issue was planned for traitsui 7.1.0. Ref https://github.com/enthought/traitsui/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22Release+7.1%22