### PR TITLE
require pyface 7.3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,7 +19,7 @@ Highlights of this release
 Notes on upgrading
 ~~~~~~~~~~~~~~~~~~
 
-* This release of TraitsUI now depends on Traits 6.2+ and pyface 7.2+. Also,
+* This release of TraitsUI now depends on Traits 6.2+ and pyface 7.3+. Also,
   deprecated code / modules have been removed. Namely, the
   :mod:`traitsui.image <traitsui.image>` module which was moved to
   ``pyface.image``, ``editors_gen`` modules, Editor and EditorFactory factory

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     __version__ = "not-built"
 
-__requires__ = ["traits>=6.2.0", "pyface>=7.2.0"]
+__requires__ = ["traits>=6.2.0", "pyface>=7.3.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],


### PR DESCRIPTION
With pyface 7.2 there was a consistent test failure.  It appears we actually require pyface 7.3

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~