### PR TITLE
skip video editor test without numpy / move numpy import to when it is needed / list numpy as test dependency

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -43,6 +43,7 @@ __extras_require__ = {
     "test": [
         # Dependencies for running test suites.
         "packaging",
+        "numpy"
     ],
 }
 

--- a/traitsui/qt4/video_editor.py
+++ b/traitsui/qt4/video_editor.py
@@ -9,9 +9,6 @@
 # Thanks for using Enthought open source!
 
 """Traits UI 'display only' video editor."""
-
-import numpy as np
-
 from pyface.qt.QtCore import QPoint, Qt, QUrl, Signal
 from pyface.qt.QtGui import QImage, QPainter, QPalette, QSizePolicy
 from pyface.qt.QtMultimedia import (QAbstractVideoBuffer,
@@ -58,6 +55,7 @@ class ImageWidget(QVideoWidget):
     """ Paints a QImage to the window body. """
 
     def __init__(self, parent=None, image_func=None):
+        import numpy as np
         super().__init__(parent)
         self.image = QImage()
         self._np_image = np.zeros(shape=(0, 0, 4))

--- a/traitsui/tests/editors/test_video_editor.py
+++ b/traitsui/tests/editors/test_video_editor.py
@@ -10,7 +10,7 @@
 import unittest
 
 try:
-    import numpy as np
+    import numpy as np  # noqa: F401
 except ImportError:
     raise unittest.SkipTest("Can't import NumPy: skipping")
 import pkg_resources

--- a/traitsui/tests/editors/test_video_editor.py
+++ b/traitsui/tests/editors/test_video_editor.py
@@ -9,6 +9,10 @@
 # Thanks for using Enthought open source!
 import unittest
 
+try:
+    import numpy as np
+except ImportError:
+    raise unittest.SkipTest("Can't import NumPy: skipping")
 import pkg_resources
 
 from traits.api import Bool, Callable, File, Float, HasTraits, Range, Str


### PR DESCRIPTION
closes #1636

This PR does a number of things.  It moves the `import numpy as np` statement from the top of the module to inside the `__init__` method so it is only imported when needed.  It skips the video editor tests when numpy is not installed.  (both of these follow exactly was it done for the `DataFrameEditor`.  

Lastly, I added `numpy` as a test dependency in `extras_require`.  My understanding was that if I do `pip install -e .[test]` I should have all the deps needed to run _every_ test in the test suite