### PR TITLE
Cleanup imports in "traitsui.editors.*"

### DIFF
--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -15,18 +15,11 @@ import numpy
 
 from traits.api import Bool, HasTraits, Int, Float, Instance, TraitError
 
-from ..editor import Editor
-
-from ..editor_factory import EditorFactory
-
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-from ..view import View
-
-from ..group import Group
-
-from ..item import Item
+from traitsui.editor import Editor
+from traitsui.editor_factory import EditorFactory
+from traitsui.group import Group
+from traitsui.item import Item
+from traitsui.view import View
 
 
 class ArrayEditor(EditorFactory):

--- a/traitsui/editors/boolean_editor.py
+++ b/traitsui/editors/boolean_editor.py
@@ -12,13 +12,8 @@
 """
 from traits.api import Dict, Str, Any
 
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-
-from ..view import View
-
-from .text_editor import TextEditor
+from traitsui.editors.text_editor import TextEditor
+from traitsui.view import View
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/editors/button_editor.py
+++ b/traitsui/editors/button_editor.py
@@ -14,9 +14,9 @@
 from pyface.ui_traits import Image
 from traits.api import Str, Range, Enum, Property, Either
 
-from ..editor_factory import EditorFactory
-from ..ui_traits import AView
-from ..view import View
+from traitsui.editor_factory import EditorFactory
+from traitsui.ui_traits import AView
+from traitsui.view import View
 
 
 class ButtonEditor(EditorFactory):

--- a/traitsui/editors/check_list_editor.py
+++ b/traitsui/editors/check_list_editor.py
@@ -29,7 +29,7 @@ toolkit backends.
 
 from traits.api import Range
 
-from ..editor_factory import EditorWithListFactory
+from traitsui.editor_factory import EditorWithListFactory
 
 
 class CheckListEditor(EditorWithListFactory):

--- a/traitsui/editors/code_editor.py
+++ b/traitsui/editors/code_editor.py
@@ -14,8 +14,8 @@ useful for tools such as debuggers.
 
 from traits.api import Instance, Str, Enum, Bool
 
-from ..editor_factory import EditorFactory
-from ..toolkit_traits import Color
+from traitsui.editor_factory import EditorFactory
+from traitsui.toolkit_traits import Color
 
 
 class CodeEditor(EditorFactory):

--- a/traitsui/editors/color_editor.py
+++ b/traitsui/editors/color_editor.py
@@ -13,14 +13,9 @@
 
 from traits.api import Bool
 
-from ..toolkit import toolkit_object
-
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-from ..view import View
-
-from ..editor_factory import EditorFactory
+from traitsui.editor_factory import EditorFactory
+from traitsui.toolkit import toolkit_object
+from traitsui.view import View
 
 # -------------------------------------------------------------------------
 #  'ToolkitEditorFactory' class:

--- a/traitsui/editors/compound_editor.py
+++ b/traitsui/editors/compound_editor.py
@@ -13,7 +13,7 @@
 
 from traits.api import Bool, List
 
-from ..editor_factory import EditorFactory
+from traitsui.editor_factory import EditorFactory
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/editors/csv_list_editor.py
+++ b/traitsui/editors/csv_list_editor.py
@@ -18,8 +18,8 @@ It allows the user to edit the list in a text field, using commas
 from traits.api import Str, Int, Float, Enum, Range, Bool, TraitError, Either
 from traits.trait_handlers import RangeTypes
 
-from .text_editor import TextEditor
-from ..helper import enum_values_changed
+from traitsui.editors.text_editor import TextEditor
+from traitsui.helper import enum_values_changed
 
 
 def _eval_list_str(s, sep=",", item_eval=None, ignore_trailing_sep=True):

--- a/traitsui/editors/custom_editor.py
+++ b/traitsui/editors/custom_editor.py
@@ -13,9 +13,8 @@
 
 from traits.api import Callable, Tuple, Property
 
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 
 class CustomEditor(BasicEditorFactory):

--- a/traitsui/editors/date_editor.py
+++ b/traitsui/editors/date_editor.py
@@ -12,8 +12,9 @@
 """
 
 from traits.trait_types import Bool, Instance, Int, Enum, Str
-from ..ui_traits import AView
-from ..editor_factory import EditorFactory
+
+from traitsui.editor_factory import EditorFactory
+from traitsui.ui_traits import AView
 
 
 class CellFormat(object):

--- a/traitsui/editors/date_range_editor.py
+++ b/traitsui/editors/date_range_editor.py
@@ -9,7 +9,8 @@
 # Thanks for using Enthought open source!
 
 from traits.api import Bool, Constant
-from .date_editor import DateEditor
+
+from traitsui.editors.date_editor import DateEditor
 
 
 class DateRangeEditor(DateEditor):

--- a/traitsui/editors/datetime_editor.py
+++ b/traitsui/editors/datetime_editor.py
@@ -15,7 +15,7 @@ import datetime
 
 from traits.api import Datetime, Str
 
-from ..editor_factory import EditorFactory
+from traitsui.editor_factory import EditorFactory
 
 
 class DatetimeEditor(EditorFactory):

--- a/traitsui/editors/default_override.py
+++ b/traitsui/editors/default_override.py
@@ -24,7 +24,8 @@ View(Item('my_range', editor=DefaultOverride(high_label='Max'))
 """
 
 from traits.api import Dict
-from ..editor_factory import EditorFactory
+
+from traitsui.editor_factory import EditorFactory
 
 
 class DefaultOverride(EditorFactory):

--- a/traitsui/editors/directory_editor.py
+++ b/traitsui/editors/directory_editor.py
@@ -11,7 +11,7 @@
 """ Defines the directory editor factory for all traits toolkit backends.
 """
 
-from .file_editor import FileEditor
+from traitsui.editors.file_editor import FileEditor
 
 
 class DirectoryEditor(FileEditor):

--- a/traitsui/editors/dnd_editor.py
+++ b/traitsui/editors/dnd_editor.py
@@ -16,7 +16,7 @@
 
 from pyface.ui_traits import Image
 
-from ..editor_factory import EditorFactory
+from traitsui.editor_factory import EditorFactory
 
 
 class DNDEditor(EditorFactory):

--- a/traitsui/editors/drop_editor.py
+++ b/traitsui/editors/drop_editor.py
@@ -15,7 +15,7 @@
 
 from traits.api import Any, Bool
 
-from .text_editor import TextEditor
+from traitsui.editors.text_editor import TextEditor
 
 
 class DropEditor(TextEditor):

--- a/traitsui/editors/enum_editor.py
+++ b/traitsui/editors/enum_editor.py
@@ -15,11 +15,10 @@ traits user interface toolkits.
 import os
 import sys
 
-from ..editor_factory import EditorWithListFactory
-
 from traits.api import Any, Range, Enum, Bool
 
-from ..toolkit import toolkit_object
+from traitsui.editor_factory import EditorWithListFactory
+from traitsui.toolkit import toolkit_object
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/editors/file_editor.py
+++ b/traitsui/editors/file_editor.py
@@ -13,14 +13,9 @@
 
 from traits.api import Bool, File, Int, List, Str
 
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-from ..view import View
-
-from ..group import Group
-
-from .text_editor import TextEditor
+from traitsui.editors.text_editor import TextEditor
+from traitsui.group import Group
+from traitsui.view import View
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/editors/font_editor.py
+++ b/traitsui/editors/font_editor.py
@@ -11,9 +11,8 @@
 """ Defines the font editor factory for all traits user interface toolkits.
 """
 
-from ..editor_factory import EditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.editor_factory import EditorFactory
+from traitsui.toolkit import toolkit_object
 
 # -------------------------------------------------------------------------
 #  'ToolkitEditorFactory' class:

--- a/traitsui/editors/history_editor.py
+++ b/traitsui/editors/history_editor.py
@@ -14,9 +14,8 @@
 
 from traits.api import Int, Bool
 
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 # Define callable which returns the 'klass' value (i.e. the editor to use in
 # the EditorFactory.

--- a/traitsui/editors/html_editor.py
+++ b/traitsui/editors/html_editor.py
@@ -14,9 +14,8 @@
 
 from traits.api import Bool, Str
 
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 # Callable that returns the editor to use in the UI.
 

--- a/traitsui/editors/image_editor.py
+++ b/traitsui/editors/image_editor.py
@@ -14,9 +14,8 @@
 from pyface.ui_traits import Image
 from traits.api import Bool, Property
 
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 # -------------------------------------------------------------------------
 #  'ImageEditor' editor factory class:

--- a/traitsui/editors/image_enum_editor.py
+++ b/traitsui/editors/image_enum_editor.py
@@ -12,15 +12,13 @@
 toolkits.
 """
 
-import sys
-
 from os import getcwd
-
 from os.path import join, dirname, exists
+import sys
 
 from traits.api import Module, Type, Str, observe
 
-from .enum_editor import EnumEditor
+from traitsui.editors.enum_editor import EnumEditor
 
 
 class ImageEnumEditor(EnumEditor):

--- a/traitsui/editors/instance_editor.py
+++ b/traitsui/editors/instance_editor.py
@@ -14,13 +14,10 @@ toolkits.
 
 from traits.api import Bool, Enum, List, Str, Type
 
-from ..view import View, AKind
-
-from ..ui_traits import AView
-
-from ..instance_choice import InstanceChoice, InstanceChoiceItem
-
-from ..editor_factory import EditorFactory
+from traitsui.editor_factory import EditorFactory
+from traitsui.instance_choice import InstanceChoice, InstanceChoiceItem
+from traitsui.ui_traits import AView
+from traitsui.view import View, AKind
 
 
 class InstanceEditor(EditorFactory):

--- a/traitsui/editors/key_binding_editor.py
+++ b/traitsui/editors/key_binding_editor.py
@@ -13,10 +13,8 @@ specialized editor used to associate a particular key with a control (i.e., the
 key binding editor).
 """
 
-# FIXME: Import from the api.py file when it has been added.
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 # Callable which returns the editor to use in the ui.
 

--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -26,21 +26,12 @@ from traits.api import (
     PrototypedFrom,
 )
 
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-from ..view import View
-
-from ..item import Item
-
-from ..ui_traits import style_trait, AView
-
-from ..editor_factory import EditorFactory
-
-from ..toolkit import toolkit_object
-
-# Currently, this traits is used only for the wx backend.
-from ..helper import DockStyle
+from traitsui.editor_factory import EditorFactory
+from traitsui.helper import DockStyle
+from traitsui.item import Item
+from traitsui.toolkit import toolkit_object
+from traitsui.ui_traits import style_trait, AView
+from traitsui.view import View
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/editors/list_str_editor.py
+++ b/traitsui/editors/list_str_editor.py
@@ -11,13 +11,11 @@
 """ Traits UI editor factory for editing lists of strings.
 """
 
+from pyface.image_resource import ImageResource
 from traits.api import Any, Str, Enum, List, Bool, Instance, Property
 
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
-
-from pyface.image_resource import ImageResource
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 # -------------------------------------------------------------------------
 #  'ListStrEditor' editor factory class:

--- a/traitsui/editors/null_editor.py
+++ b/traitsui/editors/null_editor.py
@@ -11,9 +11,8 @@
 """ Defines a completely empty editor, intended to be used as a spacer.
 """
 
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 # Callable which returns the editor to use in the ui.
 

--- a/traitsui/editors/popup_editor.py
+++ b/traitsui/editors/popup_editor.py
@@ -10,21 +10,14 @@
 
 from traits.api import Float, Enum, Any, Property
 
-from ..view import View
-
-from ..item import Item
-
-from ..editor_factory import EditorFactory
-
-from ..basic_editor_factory import BasicEditorFactory
-
-from .text_editor import TextEditor
-
-from ..ui_traits import EditorStyle
-
-from ..ui_editor import UIEditor
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.editor_factory import EditorFactory
+from traitsui.editors.text_editor import TextEditor
+from traitsui.item import Item
+from traitsui.toolkit import toolkit_object
+from traitsui.ui_editor import UIEditor
+from traitsui.ui_traits import EditorStyle
+from traitsui.view import View
 
 # -------------------------------------------------------------------------
 #  '_PopupEditor' class:

--- a/traitsui/editors/progress_editor.py
+++ b/traitsui/editors/progress_editor.py
@@ -13,7 +13,7 @@
 
 from traits.api import Int, Bool, Str
 
-from ..editor_factory import EditorFactory
+from traitsui.editor_factory import EditorFactory
 
 
 class ProgressEditor(EditorFactory):

--- a/traitsui/editors/range_editor.py
+++ b/traitsui/editors/range_editor.py
@@ -25,14 +25,10 @@ from traits.api import (
     Undefined,
 )
 
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-from ..view import View
 
-from ..editor_factory import EditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.editor_factory import EditorFactory
+from traitsui.toolkit import toolkit_object
+from traitsui.view import View
 
 
 class RangeEditor(EditorFactory):

--- a/traitsui/editors/rgb_color_editor.py
+++ b/traitsui/editors/rgb_color_editor.py
@@ -13,9 +13,8 @@
     where *red*, *green* and *blue* are floats in the range from 0.0 to 1.0.
 """
 
-from .color_editor import ToolkitEditorFactory as EditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.editors.color_editor import ToolkitEditorFactory as EditorFactory
+from traitsui.toolkit import toolkit_object
 
 # -------------------------------------------------------------------------
 #  'ToolkitEditorFactory' class:

--- a/traitsui/editors/scrubber_editor.py
+++ b/traitsui/editors/scrubber_editor.py
@@ -14,9 +14,9 @@
 from pyface.ui_traits import Alignment
 from traits.api import Float, Property
 
-from ..basic_editor_factory import BasicEditorFactory
-from ..toolkit import toolkit_object
-from ..toolkit_traits import Color
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
+from traitsui.toolkit_traits import Color
 
 # -------------------------------------------------------------------------
 #  Create the editor factory object:

--- a/traitsui/editors/search_editor.py
+++ b/traitsui/editors/search_editor.py
@@ -13,8 +13,9 @@
 """
 
 from traits.api import Bool, Property, Str
-from ..toolkit import toolkit_object
-from ..basic_editor_factory import BasicEditorFactory
+
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 
 class SearchEditor(BasicEditorFactory):

--- a/traitsui/editors/set_editor.py
+++ b/traitsui/editors/set_editor.py
@@ -11,9 +11,9 @@
 """ Defines the set editor factory for all traits user interface toolkits.
 """
 
-from ..editor_factory import EditorWithListFactory
-
 from traits.api import Bool, Str
+
+from traitsui.editor_factory import EditorWithListFactory
 
 
 class SetEditor(EditorWithListFactory):

--- a/traitsui/editors/shell_editor.py
+++ b/traitsui/editors/shell_editor.py
@@ -13,11 +13,9 @@
 
 from traits.api import Bool, Str, Event, Property
 
-from ..editor import Editor
-
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.editor import Editor
+from traitsui.toolkit import toolkit_object
 
 
 class _ShellEditor(Editor):

--- a/traitsui/editors/styled_date_editor.py
+++ b/traitsui/editors/styled_date_editor.py
@@ -9,7 +9,8 @@
 # Thanks for using Enthought open source!
 
 from traits.api import Bool, List, Str
-from .date_editor import DateEditor
+
+from traitsui.editors.date_editor import DateEditor
 
 
 class StyledDateEditor(DateEditor):

--- a/traitsui/editors/table_editor.py
+++ b/traitsui/editors/table_editor.py
@@ -28,16 +28,15 @@ from traits.api import (
     observe,
 )
 
-from ..editor_factory import EditorFactory
-from ..handler import Handler
-from ..helper import Orientation
-from ..item import Item
-from ..table_filter import TableFilter
-from ..toolkit_traits import Color, Font
-from ..ui_traits import AView
-from ..view import View
-from .enum_editor import EnumEditor
-
+from traitsui.editor_factory import EditorFactory
+from traitsui.editors.enum_editor import EnumEditor
+from traitsui.handler import Handler
+from traitsui.helper import Orientation
+from traitsui.item import Item
+from traitsui.table_filter import TableFilter
+from traitsui.toolkit_traits import Color, Font
+from traitsui.ui_traits import AView
+from traitsui.view import View
 
 # The filter used to indicate that the user wants to customize the current
 # filter

--- a/traitsui/editors/tabular_editor.py
+++ b/traitsui/editors/tabular_editor.py
@@ -17,9 +17,8 @@ import warnings
 from pyface.ui_traits import Image
 from traits.api import Str, Bool, Property, List, Enum, Instance
 
-from ..basic_editor_factory import BasicEditorFactory
-
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 
 class TabularEditor(BasicEditorFactory):

--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -13,16 +13,10 @@
 
 from traits.api import Dict, Str, Any, Bool
 
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-from ..view import View
-
-from ..group import Group
-
-from ..ui_traits import AView
-
-from ..editor_factory import EditorFactory
+from traitsui.editor_factory import EditorFactory
+from traitsui.group import Group
+from traitsui.ui_traits import AView
+from traitsui.view import View
 
 # -------------------------------------------------------------------------
 #  Define a simple identity mapping:

--- a/traitsui/editors/time_editor.py
+++ b/traitsui/editors/time_editor.py
@@ -12,8 +12,9 @@
 """
 
 from traits.api import Str
-from ..editor_factory import EditorFactory
-from ..ui_traits import AView
+
+from traitsui.editor_factory import EditorFactory
+from traitsui.ui_traits import AView
 
 
 class TimeEditor(EditorFactory):

--- a/traitsui/editors/title_editor.py
+++ b/traitsui/editors/title_editor.py
@@ -12,8 +12,9 @@
 """
 
 from traits.api import Bool
-from ..editor_factory import EditorFactory
-from ..toolkit import toolkit_object
+
+from traitsui.editor_factory import EditorFactory
+from traitsui.toolkit import toolkit_object
 
 
 class TitleEditor(EditorFactory):

--- a/traitsui/editors/tree_editor.py
+++ b/traitsui/editors/tree_editor.py
@@ -13,11 +13,11 @@
 
 from traits.api import Any, Dict, Bool, Tuple, Int, List, Instance, Str, Enum
 
-from ..menu import Action
-from ..tree_node import TreeNode
-from ..dock_window_theme import DockWindowTheme
-from ..editor_factory import EditorFactory
-from ..helper import Orientation
+from traitsui.dock_window_theme import DockWindowTheme
+from traitsui.editor_factory import EditorFactory
+from traitsui.helper import Orientation
+from traitsui.menu import Action
+from traitsui.tree_node import TreeNode
 
 # -------------------------------------------------------------------------
 #  Trait definitions:

--- a/traitsui/editors/tuple_editor.py
+++ b/traitsui/editors/tuple_editor.py
@@ -11,8 +11,6 @@
 """ Defines the tuple editor factory for all traits user interface toolkits.
 """
 
-from traits.trait_base import SequenceTypes
-
 from traits.api import (
     BaseTuple,
     Bool,
@@ -23,19 +21,13 @@ from traits.api import (
     Any,
     TraitType,
 )
+from traits.trait_base import SequenceTypes
 
-# CIRCULAR IMPORT FIXME: Importing from the source rather than traits.ui.api
-# to avoid circular imports, as this EditorFactory will be part of
-# traits.ui.api as well.
-from ..view import View
-
-from ..group import Group
-
-from ..item import Item
-
-from ..editor_factory import EditorFactory
-
-from ..editor import Editor
+from traitsui.editor import Editor
+from traitsui.editor_factory import EditorFactory
+from traitsui.group import Group
+from traitsui.item import Item
+from traitsui.view import View
 
 
 class TupleEditor(EditorFactory):

--- a/traitsui/editors/value_editor.py
+++ b/traitsui/editors/value_editor.py
@@ -13,15 +13,12 @@
 
 from traits.api import Bool, Instance, Int
 
-from .tree_editor import TreeEditor
-from ..view import View
-from ..item import Item
-
-from ..value_tree import RootNode, value_tree_nodes
-
-from ..editor_factory import EditorFactory
-
-from ..editor import Editor
+from traitsui.editor import Editor
+from traitsui.editor_factory import EditorFactory
+from traitsui.editors.tree_editor import TreeEditor
+from traitsui.item import Item
+from traitsui.value_tree import RootNode, value_tree_nodes
+from traitsui.view import View
 
 # -------------------------------------------------------------------------
 #  'SimpleEditor' class:

--- a/traitsui/editors/video_editor.py
+++ b/traitsui/editors/video_editor.py
@@ -12,8 +12,8 @@
 
 from traits.api import Enum, Property, Str
 
-from ..basic_editor_factory import BasicEditorFactory
-from ..toolkit import toolkit_object
+from traitsui.basic_editor_factory import BasicEditorFactory
+from traitsui.toolkit import toolkit_object
 
 AspectRatio = Enum('keep', 'ignore', 'expand')
 PlayerState = Enum('stopped', 'playing', 'paused')


### PR DESCRIPTION
There were a number of FIXMEs in the imports in `traitsui.editors.*` which this PR addresses and cleans up - converting them into explicit imports instead of implicit imports.