### PR TITLE
revert on_trait_change to observe changes in shell editor

### DIFF
--- a/traitsui/editors/shell_editor.py
+++ b/traitsui/editors/shell_editor.py
@@ -55,11 +55,11 @@ class _ShellEditor(Editor):
         if locals is None:
             object = self.object
             shell.bind("self", object)
-            shell.observe(
+            shell.on_trait_change(
                 self.update_object, "command_executed", dispatch="ui"
             )
             if not isinstance(value, dict):
-                object.observe(self.update_any, dispatch="ui")
+                object.on_trait_change(self.update_any, dispatch="ui")
             else:
                 self._base_locals = locals = {}
                 for name in self._shell.interpreter().locals.keys():
@@ -119,24 +119,24 @@ class _ShellEditor(Editor):
                 for name, value in dic.items():
                     locals[name] = value
 
-    def update_any(self, event):
+    def update_any(self, object, name, old, new):
         """ Updates the editor when the object trait changes externally to the
             editor.
         """
         locals = self._shell.interpreter().locals
         if self._base_locals is None:
-            locals[event.name] = event.new
+            locals[name] = new
         else:
-            self.value[event.name] = event.new
+            self.value[name] = new
 
     def dispose(self):
         """ Disposes of the contents of an editor.
         """
-        self._shell.observe(
-            self.update_object, "command_executed", remove=True, dispatch="ui"
+        self._shell.on_trait_change(
+            self.update_object, "command_executed", remove=True
         )
         if self._base_locals is None:
-            self.object.observe(self.update_any, remove=True, dispatch="ui")
+            self.object.on_trait_change(self.update_any, remove=True)
 
         super().dispose()
 


### PR DESCRIPTION
closes #1612 and closes #1620

This PR simply takes the easy way out of reverting the `on_trait_change` to `observe` changes made to `ShellEditor` in #1523 

I aim to open a separate PR that fixes the use of `observe`.  This PR should be seen as a back up plan to avoid the issues in case there is trouble coming to the real solution and we don't want to hold up the release.
Note the migration from `on_trait_change` is not yet complete and won't be by the upcoming release, so it is not as though this will be the only use of `on_trait_change` in the codebase if this PR does get merged.  

In any case I plan to try to actually fix the issue in a separate PR in which case this can simply be closed.