### PR TITLE
Move EnumEditor import in table_filter into the methods that need it

### DIFF
--- a/traitsui/table_filter.py
+++ b/traitsui/table_filter.py
@@ -516,8 +516,8 @@ class RuleTableFilter(TableFilter):
     def _get_table_editor(self, names):
         """ Returns a table editor to use for editing the filter.
         """
-        from .api import TableEditor
-        from .editors.api import EnumEditor
+        from traitsui.api import TableEditor
+        from traitsui.editors.api import EnumEditor
 
         return TableEditor(
             columns=generic_table_filter_rule_columns,

--- a/traitsui/table_filter.py
+++ b/traitsui/table_filter.py
@@ -28,7 +28,6 @@ from traits.api import (
 )
 
 from .editor_factory import EditorFactory
-from .editors.api import EnumEditor
 from .group import Group
 from .include import Include
 from .item import Item
@@ -518,6 +517,7 @@ class RuleTableFilter(TableFilter):
         """ Returns a table editor to use for editing the filter.
         """
         from .api import TableEditor
+        from .editors.api import EnumEditor
 
         return TableEditor(
             columns=generic_table_filter_rule_columns,
@@ -603,6 +603,7 @@ class MenuTableFilter(RuleTableFilter):
         """ Returns a table editor to use for editing the filter.
         """
         from .api import TableEditor
+        from .editors.api import EnumEditor
 
         names = self._object.editable_traits()
         name_editor = EnumEditor(values=names)


### PR DESCRIPTION
Importing `EnumEditor` directly from the `traitsui.editors.enum_editor` module isnt enough because the `traitsui.editors.__init__` module imports all of the editors -like the `traitsui.editors.api` module.

So, the best fix for the moment is to simply move the `EnumEditor` into the specific method where the object is needed.

fixes #575 