### PR TITLE
Update use of deprecated "Thread.setDaemon"

### DIFF
--- a/traitsui/examples/demo/Advanced/Property_List_demo.py
+++ b/traitsui/examples/demo/Advanced/Property_List_demo.py
@@ -119,7 +119,7 @@ class PropertyListDemo(HasPrivateTraits):
         """ Starts the background thread running.
         """
         thread = Thread(target=self._timer)
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
         return 0

--- a/traitsui/examples/demo/Advanced/Statusbar_demo.py
+++ b/traitsui/examples/demo/Advanced/Statusbar_demo.py
@@ -69,7 +69,7 @@ class TextEditor(HasPrivateTraits):
 
     def _time_default(self):
         thread = Thread(target=self._clock)
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
         return ''


### PR DESCRIPTION
fixes #1576

This PR updates the use of the deprecated `threading.Thread.setDaemon` to just use `threading.Thread.daemon`.