### PR TITLE
Fix Statusbar on Wx

### DIFF
--- a/traitsui/wx/ui_base.py
+++ b/traitsui/wx/ui_base.py
@@ -125,7 +125,7 @@ class BaseDialog(_BasePanel):
 
                 set_text = self._set_status_text(control, i)
                 name = item.name
-                set_text(ui.get_extended_value(name))
+                control.SetStatusText(ui.get_extended_value(name), i)
                 col = name.find(".")
                 object = "object"
                 if col >= 0:


### PR DESCRIPTION
fixes #1642 

We should not have been calling an observed method manually.  Otherwise we would need to pass in a makeshift `Event` object.  Instead we can just do what we want to do directly there by calling a method directly on control