### PR TITLE
TraitsUI Release 7.2.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Traits UI Changelog
 ===================
 
+Release 7.2.1
+-------------
+TraitsUI 7.2.1 is a bugfix release which updates TraitsUI to explicitly require
+Traits 6.2+ and Pyface 7.3+.
+
+Build and continuous integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Explicitly require traits 6.2 and pyface 7.2 (#1666)
+
 Release 7.2.0
 -------------
 TraitsUI 7.2.0 is a minor release which includes numerous bug fixes,
@@ -101,7 +110,6 @@ Build and continuous integration
 * Drop support for PyQt < 4.3.2 (#1607)
 * Remove CI test against Traits 6.0 (#1637)
 * explicitly install swig 3.0.12 for cron job (#1652)
-* Explicitly require traits 6.2 and pyface 7.2 (#1666)
 
 Test suite
 ~~~~~~~~~~

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ Traits 6.2+ and Pyface 7.3+.
 
 Build and continuous integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* Explicitly require traits 6.2 and pyface 7.2 (#1666)
+* Explicitly require traits 6.2 and pyface 7.3 (#1666, #1668)
 
 Release 7.2.0
 -------------

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ MAJOR = 7
 MINOR = 2
 MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
The commit from this PR will be tagged as the 7.2.1 release.

I will open a separate PR to flip IS_RELEASED to false and bump the version after this one is merged.
**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~