### PR TITLE
Replace deprecated "wx.ListItemAttr" with "wx.ItemAttr"

### DIFF
--- a/traitsui/wx/tabular_editor.py
+++ b/traitsui/wx/tabular_editor.py
@@ -145,7 +145,7 @@ class wxListCtrl(wx.ListCtrl, TextEditMixin):
         # manage the reference count for the returned object, and it seems to be
         # gc'ed before they finish using it. So we store an object reference to
         # it to prevent it from going away too soon...
-        self._attr = attr = wx.ListItemAttr()
+        self._attr = attr = wx.ItemAttr()
         editor = self._editor
         object, name = editor.object, editor.name
 


### PR DESCRIPTION
fixes #1411

This PR replaces the deprecated `wx.ListItemAttr` with the recommended `wx.ItemAttr`. This has been verified by running the traits-futures example which is how we originally discovered the issue.