### PR TITLE
Rename editor factory classes

### DIFF
--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -28,12 +28,8 @@ from ..group import Group
 
 from ..item import Item
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class ArrayEditor(EditorFactory):
     """ Editor factory for array editors.
     """
 
@@ -247,5 +243,5 @@ class SimpleEditor(Editor):
         self._busy = False
 
 
-# Define the ArrayEditor class
-ArrayEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = ArrayEditor

--- a/traitsui/editors/boolean_editor.py
+++ b/traitsui/editors/boolean_editor.py
@@ -18,7 +18,7 @@ from traits.api import Dict, Str, Any
 
 from ..view import View
 
-from .text_editor import ToolkitEditorFactory as EditorFactory
+from .text_editor import TextEditor as EditorFactory
 
 # -------------------------------------------------------------------------
 #  Trait definitions:
@@ -42,12 +42,8 @@ mapping_trait = Dict(
     },
 )
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class BooleanEditor(EditorFactory):
     """ Editor factory for Boolean editors.
     """
 
@@ -79,5 +75,5 @@ class ToolkitEditorFactory(EditorFactory):
         return self.simple_editor_class
 
 
-# Define the BooleanEditor class
-BooleanEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = BooleanEditor

--- a/traitsui/editors/boolean_editor.py
+++ b/traitsui/editors/boolean_editor.py
@@ -18,7 +18,7 @@ from traits.api import Dict, Str, Any
 
 from ..view import View
 
-from .text_editor import TextEditor as EditorFactory
+from .text_editor import TextEditor
 
 # -------------------------------------------------------------------------
 #  Trait definitions:
@@ -43,7 +43,7 @@ mapping_trait = Dict(
 )
 
 
-class BooleanEditor(EditorFactory):
+class BooleanEditor(TextEditor):
     """ Editor factory for Boolean editors.
     """
 

--- a/traitsui/editors/button_editor.py
+++ b/traitsui/editors/button_editor.py
@@ -19,12 +19,7 @@ from ..ui_traits import AView
 from ..view import View
 
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
-
-
-class ToolkitEditorFactory(EditorFactory):
+class ButtonEditor(EditorFactory):
     """ Editor factory for buttons.
     """
 
@@ -94,5 +89,5 @@ class ToolkitEditorFactory(EditorFactory):
         super().__init__(**traits)
 
 
-# Define the ButtonEditor class
-ButtonEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = ButtonEditor

--- a/traitsui/editors/check_list_editor.py
+++ b/traitsui/editors/check_list_editor.py
@@ -31,12 +31,8 @@ from traits.api import Range
 
 from ..editor_factory import EditorWithListFactory
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorWithListFactory):
+class CheckListEditor(EditorWithListFactory):
     """ Editor factory for checklists.
     """
 
@@ -48,5 +44,5 @@ class ToolkitEditorFactory(EditorWithListFactory):
     cols = Range(1, 20)
 
 
-# Define the CheckListEditor class
-CheckListEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = CheckListEditor

--- a/traitsui/editors/code_editor.py
+++ b/traitsui/editors/code_editor.py
@@ -17,12 +17,8 @@ from traits.api import Instance, Str, Enum, Bool
 from ..editor_factory import EditorFactory
 from ..toolkit_traits import Color
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class CodeEditor(EditorFactory):
     """ Editor factory for code editors.
     """
 
@@ -101,5 +97,5 @@ class ToolkitEditorFactory(EditorFactory):
     squiggle_color = Str()
 
 
-# Define the Code Editor class.
-CodeEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = CodeEditor

--- a/traitsui/editors/compound_editor.py
+++ b/traitsui/editors/compound_editor.py
@@ -22,12 +22,8 @@ from ..editor_factory import EditorFactory
 # List of component editor factories used to build a compound editor
 editors_trait = List(EditorFactory)
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class CompoundEditor(EditorFactory):
     """ Editor factory for compound editors.
     """
 
@@ -42,5 +38,5 @@ class ToolkitEditorFactory(EditorFactory):
     auto_set = Bool(True)
 
 
-# Define the CompoundEditor class
-CompoundEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = CompoundEditor

--- a/traitsui/editors/custom_editor.py
+++ b/traitsui/editors/custom_editor.py
@@ -17,12 +17,8 @@ from ..basic_editor_factory import BasicEditorFactory
 
 from ..toolkit import toolkit_object
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(BasicEditorFactory):
+class CustomEditor(BasicEditorFactory):
     """ Editor factory for custom editors.
     """
 
@@ -50,5 +46,5 @@ class ToolkitEditorFactory(BasicEditorFactory):
         return toolkit_object("custom_editor:CustomEditor")
 
 
-# Define the CustomEditor class.
-CustomEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = CustomEditor

--- a/traitsui/editors/date_range_editor.py
+++ b/traitsui/editors/date_range_editor.py
@@ -12,7 +12,7 @@ from traits.api import Bool, Constant
 from .date_editor import DateEditor
 
 
-class ToolkitEditorFactory(DateEditor):
+class DateRangeEditor(DateEditor):
     """ Editor for a date range. The target value should be a tuple
     containing two dates (start date, end date)
     """
@@ -26,4 +26,5 @@ class ToolkitEditorFactory(DateEditor):
     allow_no_selection = Bool(False)
 
 
-DateRangeEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = DateRangeEditor

--- a/traitsui/editors/directory_editor.py
+++ b/traitsui/editors/directory_editor.py
@@ -11,10 +11,10 @@
 """ Defines the directory editor factory for all traits toolkit backends.
 """
 
-from .file_editor import FileEditor as EditorFactory
+from .file_editor import FileEditor
 
 
-class DirectoryEditor(EditorFactory):
+class DirectoryEditor(FileEditor):
     """ Editor factory for directory editors.
     """
 

--- a/traitsui/editors/directory_editor.py
+++ b/traitsui/editors/directory_editor.py
@@ -11,19 +11,15 @@
 """ Defines the directory editor factory for all traits toolkit backends.
 """
 
-from .file_editor import ToolkitEditorFactory as EditorFactory
-
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
+from .file_editor import FileEditor as EditorFactory
 
 
-class ToolkitEditorFactory(EditorFactory):
+class DirectoryEditor(EditorFactory):
     """ Editor factory for directory editors.
     """
 
     pass
 
 
-# Define the DirectoryEditor class
-DirectoryEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = DirectoryEditor

--- a/traitsui/editors/dnd_editor.py
+++ b/traitsui/editors/dnd_editor.py
@@ -18,12 +18,8 @@ from pyface.ui_traits import Image
 
 from ..editor_factory import EditorFactory
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class DNDEditor(EditorFactory):
     """ Editor factory for drag-and-drop editors.
     """
 
@@ -38,5 +34,5 @@ class ToolkitEditorFactory(EditorFactory):
     disabled_image = Image
 
 
-# Define the DNDEditor class.
-DNDEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = DNDEditor

--- a/traitsui/editors/drop_editor.py
+++ b/traitsui/editors/drop_editor.py
@@ -15,10 +15,10 @@
 
 from traits.api import Any, Bool
 
-from .text_editor import TextEditor as EditorFactory
+from .text_editor import TextEditor
 
 
-class DropEditor(EditorFactory):
+class DropEditor(TextEditor):
     """ Editor factory for drop editors.
     """
 

--- a/traitsui/editors/drop_editor.py
+++ b/traitsui/editors/drop_editor.py
@@ -15,14 +15,10 @@
 
 from traits.api import Any, Bool
 
-from .text_editor import ToolkitEditorFactory as EditorFactory
-
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
+from .text_editor import TextEditor as EditorFactory
 
 
-class ToolkitEditorFactory(EditorFactory):
+class DropEditor(EditorFactory):
     """ Editor factory for drop editors.
     """
 
@@ -40,5 +36,5 @@ class ToolkitEditorFactory(EditorFactory):
     readonly = Bool(True)
 
 
-# Define the DropEditor class.
-DropEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = DropEditor

--- a/traitsui/editors/enum_editor.py
+++ b/traitsui/editors/enum_editor.py
@@ -31,12 +31,8 @@ Mode = Enum("radio", "list")
 #: Supported display modes for a custom style editor
 CompletionMode = Enum("inline", "popup")
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorWithListFactory):
+class EnumEditor(EditorWithListFactory):
     """ Editor factory for enumeration editors.
     """
 
@@ -85,5 +81,5 @@ class ToolkitEditorFactory(EditorWithListFactory):
             return super()._get_custom_editor_class()
 
 
-# Define the EnumEditor class.
-EnumEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = EnumEditor

--- a/traitsui/editors/file_editor.py
+++ b/traitsui/editors/file_editor.py
@@ -20,7 +20,7 @@ from ..view import View
 
 from ..group import Group
 
-from .text_editor import TextEditor as EditorFactory
+from .text_editor import TextEditor
 
 # -------------------------------------------------------------------------
 #  Trait definitions:
@@ -30,7 +30,7 @@ from .text_editor import TextEditor as EditorFactory
 filter_trait = List(Str)
 
 
-class FileEditor(EditorFactory):
+class FileEditor(TextEditor):
     """ Editor factory for file editors.
     """
 

--- a/traitsui/editors/file_editor.py
+++ b/traitsui/editors/file_editor.py
@@ -20,7 +20,7 @@ from ..view import View
 
 from ..group import Group
 
-from .text_editor import ToolkitEditorFactory as EditorFactory
+from .text_editor import TextEditor as EditorFactory
 
 # -------------------------------------------------------------------------
 #  Trait definitions:
@@ -29,12 +29,8 @@ from .text_editor import ToolkitEditorFactory as EditorFactory
 #: Wildcard filter:
 filter_trait = List(Str)
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class FileEditor(EditorFactory):
     """ Editor factory for file editors.
     """
 
@@ -105,5 +101,5 @@ class ToolkitEditorFactory(EditorFactory):
     extras = Group()
 
 
-# Define the FileEditor class.
-FileEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = FileEditor

--- a/traitsui/editors/image_enum_editor.py
+++ b/traitsui/editors/image_enum_editor.py
@@ -20,14 +20,10 @@ from os.path import join, dirname, exists
 
 from traits.api import Module, Type, Str, observe
 
-from .enum_editor import ToolkitEditorFactory as EditorFactory
-
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
+from .enum_editor import EnumEditor as EditorFactory
 
 
-class ToolkitEditorFactory(EditorFactory):
+class ImageEnumEditor(EditorFactory):
     """ Editor factory for image enumeration editors.
     """
 
@@ -84,5 +80,5 @@ class ToolkitEditorFactory(EditorFactory):
             self._image_path = join(dirname(self.module.__file__), "images")
 
 
-# Define the ImageEnumEditor class.
-ImageEnumEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = ImageEnumEditor

--- a/traitsui/editors/image_enum_editor.py
+++ b/traitsui/editors/image_enum_editor.py
@@ -20,10 +20,10 @@ from os.path import join, dirname, exists
 
 from traits.api import Module, Type, Str, observe
 
-from .enum_editor import EnumEditor as EditorFactory
+from .enum_editor import EnumEditor
 
 
-class ImageEnumEditor(EditorFactory):
+class ImageEnumEditor(EnumEditor):
     """ Editor factory for image enumeration editors.
     """
 

--- a/traitsui/editors/instance_editor.py
+++ b/traitsui/editors/instance_editor.py
@@ -22,12 +22,8 @@ from ..instance_choice import InstanceChoice, InstanceChoiceItem
 
 from ..editor_factory import EditorFactory
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class InstanceEditor(EditorFactory):
     """ Editor factory for instance editors.
     """
 
@@ -96,5 +92,5 @@ class ToolkitEditorFactory(EditorFactory):
     )
 
 
-# Define the InstanceEditor class.
-InstanceEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = InstanceEditor

--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -57,12 +57,8 @@ columns_trait = Range(1, 10, 1, desc="the number of list columns to display")
 
 editor_trait = Instance(EditorFactory)
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class ListEditor(EditorFactory):
     """ Editor factory for list editors.
     """
 
@@ -211,5 +207,5 @@ class ListItemProxy(HasTraits):
             self.list[self.index] = new_value
 
 
-# Define the ListEditor class
-ListEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = ListEditor

--- a/traitsui/editors/progress_editor.py
+++ b/traitsui/editors/progress_editor.py
@@ -16,7 +16,7 @@ from traits.api import Int, Bool, Str
 from ..editor_factory import EditorFactory
 
 
-class ToolkitEditorFactory(EditorFactory):
+class ProgressEditor(EditorFactory):
     """ Editor factory for code editors.
     """
 
@@ -55,5 +55,5 @@ class ToolkitEditorFactory(EditorFactory):
     show_percent = Bool(False)
 
 
-# Define the Code Editor class.
-ProgressEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = ProgressEditor

--- a/traitsui/editors/range_editor.py
+++ b/traitsui/editors/range_editor.py
@@ -34,12 +34,8 @@ from ..editor_factory import EditorFactory
 
 from ..toolkit import toolkit_object
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class RangeEditor(EditorFactory):
     """ Editor factory for range editors.
     """
 
@@ -293,5 +289,5 @@ class ToolkitEditorFactory(EditorFactory):
         return super().custom_editor(ui, object, name, description, parent)
 
 
-# Define the RangeEditor class
-RangeEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = RangeEditor

--- a/traitsui/editors/set_editor.py
+++ b/traitsui/editors/set_editor.py
@@ -15,12 +15,8 @@ from ..editor_factory import EditorWithListFactory
 
 from traits.api import Bool, Str
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorWithListFactory):
+class SetEditor(EditorWithListFactory):
     """ Editor factory for editors for sets.
     """
 
@@ -41,5 +37,5 @@ class ToolkitEditorFactory(EditorWithListFactory):
     right_column_title = Str()
 
 
-# Define the SetEditor class
-SetEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = SetEditor

--- a/traitsui/editors/shell_editor.py
+++ b/traitsui/editors/shell_editor.py
@@ -172,10 +172,8 @@ class _ShellEditor(Editor):
         self._shell.execute_command(command, hidden=False)
 
 
-# Editor factory for shell editors.
-
-
-class ToolkitEditorFactory(BasicEditorFactory):
+class ShellEditor(BasicEditorFactory):
+    """ Editor factory for shell editors. """
 
     #: The editor class to be instantiated.
     klass = Property()
@@ -197,5 +195,5 @@ class ToolkitEditorFactory(BasicEditorFactory):
         return toolkit_object("shell_editor:_ShellEditor")
 
 
-# Define the ShellEditor
-ShellEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = ShellEditor

--- a/traitsui/editors/styled_date_editor.py
+++ b/traitsui/editors/styled_date_editor.py
@@ -12,7 +12,7 @@ from traits.api import Bool, List, Str
 from .date_editor import DateEditor
 
 
-class ToolkitEditorFactory(DateEditor):
+class StyledDateEditor(DateEditor):
     """ A DateEditor that can show sets of dates in different styles.
     """
 
@@ -37,4 +37,5 @@ class ToolkitEditorFactory(DateEditor):
     relative_dates = List()
 
 
-StyledDateEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = StyledDateEditor

--- a/traitsui/editors/table_editor.py
+++ b/traitsui/editors/table_editor.py
@@ -51,7 +51,7 @@ customize_filter = TableFilter(name="Customize...")
 BoolOrCallable = Trait(False, Bool, Callable)
 
 
-class ToolkitEditorFactory(EditorFactory):
+class TableEditor(EditorFactory):
     """ Editor factory for table editors.
     """
 
@@ -416,8 +416,8 @@ class ToolkitEditorFactory(EditorFactory):
             self._filter_editor.values = values
 
 
-# Define the TableEditor class
-TableEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = TableEditor
 
 # -------------------------------------------------------------------------
 #  Base class for toolkit-specific editors

--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -47,12 +47,8 @@ mapping_trait = Dict(Str, Any)
 #: Function used to evaluate textual user input
 evaluate_trait = Any(_Identity())
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class TextEditor(EditorFactory):
     """ Editor factory for text editors.
     """
 
@@ -118,5 +114,5 @@ class ToolkitEditorFactory(EditorFactory):
     extras = Group("password{Is this a password field?}")
 
 
-# Define the TextEditor class.
-TextEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = TextEditor

--- a/traitsui/editors/title_editor.py
+++ b/traitsui/editors/title_editor.py
@@ -16,7 +16,7 @@ from ..editor_factory import EditorFactory
 from ..toolkit import toolkit_object
 
 
-class ToolkitEditorFactory(EditorFactory):
+class TitleEditor(EditorFactory):
     """ Editor factory for Title editors.
     """
 
@@ -34,7 +34,5 @@ class ToolkitEditorFactory(EditorFactory):
         return SimpleEditor
 
 
-# -------------------------------------------------------------------------
-#  Create the editor factory object:
-# -------------------------------------------------------------------------
-TitleEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = TitleEditor

--- a/traitsui/editors/tree_editor.py
+++ b/traitsui/editors/tree_editor.py
@@ -60,12 +60,7 @@ RenameAction = Action(
 )
 
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
-
-
-class ToolkitEditorFactory(EditorFactory):
+class TreeEditor(EditorFactory):
     """ Editor factory for tree editors.
     """
 
@@ -189,5 +184,5 @@ class ToolkitEditorFactory(EditorFactory):
     word_wrap = Bool(False)
 
 
-#: Define the TreeEditor class.
-TreeEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = TreeEditor

--- a/traitsui/editors/tuple_editor.py
+++ b/traitsui/editors/tuple_editor.py
@@ -37,12 +37,8 @@ from ..editor_factory import EditorFactory
 
 from ..editor import Editor
 
-# -------------------------------------------------------------------------
-#  'ToolkitEditorFactory' class:
-# -------------------------------------------------------------------------
 
-
-class ToolkitEditorFactory(EditorFactory):
+class TupleEditor(EditorFactory):
     """ Editor factory for tuple editors.
     """
 
@@ -210,5 +206,5 @@ class TupleStructure(HasTraits):
             )
 
 
-# Define the TupleEditor class.
-TupleEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = TupleEditor

--- a/traitsui/editors/value_editor.py
+++ b/traitsui/editors/value_editor.py
@@ -84,7 +84,7 @@ class _ValueEditor(Editor):
         return self._ui.get_error_controls()
 
 
-class ToolkitEditorFactory(EditorFactory):
+class ValueEditor(EditorFactory):
     """ Editor factory for tree-based value editors.
     """
 
@@ -96,5 +96,5 @@ class ToolkitEditorFactory(EditorFactory):
     auto_open = Int(2)
 
 
-# Define the ValueEditor class.
-ValueEditor = ToolkitEditorFactory
+# This alias is deprecated and will be removed in TraitsUI 8.
+ToolkitEditorFactory = ValueEditor


### PR DESCRIPTION
This PR swaps the editor names with the new alias `ToolkitEditorFactory` e.g. `ArrayEditor` is the class name now and `ToolkitEditorFactory` is now the alias. Note that this PR doesn't address all of the uses of `ToolkitEditorFactory` as the class name. There are all of the trivial changes and i'll open a separate PR to address the non-trivial changes.

addresses a part of #1586 