### PR TITLE
Explicitly require traits 6.2 and pyface 7.2

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     __version__ = "not-built"
 
-__requires__ = ["traits>=6.1.0", "pyface>=7.1.0"]
+__requires__ = ["traits>=6.2.0", "pyface>=7.2.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],


### PR DESCRIPTION
This was accidentally missed before the release.  With recent changes `TraitsUI` now rquires newer `Traits` and `Pyface`.

These are a result of using `Property(observe=...)` and `from pyface.undo.api import ...`
**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~