### PR TITLE
Remove backwards compatibility toolkit factory imports

### DIFF
--- a/traitsui/qt4/array_editor.py
+++ b/traitsui/qt4/array_editor.py
@@ -12,13 +12,7 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.array_editor file.
-from traitsui.editors.array_editor import (
-    SimpleEditor as BaseSimpleEditor,
-    ToolkitEditorFactory,
-)
+from traitsui.editors.array_editor import SimpleEditor as BaseSimpleEditor
 
 from .editor import Editor
 

--- a/traitsui/qt4/boolean_editor.py
+++ b/traitsui/qt4/boolean_editor.py
@@ -26,11 +26,6 @@
 
 from pyface.qt import QtCore, QtGui
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.boolean_editor file.
-from traitsui.editors.boolean_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 # This needs to be imported in here for use by the editor factory for boolean

--- a/traitsui/qt4/button_editor.py
+++ b/traitsui/qt4/button_editor.py
@@ -29,11 +29,6 @@ from pyface.api import Image
 
 from traits.api import Str, List, Str, observe, on_trait_change
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.button_editor file.
-from traitsui.editors.button_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 

--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -32,11 +32,6 @@ from pyface.qt import QtCore, QtGui
 
 from traits.api import Any, Callable, List, Str, TraitError, Tuple
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.check_list_editor file.
-from traitsui.editors.check_list_editor import ToolkitEditorFactory
-
 from .editor_factory import TextEditor as BaseTextEditor
 
 from .editor import EditorWithList

--- a/traitsui/qt4/code_editor.py
+++ b/traitsui/qt4/code_editor.py
@@ -39,11 +39,6 @@ from traits.api import (
 )
 from traits.trait_base import SequenceTypes
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.code_editor file.
-from traitsui.editors.code_editor import ToolkitEditorFactory
-
 from pyface.key_pressed_event import KeyPressedEvent
 
 from .constants import OKColor, ErrorColor

--- a/traitsui/qt4/compound_editor.py
+++ b/traitsui/qt4/compound_editor.py
@@ -29,11 +29,6 @@ from pyface.qt import QtGui
 
 from traits.api import Str
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.compound_editor file.
-from traitsui.editors.compound_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 

--- a/traitsui/qt4/custom_editor.py
+++ b/traitsui/qt4/custom_editor.py
@@ -27,11 +27,6 @@ based custom control.
 
 from pyface.qt import QtGui
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.custom_editor file.
-from traitsui.editors.custom_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 # -------------------------------------------------------------------------

--- a/traitsui/qt4/directory_editor.py
+++ b/traitsui/qt4/directory_editor.py
@@ -22,11 +22,6 @@
 
 from pyface.qt import QtGui
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.custom_editor file.
-from traitsui.editors.directory_editor import ToolkitEditorFactory
-
 from .file_editor import (
     SimpleEditor as SimpleFileEditor,
     CustomEditor as CustomFileEditor,

--- a/traitsui/qt4/drop_editor.py
+++ b/traitsui/qt4/drop_editor.py
@@ -27,11 +27,6 @@ target editor handles drag and drop operations as a drop target.
 
 from pyface.qt import QtGui, QtCore
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.drop_editor file.
-from traitsui.editors.drop_editor import ToolkitEditorFactory
-
 from .editor import Editor as _BaseEditor
 from .text_editor import SimpleEditor as Editor
 from .constants import DropColor

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -32,10 +32,6 @@ from pyface.qt import QtCore, QtGui
 
 from traits.api import Bool, Property
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.enum_editor file.
-from traitsui.editors.enum_editor import ToolkitEditorFactory
 from traitsui.helper import enum_values_changed
 from .constants import OKColor, ErrorColor
 from .editor import Editor

--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -25,10 +25,6 @@ from os.path import abspath, splitext, isfile, exists
 from pyface.qt import QtCore, QtGui, is_qt5
 from traits.api import Any, Callable, List, Event, File, Str, TraitError, Tuple
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.file_editor file.
-from traitsui.editors.file_editor import ToolkitEditorFactory
 from .editor import Editor
 from .text_editor import SimpleEditor as SimpleTextEditor
 from .helper import IconButton

--- a/traitsui/qt4/image_enum_editor.py
+++ b/traitsui/qt4/image_enum_editor.py
@@ -15,11 +15,6 @@
 
 from pyface.qt import QtCore, QtGui, is_qt5
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.image_enum_editor file.
-from traitsui.editors.image_enum_editor import ToolkitEditorFactory
-
 from .editor import Editor
 from .enum_editor import BaseEditor as BaseEnumEditor
 from .enum_editor import SimpleEditor as SimpleEnumEditor

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -29,10 +29,6 @@ from pyface.qt import QtCore, QtGui
 
 from traits.api import HasTraits, Instance, Property
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.instance_editor file.
-from traitsui.editors.instance_editor import ToolkitEditorFactory
 from traitsui.ui_traits import AView
 from traitsui.helper import user_name_for
 from traitsui.handler import Handler

--- a/traitsui/qt4/key_binding_editor.py
+++ b/traitsui/qt4/key_binding_editor.py
@@ -30,13 +30,6 @@ from pyface.qt import QtCore, QtGui
 
 from traits.api import Bool, Event
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.key_binding_editor file.
-from traitsui.editors.key_binding_editor import (
-    KeyBindingEditor as ToolkitEditorFactory,
-)
-
 from .editor import Editor
 
 from .key_event_to_name import key_event_to_name

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -31,10 +31,7 @@ from pyface.api import ImageResource
 from traits.api import Str, Any, Bool, Dict, Instance, List
 from traits.trait_base import user_name_for, xgetattr
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.list_editor file.
-from traitsui.editors.list_editor import ListItemProxy, ToolkitEditorFactory
+from traitsui.editors.list_editor import ListItemProxy
 
 from .editor import Editor
 from .helper import IconButton

--- a/traitsui/qt4/null_editor.py
+++ b/traitsui/qt4/null_editor.py
@@ -14,11 +14,6 @@
 
 from pyface.qt import QtGui
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.null_editor file.
-from traitsui.editors.null_editor import NullEditor as ToolkitEditorFactory
-
 from .editor import Editor
 
 

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -31,11 +31,6 @@ from pyface.qt import QtCore, QtGui
 
 from traits.api import TraitError, Str, Float, Any, Bool
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.range_editor file.
-from traitsui.editors.range_editor import ToolkitEditorFactory
-
 from .editor_factory import TextEditor
 
 from .editor import Editor

--- a/traitsui/qt4/set_editor.py
+++ b/traitsui/qt4/set_editor.py
@@ -26,11 +26,6 @@
 
 from pyface.qt import QtCore, QtGui
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.set_editor file.
-from traitsui.editors.set_editor import ToolkitEditorFactory
-
 from traitsui.helper import enum_values_changed
 
 from .editor import Editor

--- a/traitsui/qt4/shell_editor.py
+++ b/traitsui/qt4/shell_editor.py
@@ -12,9 +12,6 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.shell_editor file.
 from traitsui.editors.shell_editor import _ShellEditor as BaseShellEditor
 
 from .editor import Editor

--- a/traitsui/qt4/text_editor.py
+++ b/traitsui/qt4/text_editor.py
@@ -27,10 +27,7 @@ from pyface.qt import QtCore, QtGui
 
 from traits.api import Any, Callable, List, TraitError, Tuple
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.text_editor file.
-from traitsui.editors.text_editor import evaluate_trait, ToolkitEditorFactory
+from traitsui.editors.text_editor import evaluate_trait
 
 from .editor import Editor
 

--- a/traitsui/qt4/title_editor.py
+++ b/traitsui/qt4/title_editor.py
@@ -28,11 +28,6 @@ from .editor import Editor
 
 from pyface.heading_text import HeadingText
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.title_editor file.
-from ..editors.title_editor import TitleEditor
-
 
 class SimpleEditor(Editor):
     def init(self, parent):

--- a/traitsui/qt4/tuple_editor.py
+++ b/traitsui/qt4/tuple_editor.py
@@ -24,13 +24,7 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.tuple_editor file.
-from traitsui.editors.tuple_editor import (
-    SimpleEditor as BaseSimpleEditor,
-    ToolkitEditorFactory,
-)
+from traitsui.editors.tuple_editor import SimpleEditor as BaseSimpleEditor
 
 from .editor import Editor
 

--- a/traitsui/qt4/value_editor.py
+++ b/traitsui/qt4/value_editor.py
@@ -13,10 +13,7 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.value_editor file.
-from traitsui.editors.value_editor import _ValueEditor, ToolkitEditorFactory
+from traitsui.editors.value_editor import _ValueEditor
 
 from .editor import Editor
 

--- a/traitsui/wx/array_editor.py
+++ b/traitsui/wx/array_editor.py
@@ -12,13 +12,7 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.array_editor file.
-from traitsui.editors.array_editor import (
-    SimpleEditor as BaseSimpleEditor,
-    ToolkitEditorFactory,
-)
+from traitsui.editors.array_editor import SimpleEditor as BaseSimpleEditor
 
 from .editor import Editor
 

--- a/traitsui/wx/boolean_editor.py
+++ b/traitsui/wx/boolean_editor.py
@@ -14,11 +14,6 @@
 
 import wx
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.boolean_editor file.
-from traitsui.editors.boolean_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 # This needs to be imported in here for use by the editor factory for boolean

--- a/traitsui/wx/button_editor.py
+++ b/traitsui/wx/button_editor.py
@@ -17,11 +17,6 @@ import wx
 from pyface.ui_traits import Image
 from traits.api import Str, observe
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.button_editor file.
-from traitsui.editors.button_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 # -------------------------------------------------------------------------

--- a/traitsui/wx/check_list_editor.py
+++ b/traitsui/wx/check_list_editor.py
@@ -19,11 +19,6 @@ import wx
 
 from traits.api import List, Str, TraitError
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.check_list_editor file.
-from traitsui.editors.check_list_editor import ToolkitEditorFactory
-
 from .editor_factory import TextEditor as BaseTextEditor
 
 from .editor import EditorWithList

--- a/traitsui/wx/code_editor.py
+++ b/traitsui/wx/code_editor.py
@@ -20,11 +20,6 @@ from traits.api import Str, List, Int, Event, Bool, TraitError, observe
 
 from traits.trait_base import SequenceTypes
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.code_editor file.
-from traitsui.editors.code_editor import ToolkitEditorFactory
-
 from pyface.api import PythonEditor
 
 from pyface.wx.python_stc import faces

--- a/traitsui/wx/compound_editor.py
+++ b/traitsui/wx/compound_editor.py
@@ -17,11 +17,6 @@ import wx
 
 from traits.api import Str
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.compound_editor file.
-from traitsui.editors.compound_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 from .helper import TraitsUIPanel

--- a/traitsui/wx/custom_editor.py
+++ b/traitsui/wx/custom_editor.py
@@ -15,11 +15,6 @@ based custom control.
 
 import wx
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.custom_editor file.
-from traitsui.editors.custom_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 # -------------------------------------------------------------------------

--- a/traitsui/wx/directory_editor.py
+++ b/traitsui/wx/directory_editor.py
@@ -16,11 +16,6 @@ import wx
 
 from os.path import isdir
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.custom_editor file.
-from traitsui.editors.directory_editor import ToolkitEditorFactory
-
 from .file_editor import (
     SimpleEditor as SimpleFileEditor,
     CustomEditor as CustomFileEditor,

--- a/traitsui/wx/dnd_editor.py
+++ b/traitsui/wx/dnd_editor.py
@@ -23,11 +23,6 @@ from pickle import load
 
 from traits.api import Bool
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.dnd_editor file.
-from traitsui.editors.dnd_editor import ToolkitEditorFactory
-
 from pyface.wx.drag_and_drop import (
     PythonDropSource,
     PythonDropTarget,

--- a/traitsui/wx/drop_editor.py
+++ b/traitsui/wx/drop_editor.py
@@ -15,11 +15,6 @@
 
 import wx
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.drop_editor file.
-from traitsui.editors.drop_editor import ToolkitEditorFactory
-
 from pyface.wx.drag_and_drop import PythonDropTarget, clipboard
 
 from .text_editor import SimpleEditor as Editor

--- a/traitsui/wx/enum_editor.py
+++ b/traitsui/wx/enum_editor.py
@@ -17,11 +17,6 @@ import wx
 
 from traits.api import Property
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.drop_editor file.
-from traitsui.editors.enum_editor import ToolkitEditorFactory
-
 from traitsui.helper import enum_values_changed
 
 from .editor import Editor

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -18,11 +18,6 @@ from os.path import abspath, split, splitext, isfile, exists
 
 from traits.api import List, Str, Event, Any, observe, TraitError
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.file_editor file.
-from traitsui.editors.file_editor import ToolkitEditorFactory
-
 from .text_editor import SimpleEditor as SimpleTextEditor
 
 from .helper import TraitsUIPanel, PopupControl

--- a/traitsui/wx/html_editor.py
+++ b/traitsui/wx/html_editor.py
@@ -21,11 +21,6 @@ import wx.html as wh
 
 from traits.api import Str
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.html_editor file.
-from traitsui.editors.html_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 

--- a/traitsui/wx/image_enum_editor.py
+++ b/traitsui/wx/image_enum_editor.py
@@ -16,11 +16,6 @@ import wx
 
 from traits.api import Any
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.image_enum_editor file.
-from traitsui.editors.image_enum_editor import ToolkitEditorFactory
-
 from .editor import Editor
 
 from .enum_editor import BaseEditor as BaseEnumEditor

--- a/traitsui/wx/instance_editor.py
+++ b/traitsui/wx/instance_editor.py
@@ -18,10 +18,6 @@ import wx
 from pyface.wx.drag_and_drop import PythonDropTarget
 from traits.api import HasTraits, Instance, Property
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.instance_editor file.
-from traitsui.editors.instance_editor import ToolkitEditorFactory
 from traitsui.ui_traits import AView
 from traitsui.helper import user_name_for
 from traitsui.handler import Handler

--- a/traitsui/wx/key_binding_editor.py
+++ b/traitsui/wx/key_binding_editor.py
@@ -18,13 +18,6 @@ import wx
 
 from traits.api import Bool, Event
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.key_binding_editor file.
-from traitsui.editors.key_binding_editor import (
-    KeyBindingEditor as ToolkitEditorFactory,
-)
-
 from pyface.wx.dialog import confirmation
 
 from .editor import Editor

--- a/traitsui/wx/null_editor.py
+++ b/traitsui/wx/null_editor.py
@@ -14,11 +14,6 @@
 
 import wx
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.null_editor file.
-from traitsui.editors.null_editor import NullEditor as ToolkitEditorFactory
-
 from .editor import Editor
 
 

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -19,11 +19,6 @@ from math import log10
 
 from traits.api import TraitError, Str, Float, Any, Bool
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.range_editor file.
-from traitsui.editors.range_editor import ToolkitEditorFactory
-
 from .editor_factory import TextEditor
 
 from .editor import Editor
@@ -928,7 +923,7 @@ def CustomEnumEditor(
     if factory._enum is None:
         import traitsui.editors.enum_editor as enum_editor
 
-        factory._enum = enum_editor.ToolkitEditorFactory(
+        factory._enum = enum_editor.EnumEditor(
             values=list(range(factory.low, factory.high + 1)),
             cols=factory.cols,
         )

--- a/traitsui/wx/set_editor.py
+++ b/traitsui/wx/set_editor.py
@@ -18,11 +18,6 @@ import wx
 
 from traits.api import Property
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.set_editor file.
-from traitsui.editors.set_editor import ToolkitEditorFactory
-
 from traitsui.helper import enum_values_changed
 
 from .editor import Editor

--- a/traitsui/wx/shell_editor.py
+++ b/traitsui/wx/shell_editor.py
@@ -12,13 +12,7 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.shell_editor file.
-from traitsui.editors.shell_editor import (
-    _ShellEditor as BaseShellEditor,
-    ToolkitEditorFactory,
-)
+from traitsui.editors.shell_editor import _ShellEditor as BaseShellEditor
 
 from .editor import Editor
 

--- a/traitsui/wx/text_editor.py
+++ b/traitsui/wx/text_editor.py
@@ -16,10 +16,7 @@ import wx
 
 from traits.api import TraitError
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.text_editor file.
-from traitsui.editors.text_editor import ToolkitEditorFactory, evaluate_trait
+from traitsui.editors.text_editor import evaluate_trait
 
 from .editor import Editor
 

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -26,9 +26,6 @@ from pyface.ui.wx.image_list import ImageList
 from traits.api import HasStrictTraits, Any, Str, Event, TraitError
 from traitsui.api import View, TreeNode, ObjectTreeNode, MultiTreeNode
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.tree_editor file.
 from traitsui.editors.tree_editor import (
     CopyAction,
     CutAction,
@@ -36,7 +33,6 @@ from traitsui.editors.tree_editor import (
     NewAction,
     PasteAction,
     RenameAction,
-    ToolkitEditorFactory,
 )
 from traitsui.undo import ListUndoItem
 from traitsui.tree_node import ITreeNodeAdapterBridge

--- a/traitsui/wx/tuple_editor.py
+++ b/traitsui/wx/tuple_editor.py
@@ -12,13 +12,7 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.tuple_editor file.
-from traitsui.editors.tuple_editor import (
-    SimpleEditor as BaseSimpleEditor,
-    ToolkitEditorFactory,
-)
+from traitsui.editors.tuple_editor import SimpleEditor as BaseSimpleEditor
 
 from .editor import Editor
 

--- a/traitsui/wx/value_editor.py
+++ b/traitsui/wx/value_editor.py
@@ -13,10 +13,7 @@
 """
 
 
-# FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
-# compatibility. The class has been moved to the
-# traitsui.editors.value_editor file.
-from traitsui.editors.value_editor import _ValueEditor, ToolkitEditorFactory
+from traitsui.editors.value_editor import _ValueEditor
 
 from .editor import Editor
 


### PR DESCRIPTION
This PR removes backwards compatibility toolkit factory imports introduced in the toolkit-specific editor implementations.

fixes #1473

Note that these backwards compatibility imports have existed in traitsui since atleast version 4.0.0 and at this point, it is more than safe for us to remove them.