### PR TITLE
User facing docs for VideoEditor

### DIFF
--- a/docs/source/demos/index.rst
+++ b/docs/source/demos/index.rst
@@ -37,6 +37,7 @@ Standard Editors
 - :github-demo:`TitleEditor <Standard_Editors/TitleEditor_demo.py>`
 - :github-demo:`TreeEditor <Standard_Editors/TreeEditor_demo.py>`
 - :github-demo:`TupleEditor <Standard_Editors/TupleEditor_demo.py>`
+- :github-demo:`VideoEditor <Standard_Editors/VideoEditor_demo.py>`
 
 Advanced Demos
 --------------

--- a/docs/source/traitsui_user_manual/factories_advanced_extra.rst
+++ b/docs/source/traitsui_user_manual/factories_advanced_extra.rst
@@ -1311,6 +1311,9 @@ for a demo.
     See the `Qt Multimedia Backends Wiki <https://wiki.qt.io/Qt_5.13_Multimedia_Backends>`_
     page for full information.
 
+.. note:: The VideoEditor is new and still under active development. As such,
+    the API of the editor might change in future releases.
+
 .. _extra-trait-editor-factories:
 
 "Extra" Trait Editor Factories

--- a/docs/source/traitsui_user_manual/factories_advanced_extra.rst
+++ b/docs/source/traitsui_user_manual/factories_advanced_extra.rst
@@ -1295,9 +1295,10 @@ for a demo.
 .. note:: Depending on your operating system, you might have to install
     external codecs to get the VideoEditor working.
 
-    On Windows, you will need to install the
-    `K-Lite Codec Pack<https://codecguide.com/about_kl.htm>` if you are using EDM
-    to install Qt5. This is because the EDM build of Qt5 is built to use
+    On Windows, you will need to install DirectShow filters (such as those
+    available in the K-Lite Codec Pack) in order to play most video formats
+    when using EDM to install Qt5. This is because the EDM build of Qt5 is
+    built to use
     `DirectShow <https://docs.microsoft.com/en-us/windows/win32/directshow/supported-formats-in-directshow>`_,
     not `WMF <https://docs.microsoft.com/en-us/windows/win32/medfound/supported-media-formats-in-media-foundation>`_.
 

--- a/docs/source/traitsui_user_manual/factories_advanced_extra.rst
+++ b/docs/source/traitsui_user_manual/factories_advanced_extra.rst
@@ -1285,6 +1285,30 @@ For example, the default editor for Range(low=0, high=1500) has
 
     View(Item('my_range', editor=DefaultOverride(high_label='Max'))
 
+VideoEditor()
+`````````````
+
+VideoEditor() is a display-only video editor. Note that this editor is only
+available on Qt at the moment. Please see :ref:`TraitsUI Demos <traitsui-demo>`
+for a demo.
+
+.. note:: Depending on your operating system, you might have to install
+    external codecs to get the VideoEditor working.
+
+    On Windows, you will need to install the
+    `K-Lite Codec Pack<https://codecguide.com/about_kl.htm>` if you are using EDM
+    to install Qt5. This is because the EDM build of Qt5 is built to use
+    `DirectShow <https://docs.microsoft.com/en-us/windows/win32/directshow/supported-formats-in-directshow>`_,
+    not `WMF <https://docs.microsoft.com/en-us/windows/win32/medfound/supported-media-formats-in-media-foundation>`_.
+
+    On MacOS, the video editor will work as expected as long as the video format
+    is `supported <https://developer.apple.com/documentation/coremedia/1564239-video_codec_constants?language=objc>`_
+    by the `AVFoundation <https://developer.apple.com/av-foundation/>`_.
+
+    On Linux, `GStreamer <https://gstreamer.freedesktop.org/>`_ needs to be installed.
+
+    See the `Qt Multimedia Backends Wiki <https://wiki.qt.io/Qt_5.13_Multimedia_Backends>`_
+    page for full information.
 
 .. _extra-trait-editor-factories:
 

--- a/traitsui/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -9,10 +9,11 @@
 # Thanks for using Enthought open source!
 
 """
-VideoEditor
+Demonstrates a 'display only' video editor for Qt5+.
 
-Demonstrates a 'display only' video editor for Qt5+
+Please refer to the `VideoEditor API docs`_ for further information.
 
+.. _VideoEditor API docs: https://docs.enthought.com/traitsui/api/traitsui.editors.video_editor.html#traitsui.editors.video_editor.VideoEditor
 """
 import numpy as np
 from PIL import Image


### PR DESCRIPTION
This PR adds a small new "VideoEditor" section in the advanced factories page of the traitsui user docs. The section links to the traitsui demos page and the demo page has been updated to link to the new video editor demo

The video editor section includes a rather large note containing information regarding platform support for the video editor and what codecs need to be installed to get things working. Note that this advice was extracted from https://github.com/enthought/traitsui/pull/745#issuecomment-821088282. Thanks @mdsmarte for putting together this information.

fixes #1629