### PR TITLE
Bump release version for the development of 7.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ from io import open
 # into the package source.
 MAJOR = 7
 MINOR = 2
-MICRO = 1
+MICRO = 2
 PRERELEASE = ""
-IS_RELEASED = True
+IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
Targeting `maint/7.2`

This PR bumps the release version and flip the `IS_RELEASED` flag for the development of the next bug fix release.


**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)