### PR TITLE
explicitly install swig 3.0.12 for cron job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,6 +32,7 @@ jobs:
         # Dependencies include enable, which has known issue with swig 4.0
         # seeenthought/enable#360
         run: sudo apt-get install swig=3.0.12
+        if: startsWith(matrix.os, 'ubuntu')
       - name: Install Python packages and dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,9 +4,9 @@
 
 name: Integration tests
 
-on:
-  schedule:
-    - cron:  '0 0 * * 4'
+on: pull_request
+  #schedule:
+  #  - cron:  '0 0 * * 4'
 
 jobs:
   test:
@@ -28,6 +28,10 @@ jobs:
       - name: Install Qt dependencies for Linux
         uses: ./.github/actions/apt-get-qt-deps
         if: startsWith(matrix.os, 'ubuntu')
+      - name: Install Swig 3.0.12
+        # Dependencies include enable, which has known issue with swig 4.0
+        # seeenthought/enable#360
+        run: sudo apt-get install swig=3.0.12
       - name: Install Python packages and dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
This PR is in response to the failing cron job https://github.com/enthought/traitsui/runs/2514003659?check_suite_focus=true 

I believe failure was a result of https://github.com/enthought/enable/issues/360

This PR explicitly installs swig 3.0.12 before trying to run tests

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)