### PR TITLE
Drop support for PyQt < 4.3.2

### DIFF
--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -398,14 +398,6 @@ class GUIToolkit(Toolkit):
         control.hide()
         control.deleteLater()
 
-        # PyQt v4.3.1 and earlier deleteLater() didn't transfer ownership to
-        # C++, which is necessary for the QObject system to garbage collect it.
-        if qt_api == "pyqt":
-            if QtCore.PYQT_VERSION < 0x040302:
-                import sip
-
-                sip.transferto(control, None)
-
     def destroy_children(self, control):
         """ Destroys all of the child controls of a specified GUI toolkit
             control.


### PR DESCRIPTION
This PR removes a conditional that handled support for PyQt version < 4.3.2 - and thereby officially removes support for this version. I'm reasonably sure that no one was using such an old version of PyQt (the latest is 4.12.1 and the only other available version on python 3 for pyqt4 is 4.11.4).