### PR TITLE
skip a couple wx test failures

### DIFF
--- a/traitsui/tests/editors/test_button_editor.py
+++ b/traitsui/tests/editors/test_button_editor.py
@@ -106,6 +106,8 @@ class TestButtonEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
     def test_simple_button_editor(self):
         self.check_button_text_update(simple_view)
 
+    # this currently fails on wx, see enthought/traitsui#1654
+    @requires_toolkit([ToolkitName.qt])
     def test_custom_button_editor(self):
         self.check_button_text_update(custom_view)
 

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -207,6 +207,8 @@ class TestSimpleListEditor(unittest.TestCase):
 
             self.assertEqual(len(obj.dirs), 0)
 
+    # this test hits a problem on wx, see issue enthought/traitsui#1653
+    @requires_toolkit([ToolkitName.qt])
     def test_default_factory(self):
         temp_dir = tempfile.mkdtemp()
 


### PR DESCRIPTION
This PR simply skips a couple tests that were failing on wx.

See issues #1653 and #1654 

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)