### PR TITLE
Expose notify interval in VideoEditor

### DIFF
--- a/traitsui/editors/video_editor.py
+++ b/traitsui/editors/video_editor.py
@@ -80,6 +80,10 @@ class VideoEditor(BasicEditorFactory):
     #: The referenced trait should be a Str.
     image_func = Str(sync_value='both', sync_name='image_func')
 
+    #: The name of a trait to synchronise with the player's notify interval.
+    #: The referenced trait should be a Float representing time in seconds.
+    notify_interval = Str(sync_value='from', sync_name='notify_interval')
+
     def _get_klass(self):
         """ Returns the editor class to be instantiated.
         """

--- a/traitsui/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -100,6 +100,8 @@ class VideoEditorDemo(HasTraits):
 
     image_func = Callable()
 
+    notify_interval = Float(0.5)
+
     @observe('state')
     def _state_update(self, event):
         if event.new == 'stopped' or event.new == 'paused':
@@ -129,7 +131,8 @@ class VideoEditorDemo(HasTraits):
                 muted='muted',
                 volume='volume',
                 playback_rate='playback_rate',
-                image_func='image_func'
+                image_func='image_func',
+                notify_interval='notify_interval',
             ),
         ),
         HGroup(

--- a/traitsui/tests/editors/test_video_editor.py
+++ b/traitsui/tests/editors/test_video_editor.py
@@ -32,6 +32,7 @@ class MovieTheater(HasTraits):
     volume = Range(0.0, 100.0, value=100.0)
     playback_rate = Float(1.0)
     image_func = Callable()
+    notify_interval = Float(0.5)
 
 
 @unittest.skipIf(not is_qt5(), 'Requires Qt5')
@@ -58,7 +59,8 @@ class TestVideoEditor(BaseTestMixin, unittest.TestCase):
                     muted='muted',
                     volume='volume',
                     playback_rate='playback_rate',
-                    image_func='image_func'
+                    image_func='image_func',
+                    notify_interval='notify_interval',
                 ),
             ),
         )


### PR DESCRIPTION
Follow up to PR #745 that adds the ability to control the [notify interval](https://doc.qt.io/qt-5/qmediaobject.html#notifyInterval-prop) of the media player.

When running the `VideoEditor` demo, you should see position updates occur approx every 0.5s now (previously 1s).