### PR TITLE
Remove code handling old/outdated versions of wx

### DIFF
--- a/traitsui/tests/editors/test_range_editor_spinner.py
+++ b/traitsui/tests/editors/test_range_editor_spinner.py
@@ -87,42 +87,6 @@ class TestRangeEditorSpinner(BaseTestMixin, unittest.TestCase):
             # if all went well, we should not be here
             self.fail("AttributeError raised")
 
-    @requires_toolkit([ToolkitName.wx])
-    def test_wx_spin_control_editing_does_not_update(self):
-        # Bug: when editing the text part of a spin control box, pressing
-        # the OK button does not update the value of the HasTraits class
-        # on Mac OS X
-
-        # But under wx >= 3.0 this has been resolved
-        import wx
-
-        if wx.VERSION >= (3, 0):
-            return
-
-        num = NumberWithSpinnerEditor()
-        with reraise_exceptions(), create_ui(num) as ui:
-
-            # the following is equivalent to clicking in the text control of
-            # the range editor, enter a number, and clicking ok without
-            # defocusing
-
-            # SpinCtrl object
-            spin = ui.control.FindWindowByName("wxSpinCtrl")
-            spin.SetFocusFromKbd()
-
-            # on Windows, a wxSpinCtrl does not have children, and we cannot do
-            # the more fine-grained testing below
-            if len(spin.GetChildren()) == 0:
-                spin.SetValueString("4")
-            else:
-                # TextCtrl object of the spin control
-                spintxt = spin.FindWindowByName("text")
-                spintxt.SetValue("4")
-
-            # if all went well, the number traits has been updated and its
-            # value is 4
-            self.assertEqual(num.number, 4)
-
     @requires_toolkit([ToolkitName.qt])
     def test_qt_spin_control_editing(self):
         # Behavior: when editing the text part of a spin control box, pressing

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -737,8 +737,6 @@ class SimpleSpinEditor(BaseRangeEditor):
             parent, -1, self.str_value, min=low, max=high, initial=self.value
         )
         parent.Bind(wx.EVT_SPINCTRL, self.update_object, id=self.control.GetId())
-        if wx.VERSION < (3, 0):
-            parent.Bind(wx.EVT_TEXT, self.update_object, id=self.control.GetId())
         self.set_tooltip()
 
     def update_object(self, event):


### PR DESCRIPTION
At the moment, we only support the latest versions of WxPython (4.x) so this PR removes the code which was explicitly handling these old/outdated versions.