### PR TITLE
[WIP] Add default factory callable

### DIFF
--- a/traitsui/editors/list_editor.py
+++ b/traitsui/editors/list_editor.py
@@ -99,6 +99,10 @@ class ToolkitEditorFactory(EditorFactory):
     #: Show a right-click context menu for the notebook tabs?  (Qt only)
     show_notebook_menu = Bool(False)
 
+    #: Factory callable that will be called to create the new element to add to
+    #: this list.  If None, the default value for the trait of interest is used.
+    default_factory = Callable()
+
     # -- Notebook Specific Traits ---------------------------------------------
 
     #: Are notebook items deletable?

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -28,7 +28,7 @@ from pyface.qt import QtCore, QtGui
 
 from pyface.api import ImageResource
 
-from traits.api import Str, Any, Bool, Dict, Instance, List
+from traits.api import Str, Any, Bool, Dict, Instance, List, TraitError
 from traits.trait_base import user_name_for, xgetattr
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward
@@ -311,7 +311,12 @@ class SimpleEditor(Editor):
         index += offset
         item_trait = self._trait_handler.item_trait
         value = item_trait.default_value_for(self.object, self.name)
-        self.value = list[:index] + [value] + list[index:]
+        try:
+            self.value = list[:index] + [value] + list[index:]
+        # if the default new item is invalid, we just don't add it to the list.
+        # traits will still give an error message, but we don't want to crash
+        except TraitError:
+            pass
         self.update_editor()
 
     def add_before(self):

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -316,7 +316,8 @@ class SimpleEditor(Editor):
         # if the default new item is invalid, we just don't add it to the list.
         # traits will still give an error message, but we don't want to crash
         except TraitError:
-            pass
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
         self.update_editor()
 
     def add_before(self):

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -54,10 +54,6 @@ class SimpleEditor(Editor):
     #  Trait definitions:
     # -------------------------------------------------------------------------
 
-    #: Factory callable that will be called to create the new element to add to
-    #: this list.  If None, the default value for the trait of interest is used.
-    default_factory = Callable()
-
     #: The kind of editor to create for each list item
     kind = Str()
 
@@ -316,8 +312,8 @@ class SimpleEditor(Editor):
         list, index = self.get_info()
         index += offset
         item_trait = self._trait_handler.item_trait
-        if self.default_factory:
-            value = self.default_factory()
+        if self.factory.default_factory:
+            value = self.factory.default_factory()
         else:
             value = item_trait.default_value_for(self.object, self.name)
         try:

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -52,6 +52,10 @@ class SimpleEditor(Editor):
     #  Trait definitions:
     # -------------------------------------------------------------------------
 
+    #: Factory callable that will be called to create the new element to add to
+    #: this list.  If None, the default value for the trait of interest is used.
+    default_factory = Callable()
+
     #: The kind of editor to create for each list item
     kind = Str()
 
@@ -310,7 +314,10 @@ class SimpleEditor(Editor):
         list, index = self.get_info()
         index += offset
         item_trait = self._trait_handler.item_trait
-        value = item_trait.default_value_for(self.object, self.name)
+        if self.default_factory:
+            value = self.default_factory()
+        else:
+            value = item_trait.default_value_for(self.object, self.name)
         try:
             self.value = list[:index] + [value] + list[index:]
         # if the default new item is invalid, we just don't add it to the list.

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -28,7 +28,9 @@ from pyface.qt import QtCore, QtGui
 
 from pyface.api import ImageResource
 
-from traits.api import Str, Any, Bool, Dict, Instance, List, TraitError
+from traits.api import (
+    Any, Bool, Callable, Dict, Instance, List, Str, TraitError
+)
 from traits.trait_base import user_name_for, xgetattr
 
 # FIXME: ToolkitEditorFactory is a proxy class defined here just for backward

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -7,7 +7,8 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-
+import shutil
+import tempfile
 import unittest
 
 from pyface.toolkit import toolkit_object
@@ -205,6 +206,32 @@ class TestSimpleListEditor(unittest.TestCase):
             self.assertTrue(mdtester.result)
 
             self.assertEqual(len(obj.dirs), 0)
+
+    def test_default_factory(self):
+        temp_dir = tempfile.mkdtemp()
+
+        def test_callable():    
+            return temp_dir
+
+        class Foo(HasStrictTraits):
+            dirs = List(Directory(exists=True))
+            view = View(
+                Item(
+                    "dirs",
+                    editor=ListEditor(default_factory=test_callable)
+                )
+            )
+
+        obj = Foo()
+        tester = UITester()
+        with tester.create_ui(obj) as ui:
+            dirs_list_editor = tester.find_by_name(ui, "dirs")
+            # should not raise error (see above test_add_item_fails)
+            dirs_list_editor._target.add_empty()
+            self.assertEqual(len(obj.dirs), 1)
+
+        shutil.rmtree(temp_dir)
+        
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -11,7 +11,9 @@
 import unittest
 
 from pyface.toolkit import toolkit_object
-from traits.api import Directory, HasStrictTraits, Instance, Int, List, Str
+from traits.api import (
+    Directory, HasStrictTraits, Instance, Int, List, Str, TraitError
+)
 
 from traitsui.api import Item, ListEditor, View
 from traitsui.testing.api import (
@@ -181,7 +183,6 @@ class TestSimpleListEditor(unittest.TestCase):
     @requires_toolkit([ToolkitName.qt])
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_add_item_fails(self):
-        from traits.api import TraitError
 
         class Foo(HasStrictTraits):
             dirs = List(Directory(exists=True))

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -34,7 +34,6 @@ from traitsui.tests._tools import (
 ModalDialogTester = toolkit_object(
     "util.modal_dialog_tester:ModalDialogTester"
 )
-no_modal_dialog_tester = ModalDialogTester.__name__ == "Unimplemented"
 
 
 # 'Person' class:
@@ -181,7 +180,6 @@ class TestSimpleListEditor(unittest.TestCase):
 
     # regression test for enthought/traitsui#1154
     @requires_toolkit([ToolkitName.qt])
-    @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_add_item_fails(self):
 
         class Foo(HasStrictTraits):

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -200,7 +200,7 @@ class TestSimpleListEditor(unittest.TestCase):
 
             mdtester = ModalDialogTester(trigger_error)
             mdtester.open_and_run(lambda x: x.close())
-            # we want an error dialog to open, but don't want to raise a 
+            # we want an error dialog to open, but don't want to raise a
             # TraitError and crash the full application
             self.assertTrue(mdtester.dialog_was_opened)
             self.assertTrue(mdtester.result)

--- a/traitsui/wx/list_editor.py
+++ b/traitsui/wx/list_editor.py
@@ -16,7 +16,8 @@ import wx
 
 import wx.lib.scrolledpanel as wxsp
 
-from traits.api import Str, Any, Instance, Property, Bool, cached_property
+from traits.api import (
+    Any, Bool, cached_property, Instance, Property, Str, TraitError
 from traits.trait_base import user_name_for, xgetattr
 
 from traitsui.ui_traits import Image, convert_bitmap
@@ -343,8 +344,17 @@ class SimpleEditor(Editor):
         list, index = self.get_info()
         index += offset
         item_trait = self._trait_handler.item_trait
-        value = item_trait.default_value_for(self.object, self.name)
-        self.value = list[:index] + [value] + list[index:]
+        if self.factory.default_factory:
+            value = self.factory.default_factory()
+        else:
+            value = item_trait.default_value_for(self.object, self.name)
+        try:
+            self.value = list[:index] + [value] + list[index:]
+        # if the default new item is invalid, we just don't add it to the list.
+        # traits will still give an error message, but we don't want to crash
+        except TraitError:
+            from traitsui.api import raise_to_debug
+            raise_to_debug()
         wx.CallAfter(self.update_editor)
 
     def add_before(self):


### PR DESCRIPTION
follow up PR to #1559 
closes #1627

This PR adds a `default_factory` `Callable` trait on the `ListEditor` factory class.  Then it uses this callable to create a new item in the `add_item` methods of the toolkit specific editors if it was specified.  Otherwise, it defaults back to the old behavior of using the default value for the trait type in the list.