### PR TITLE
Import "TraitFactory" from "traits.api"

### DIFF
--- a/traitsui/toolkit_traits.py
+++ b/traitsui/toolkit_traits.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-# XXX eventually should replace with traits.api
-from traits.trait_factory import TraitFactory
+from traits.api import TraitFactory
 
 from .toolkit import toolkit
 


### PR DESCRIPTION
This PR makes a very trivial/simple change - it imports `TraitFactory` from `traits.api` instead of `traits.trait_factory`. This was fixed in traits in https://github.com/enthought/traits/pull/730/ and has been available in traits since v 6.0.0.