### PR TITLE
use UI Tester for all tests in test_html_editor.py

### DIFF
--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -15,10 +15,8 @@ from traits.api import HasTraits, Str
 from traitsui.api import HTMLEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
-    create_ui,
     is_qt,
     requires_toolkit,
-    reraise_exceptions,
     ToolkitName,
 )
 from traitsui.testing.api import MouseClick, TargetRegistry, UITester

--- a/traitsui/tests/editors/test_html_editor.py
+++ b/traitsui/tests/editors/test_html_editor.py
@@ -239,8 +239,7 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
         # Smoke test to check init and dispose do not fail.
         model = HTMLModel()
         view = get_view(base_url_name="")
-        with reraise_exceptions(), \
-                create_ui(model, dict(view=view)):
+        with self.tester.create_ui(model, dict(view=view)):
             pass
 
     def test_base_url_changed(self):
@@ -248,11 +247,10 @@ class TestHTMLEditor(BaseTestMixin, unittest.TestCase):
         # fails because sync_value is unhooked in the base class.
         model = HTMLModel()
         view = get_view(base_url_name="model_base_url")
-        with reraise_exceptions():
-            with create_ui(model, dict(view=view)):
-                pass
-            # It is okay to modify base_url after the UI is closed
-            model.model_base_url = "/new_dir"
+        with self.tester.create_ui(model, dict(view=view)):
+            pass
+        # It is okay to modify base_url after the UI is closed
+        model.model_base_url = "/new_dir"
 
     @requires_toolkit([ToolkitName.qt])
     def test_open_internal_link(self):


### PR DESCRIPTION
#1551 

Has been coming up more frequently it seems lately.  This PR will not change that, but seeing the failure made me notice we were not using UI Tester on the failing test, and instead were using the old `create_ui` function which now just goes through UITester itself anyway.  This PR updates two tests to use `UITester.create_ui` instead