### PR TITLE
Update documentation for 7.2.1

### DIFF
--- a/7.2/_modules/index.html
+++ b/7.2/_modules/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/pyface/action/group.html
+++ b/7.2/_modules/pyface/action/group.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/pyface/ui/qt4/action/menu_bar_manager.html
+++ b/7.2/_modules/pyface/ui/qt4/action/menu_bar_manager.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traits/trait_types.html
+++ b/7.2/_modules/traits/trait_types.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/api.html
+++ b/7.2/_modules/traitsui/api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/base_panel.html
+++ b/7.2/_modules/traitsui/base_panel.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/basic_editor_factory.html
+++ b/7.2/_modules/traitsui/basic_editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/color_column.html
+++ b/7.2/_modules/traitsui/color_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/context_value.html
+++ b/7.2/_modules/traitsui/context_value.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/delegating_handler.html
+++ b/7.2/_modules/traitsui/delegating_handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/dock_window_theme.html
+++ b/7.2/_modules/traitsui/dock_window_theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/dockable_view_element.html
+++ b/7.2/_modules/traitsui/dockable_view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editor.html
+++ b/7.2/_modules/traitsui/editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editor_factory.html
+++ b/7.2/_modules/traitsui/editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/array_editor.html
+++ b/7.2/_modules/traitsui/editors/array_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/boolean_editor.html
+++ b/7.2/_modules/traitsui/editors/boolean_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/button_editor.html
+++ b/7.2/_modules/traitsui/editors/button_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/check_list_editor.html
+++ b/7.2/_modules/traitsui/editors/check_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/code_editor.html
+++ b/7.2/_modules/traitsui/editors/code_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/color_editor.html
+++ b/7.2/_modules/traitsui/editors/color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/compound_editor.html
+++ b/7.2/_modules/traitsui/editors/compound_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/csv_list_editor.html
+++ b/7.2/_modules/traitsui/editors/csv_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/custom_editor.html
+++ b/7.2/_modules/traitsui/editors/custom_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/date_editor.html
+++ b/7.2/_modules/traitsui/editors/date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/date_range_editor.html
+++ b/7.2/_modules/traitsui/editors/date_range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/datetime_editor.html
+++ b/7.2/_modules/traitsui/editors/datetime_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/default_override.html
+++ b/7.2/_modules/traitsui/editors/default_override.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/directory_editor.html
+++ b/7.2/_modules/traitsui/editors/directory_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/dnd_editor.html
+++ b/7.2/_modules/traitsui/editors/dnd_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/drop_editor.html
+++ b/7.2/_modules/traitsui/editors/drop_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/enum_editor.html
+++ b/7.2/_modules/traitsui/editors/enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/file_editor.html
+++ b/7.2/_modules/traitsui/editors/file_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/font_editor.html
+++ b/7.2/_modules/traitsui/editors/font_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/history_editor.html
+++ b/7.2/_modules/traitsui/editors/history_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/html_editor.html
+++ b/7.2/_modules/traitsui/editors/html_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/image_editor.html
+++ b/7.2/_modules/traitsui/editors/image_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/image_enum_editor.html
+++ b/7.2/_modules/traitsui/editors/image_enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/instance_editor.html
+++ b/7.2/_modules/traitsui/editors/instance_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/key_binding_editor.html
+++ b/7.2/_modules/traitsui/editors/key_binding_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/list_editor.html
+++ b/7.2/_modules/traitsui/editors/list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/list_str_editor.html
+++ b/7.2/_modules/traitsui/editors/list_str_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/null_editor.html
+++ b/7.2/_modules/traitsui/editors/null_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/popup_editor.html
+++ b/7.2/_modules/traitsui/editors/popup_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/progress_editor.html
+++ b/7.2/_modules/traitsui/editors/progress_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/range_editor.html
+++ b/7.2/_modules/traitsui/editors/range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/rgb_color_editor.html
+++ b/7.2/_modules/traitsui/editors/rgb_color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/scrubber_editor.html
+++ b/7.2/_modules/traitsui/editors/scrubber_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/search_editor.html
+++ b/7.2/_modules/traitsui/editors/search_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/set_editor.html
+++ b/7.2/_modules/traitsui/editors/set_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/shell_editor.html
+++ b/7.2/_modules/traitsui/editors/shell_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/styled_date_editor.html
+++ b/7.2/_modules/traitsui/editors/styled_date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/table_editor.html
+++ b/7.2/_modules/traitsui/editors/table_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/tabular_editor.html
+++ b/7.2/_modules/traitsui/editors/tabular_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/text_editor.html
+++ b/7.2/_modules/traitsui/editors/text_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/time_editor.html
+++ b/7.2/_modules/traitsui/editors/time_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/title_editor.html
+++ b/7.2/_modules/traitsui/editors/title_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/tree_editor.html
+++ b/7.2/_modules/traitsui/editors/tree_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/tuple_editor.html
+++ b/7.2/_modules/traitsui/editors/tuple_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/value_editor.html
+++ b/7.2/_modules/traitsui/editors/value_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/editors/video_editor.html
+++ b/7.2/_modules/traitsui/editors/video_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/extras/checkbox_column.html
+++ b/7.2/_modules/traitsui/extras/checkbox_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/extras/edit_column.html
+++ b/7.2/_modules/traitsui/extras/edit_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/extras/has_dynamic_views.html
+++ b/7.2/_modules/traitsui/extras/has_dynamic_views.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/extras/progress_column.html
+++ b/7.2/_modules/traitsui/extras/progress_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/extras/saving.html
+++ b/7.2/_modules/traitsui/extras/saving.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/file_dialog.html
+++ b/7.2/_modules/traitsui/file_dialog.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/group.html
+++ b/7.2/_modules/traitsui/group.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/handler.html
+++ b/7.2/_modules/traitsui/handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/help.html
+++ b/7.2/_modules/traitsui/help.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/help_template.html
+++ b/7.2/_modules/traitsui/help_template.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/helper.html
+++ b/7.2/_modules/traitsui/helper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/include.html
+++ b/7.2/_modules/traitsui/include.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/instance_choice.html
+++ b/7.2/_modules/traitsui/instance_choice.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/item.html
+++ b/7.2/_modules/traitsui/item.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/key_bindings.html
+++ b/7.2/_modules/traitsui/key_bindings.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/list_str_adapter.html
+++ b/7.2/_modules/traitsui/list_str_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/menu.html
+++ b/7.2/_modules/traitsui/menu.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/message.html
+++ b/7.2/_modules/traitsui/message.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/null/color_trait.html
+++ b/7.2/_modules/traitsui/null/color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/null/font_trait.html
+++ b/7.2/_modules/traitsui/null/font_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/null/rgb_color_trait.html
+++ b/7.2/_modules/traitsui/null/rgb_color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/null/toolkit.html
+++ b/7.2/_modules/traitsui/null/toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/table_column.html
+++ b/7.2/_modules/traitsui/table_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/table_filter.html
+++ b/7.2/_modules/traitsui/table_filter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/tabular_adapter.html
+++ b/7.2/_modules/traitsui/tabular_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/testing/tester/command.html
+++ b/7.2/_modules/traitsui/testing/tester/command.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/testing/tester/exceptions.html
+++ b/7.2/_modules/traitsui/testing/tester/exceptions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/testing/tester/locator.html
+++ b/7.2/_modules/traitsui/testing/tester/locator.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/testing/tester/query.html
+++ b/7.2/_modules/traitsui/testing/tester/query.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/testing/tester/target_registry.html
+++ b/7.2/_modules/traitsui/testing/tester/target_registry.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/testing/tester/ui_tester.html
+++ b/7.2/_modules/traitsui/testing/tester/ui_tester.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/testing/tester/ui_wrapper.html
+++ b/7.2/_modules/traitsui/testing/tester/ui_wrapper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/theme.html
+++ b/7.2/_modules/traitsui/theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/toolkit.html
+++ b/7.2/_modules/traitsui/toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/toolkit_traits.html
+++ b/7.2/_modules/traitsui/toolkit_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/tree_node.html
+++ b/7.2/_modules/traitsui/tree_node.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/tree_node_renderer.html
+++ b/7.2/_modules/traitsui/tree_node_renderer.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/ui.html
+++ b/7.2/_modules/traitsui/ui.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/ui_editor.html
+++ b/7.2/_modules/traitsui/ui_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/ui_editors/array_view_editor.html
+++ b/7.2/_modules/traitsui/ui_editors/array_view_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/ui_editors/data_frame_editor.html
+++ b/7.2/_modules/traitsui/ui_editors/data_frame_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/ui_info.html
+++ b/7.2/_modules/traitsui/ui_info.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/ui_traits.html
+++ b/7.2/_modules/traitsui/ui_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/undo.html
+++ b/7.2/_modules/traitsui/undo.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/value_tree.html
+++ b/7.2/_modules/traitsui/value_tree.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/view.html
+++ b/7.2/_modules/traitsui/view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/view_element.html
+++ b/7.2/_modules/traitsui/view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_modules/traitsui/view_elements.html
+++ b/7.2/_modules/traitsui/view_elements.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/_static/documentation_options.js
+++ b/7.2/_static/documentation_options.js
@@ -1,6 +1,6 @@
 var DOCUMENTATION_OPTIONS = {
     URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
-    VERSION: '7.2.0',
+    VERSION: '7.2.1',
     LANGUAGE: 'None',
     COLLAPSE_INDEX: false,
     BUILDER: 'html',

--- a/7.2/api/index.html
+++ b/7.2/api/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.api.html
+++ b/7.2/api/traitsui.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.base_panel.html
+++ b/7.2/api/traitsui.base_panel.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.basic_editor_factory.html
+++ b/7.2/api/traitsui.basic_editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.color_column.html
+++ b/7.2/api/traitsui.color_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.context_value.html
+++ b/7.2/api/traitsui.context_value.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.default_dock_window_theme.html
+++ b/7.2/api/traitsui.default_dock_window_theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.delegating_handler.html
+++ b/7.2/api/traitsui.delegating_handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.dock_window_theme.html
+++ b/7.2/api/traitsui.dock_window_theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.dockable_view_element.html
+++ b/7.2/api/traitsui.dockable_view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editor.html
+++ b/7.2/api/traitsui.editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editor_factory.html
+++ b/7.2/api/traitsui.editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.api.html
+++ b/7.2/api/traitsui.editors.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.array_editor.html
+++ b/7.2/api/traitsui.editors.array_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.boolean_editor.html
+++ b/7.2/api/traitsui.editors.boolean_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.button_editor.html
+++ b/7.2/api/traitsui.editors.button_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.check_list_editor.html
+++ b/7.2/api/traitsui.editors.check_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.code_editor.html
+++ b/7.2/api/traitsui.editors.code_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.color_editor.html
+++ b/7.2/api/traitsui.editors.color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.compound_editor.html
+++ b/7.2/api/traitsui.editors.compound_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.csv_list_editor.html
+++ b/7.2/api/traitsui.editors.csv_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.custom_editor.html
+++ b/7.2/api/traitsui.editors.custom_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.date_editor.html
+++ b/7.2/api/traitsui.editors.date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.date_range_editor.html
+++ b/7.2/api/traitsui.editors.date_range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.datetime_editor.html
+++ b/7.2/api/traitsui.editors.datetime_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.default_override.html
+++ b/7.2/api/traitsui.editors.default_override.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.directory_editor.html
+++ b/7.2/api/traitsui.editors.directory_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.dnd_editor.html
+++ b/7.2/api/traitsui.editors.dnd_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.drop_editor.html
+++ b/7.2/api/traitsui.editors.drop_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.enum_editor.html
+++ b/7.2/api/traitsui.editors.enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.file_editor.html
+++ b/7.2/api/traitsui.editors.file_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.font_editor.html
+++ b/7.2/api/traitsui.editors.font_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.history_editor.html
+++ b/7.2/api/traitsui.editors.history_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.html
+++ b/7.2/api/traitsui.editors.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.html_editor.html
+++ b/7.2/api/traitsui.editors.html_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.image_editor.html
+++ b/7.2/api/traitsui.editors.image_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.image_enum_editor.html
+++ b/7.2/api/traitsui.editors.image_enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.instance_editor.html
+++ b/7.2/api/traitsui.editors.instance_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.key_binding_editor.html
+++ b/7.2/api/traitsui.editors.key_binding_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.list_editor.html
+++ b/7.2/api/traitsui.editors.list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.list_str_editor.html
+++ b/7.2/api/traitsui.editors.list_str_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.null_editor.html
+++ b/7.2/api/traitsui.editors.null_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.popup_editor.html
+++ b/7.2/api/traitsui.editors.popup_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.progress_editor.html
+++ b/7.2/api/traitsui.editors.progress_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.range_editor.html
+++ b/7.2/api/traitsui.editors.range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.rgb_color_editor.html
+++ b/7.2/api/traitsui.editors.rgb_color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.scrubber_editor.html
+++ b/7.2/api/traitsui.editors.scrubber_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.search_editor.html
+++ b/7.2/api/traitsui.editors.search_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.set_editor.html
+++ b/7.2/api/traitsui.editors.set_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.shell_editor.html
+++ b/7.2/api/traitsui.editors.shell_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.styled_date_editor.html
+++ b/7.2/api/traitsui.editors.styled_date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.table_editor.html
+++ b/7.2/api/traitsui.editors.table_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.tabular_editor.html
+++ b/7.2/api/traitsui.editors.tabular_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.text_editor.html
+++ b/7.2/api/traitsui.editors.text_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.time_editor.html
+++ b/7.2/api/traitsui.editors.time_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.title_editor.html
+++ b/7.2/api/traitsui.editors.title_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.tree_editor.html
+++ b/7.2/api/traitsui.editors.tree_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.tuple_editor.html
+++ b/7.2/api/traitsui.editors.tuple_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.value_editor.html
+++ b/7.2/api/traitsui.editors.value_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.editors.video_editor.html
+++ b/7.2/api/traitsui.editors.video_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.api.html
+++ b/7.2/api/traitsui.extras.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.checkbox_column.html
+++ b/7.2/api/traitsui.extras.checkbox_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.demo.html
+++ b/7.2/api/traitsui.extras.demo.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.edit_column.html
+++ b/7.2/api/traitsui.extras.edit_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.has_dynamic_views.html
+++ b/7.2/api/traitsui.extras.has_dynamic_views.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.html
+++ b/7.2/api/traitsui.extras.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.progress_column.html
+++ b/7.2/api/traitsui.extras.progress_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.extras.saving.html
+++ b/7.2/api/traitsui.extras.saving.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.file_dialog.html
+++ b/7.2/api/traitsui.file_dialog.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.group.html
+++ b/7.2/api/traitsui.group.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.handler.html
+++ b/7.2/api/traitsui.handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.help.html
+++ b/7.2/api/traitsui.help.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.help_template.html
+++ b/7.2/api/traitsui.help_template.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.helper.html
+++ b/7.2/api/traitsui.helper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.html
+++ b/7.2/api/traitsui.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.include.html
+++ b/7.2/api/traitsui.include.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.instance_choice.html
+++ b/7.2/api/traitsui.instance_choice.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.item.html
+++ b/7.2/api/traitsui.item.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.key_bindings.html
+++ b/7.2/api/traitsui.key_bindings.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.list_str_adapter.html
+++ b/7.2/api/traitsui.list_str_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.menu.html
+++ b/7.2/api/traitsui.menu.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.message.html
+++ b/7.2/api/traitsui.message.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.mimedata.html
+++ b/7.2/api/traitsui.mimedata.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.null.color_trait.html
+++ b/7.2/api/traitsui.null.color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.null.font_trait.html
+++ b/7.2/api/traitsui.null.font_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.null.html
+++ b/7.2/api/traitsui.null.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.null.rgb_color_trait.html
+++ b/7.2/api/traitsui.null.rgb_color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.null.toolkit.html
+++ b/7.2/api/traitsui.null.toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.table_column.html
+++ b/7.2/api/traitsui.table_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.table_filter.html
+++ b/7.2/api/traitsui.table_filter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.tabular_adapter.html
+++ b/7.2/api/traitsui.tabular_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.api.html
+++ b/7.2/api/traitsui.testing.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.html
+++ b/7.2/api/traitsui.testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.command.html
+++ b/7.2/api/traitsui.testing.tester.command.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.exceptions.html
+++ b/7.2/api/traitsui.testing.tester.exceptions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.html
+++ b/7.2/api/traitsui.testing.tester.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.locator.html
+++ b/7.2/api/traitsui.testing.tester.locator.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.query.html
+++ b/7.2/api/traitsui.testing.tester.query.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.target_registry.html
+++ b/7.2/api/traitsui.testing.tester.target_registry.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.ui_tester.html
+++ b/7.2/api/traitsui.testing.tester.ui_tester.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.testing.tester.ui_wrapper.html
+++ b/7.2/api/traitsui.testing.tester.ui_wrapper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.theme.html
+++ b/7.2/api/traitsui.theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.toolkit.html
+++ b/7.2/api/traitsui.toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.toolkit_traits.html
+++ b/7.2/api/traitsui.toolkit_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.tree_node.html
+++ b/7.2/api/traitsui.tree_node.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.tree_node_renderer.html
+++ b/7.2/api/traitsui.tree_node_renderer.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.ui.html
+++ b/7.2/api/traitsui.ui.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.ui_editor.html
+++ b/7.2/api/traitsui.ui_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.ui_editors.array_view_editor.html
+++ b/7.2/api/traitsui.ui_editors.array_view_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.ui_editors.data_frame_editor.html
+++ b/7.2/api/traitsui.ui_editors.data_frame_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.ui_editors.html
+++ b/7.2/api/traitsui.ui_editors.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.ui_info.html
+++ b/7.2/api/traitsui.ui_info.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.ui_traits.html
+++ b/7.2/api/traitsui.ui_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.undo.html
+++ b/7.2/api/traitsui.undo.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.value_tree.html
+++ b/7.2/api/traitsui.value_tree.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.view.html
+++ b/7.2/api/traitsui.view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.view_element.html
+++ b/7.2/api/traitsui.view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/api/traitsui.view_elements.html
+++ b/7.2/api/traitsui.view_elements.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/changelog.html
+++ b/7.2/changelog.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',
@@ -86,6 +86,17 @@
             
   <div class="section" id="traits-ui-changelog">
 <h1>Traits UI Changelog<a class="headerlink" href="#traits-ui-changelog" title="Permalink to this headline">¶</a></h1>
+<div class="section" id="release-7-2-1">
+<h2>Release 7.2.1<a class="headerlink" href="#release-7-2-1" title="Permalink to this headline">¶</a></h2>
+<p>TraitsUI 7.2.1 is a bugfix release which updates TraitsUI to explicitly require
+Traits 6.2+ and Pyface 7.3+.</p>
+<div class="section" id="build-and-continuous-integration">
+<h3>Build and continuous integration<a class="headerlink" href="#build-and-continuous-integration" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Explicitly require traits 6.2 and pyface 7.3 (#1666, #1668)</p></li>
+</ul>
+</div>
+</div>
 <div class="section" id="release-7-2-0">
 <h2>Release 7.2.0<a class="headerlink" href="#release-7-2-0" title="Permalink to this headline">¶</a></h2>
 <p>TraitsUI 7.2.0 is a minor release which includes numerous bug fixes,
@@ -94,7 +105,7 @@ documentation improvements, code maintenance changes, and enhancements.</p>
 <h3>Highlights of this release<a class="headerlink" href="#highlights-of-this-release" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>The migration from <code class="docutils literal notranslate"><span class="pre">on_trait_change</span></code> to <code class="docutils literal notranslate"><span class="pre">observe</span></code> is underway. As a
-result, TraitsUI now requires Traits &gt;= 6.1.</p></li>
+result, TraitsUI now requires Traits &gt;= 6.2.</p></li>
 <li><p>New display-only VideoEditor (currently only on Qt backend).</p></li>
 <li><p>Exapnsion of features for the new <code class="docutils literal notranslate"><span class="pre">UITester</span></code> including the ability to
 inspect UI object visibility / enabledness. Also documentation for testing
@@ -104,14 +115,15 @@ has been updated.</p></li>
 <div class="section" id="notes-on-upgrading">
 <h3>Notes on upgrading<a class="headerlink" href="#notes-on-upgrading" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>This release of TraitsUI now depends on Traits 6.1+. Also, deprecated code /
-modules have been removed. Namely, the <code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.image</span></code>
-module which was moved to <code class="docutils literal notranslate"><span class="pre">pyface.image</span></code>, <code class="docutils literal notranslate"><span class="pre">editors_gen</span></code> modules, Editor
-and EditorFactory factory methods on Toolkit objects, and more.  For a
-complete list, see PRs in the “Removals” section below.  These were all
-generally unused / deprecated for sometime. Also, importing directly from
-<code class="docutils literal notranslate"><span class="pre">traitsui.editors</span></code> has been deprecated. Please update imports to import
-directly from <a class="reference internal" href="api/traitsui.api.html#module-traitsui.api" title="traitsui.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.api</span></code></a> or <a class="reference internal" href="api/traitsui.editors.api.html#module-traitsui.editors.api" title="traitsui.editors.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.editors.api</span></code></a>.</p></li>
+<li><p>This release of TraitsUI now depends on Traits 6.2+ and pyface 7.3+. Also,
+deprecated code / modules have been removed. Namely, the
+<code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.image</span></code> module which was moved to
+<code class="docutils literal notranslate"><span class="pre">pyface.image</span></code>, <code class="docutils literal notranslate"><span class="pre">editors_gen</span></code> modules, Editor and EditorFactory factory
+methods on Toolkit objects, and more.  For a complete list, see PRs in the
+“Removals” section below.  These were all generally unused / deprecated for
+sometime. Also, importing directly from <code class="docutils literal notranslate"><span class="pre">traitsui.editors</span></code> has been
+deprecated. Please update imports to import directly from <a class="reference internal" href="api/traitsui.api.html#module-traitsui.api" title="traitsui.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.api</span></code></a>
+or <a class="reference internal" href="api/traitsui.editors.api.html#module-traitsui.editors.api" title="traitsui.editors.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.editors.api</span></code></a>.</p></li>
 </ul>
 </div>
 <div class="section" id="detailed-changes">
@@ -175,8 +187,8 @@ directly from <a class="reference internal" href="api/traitsui.api.html#module-t
 <li><p>Format code examples in the user documentation (#1640)</p></li>
 </ul>
 </div>
-<div class="section" id="build-and-continuous-integration">
-<h3>Build and continuous integration<a class="headerlink" href="#build-and-continuous-integration" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id1">
+<h3>Build and continuous integration<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix cron job not installing additional dependencies (#1427)</p></li>
 <li><p>Remove job on Travis for testing against Traits 6.0 (#1430)</p></li>
@@ -214,7 +226,7 @@ directly from <a class="reference internal" href="api/traitsui.api.html#module-t
 <li><p>Remove clause that deviates from PEP8 backward compatibility convention in the testing package (#1481)</p></li>
 <li><p>Formal editor interface for tooltips (#1493</p></li>
 <li><p>Add instance choice classes to traitsui.api (#1495)</p></li>
-<li><p>Undo/Redo cleanup (#1510</p></li>
+<li><p>Undo/Redo cleanup (#1510)</p></li>
 <li><p>start on_trait_change to observe migration (#1519, #1520, #1523, #1525, #1545, #1622, #1644)</p></li>
 <li><p>Refactor TreeEditor _new_actions and _menu_new_node to avoid hacky eval (#1524)</p></li>
 <li><p>Refactor _add_items method of _GroupPanel object (#1549)</p></li>
@@ -248,8 +260,8 @@ directly from <a class="reference internal" href="api/traitsui.api.html#module-t
 <h2>Release 7.1.1<a class="headerlink" href="#release-7-1-1" title="Permalink to this headline">¶</a></h2>
 <p>This is a bugfix release that fixes a number of issues since the 7.1.0 release.
 Thanks to Corran Webster and Kit Choi for the patches.</p>
-<div class="section" id="id1">
-<h3>Fixes<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id2">
+<h3>Fixes<a class="headerlink" href="#id2" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix <code class="docutils literal notranslate"><span class="pre">scrollable</span></code> trait of a Group not being implemented on Qt (#1406)</p></li>
 <li><p>Fix icon button’s clickable area too small for FileEditor and RangeEditor on
@@ -268,8 +280,8 @@ be installed separately).</p>
 <p>This release should be compatible with Traits 6.0+. Users are encouraged to
 upgrade to Traits 6.1+ to stay current as future releases of TraitsUI will
 stop supporting Traits 6.0.</p>
-<div class="section" id="id2">
-<h3>Highlights of this release<a class="headerlink" href="#id2" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id3">
+<h3>Highlights of this release<a class="headerlink" href="#id3" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>A new <a class="reference internal" href="api/traitsui.testing.api.html#module-traitsui.testing.api" title="traitsui.testing.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.testing.api</span></code></a> module has been introduced for testing
 GUI applications built using TraitsUI. See
@@ -285,8 +297,8 @@ changed as an attempt to resolve AttributeError that occurs while a nested
 UI is removed.</p></li>
 </ul>
 </div>
-<div class="section" id="id3">
-<h3>Notes on upgrading<a class="headerlink" href="#id3" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id4">
+<h3>Notes on upgrading<a class="headerlink" href="#id4" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>On the issue about Qt button not causing views to update on OSX, projects
 that have been working around the issue by adding <code class="docutils literal notranslate"><span class="pre">GUI().process_events()</span></code>
@@ -309,8 +321,8 @@ ago and has since been deprecated. Previously it was scheduled to be removed
 in TraitsUI 6.0. This planned removal is now deferred to TraitsUI 7.2.</p></li>
 </ul>
 </div>
-<div class="section" id="id4">
-<h3>Detailed changes<a class="headerlink" href="#id4" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id5">
+<h3>Detailed changes<a class="headerlink" href="#id5" title="Permalink to this headline">¶</a></h3>
 <p>More than 100 PRs went into this release. Thanks to:</p>
 <ul class="simple">
 <li><p>Aaron Ayres</p></li>
@@ -335,8 +347,8 @@ been omitted.</p>
 applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 </ul>
 </div>
-<div class="section" id="id5">
-<h3>Fixes<a class="headerlink" href="#id5" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id6">
+<h3>Fixes<a class="headerlink" href="#id6" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix AttributeError when a nested UI is disposed (#1286)</p></li>
 <li><p>Fix wx error due to use of alignment flag wxEXPAND (#1095)</p></li>
@@ -351,8 +363,8 @@ applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 <li><p>Fix deprecation warnings from using ABC in collections (#1103, #1129)</p></li>
 </ul>
 </div>
-<div class="section" id="id6">
-<h3>Documentation<a class="headerlink" href="#id6" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id7">
+<h3>Documentation<a class="headerlink" href="#id7" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Make demo examples as package data (#1088)</p></li>
 <li><p>Add UITester documentation in User Manual (#1263)</p></li>
@@ -361,8 +373,8 @@ applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 <li><p>Generate API documentation automatically (#1368)</p></li>
 </ul>
 </div>
-<div class="section" id="id7">
-<h3>Build and continuous integration<a class="headerlink" href="#id7" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id8">
+<h3>Build and continuous integration<a class="headerlink" href="#id8" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add a CI job for testing against traits 6.0 (#1108)</p></li>
 <li><p>Move MacOS CI build from Travis to Appveyor (#1160)</p></li>
@@ -371,8 +383,8 @@ applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 <li><p>Explicitly require a minimum version for Traits (#1323)</p></li>
 </ul>
 </div>
-<div class="section" id="id8">
-<h3>Maintenance and code organization<a class="headerlink" href="#id8" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id9">
+<h3>Maintenance and code organization<a class="headerlink" href="#id9" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Relax constraint on PySide2 version (#1146)</p></li>
 <li><p>Update edm version in travis and appveyor config files (#1049)</p></li>
@@ -391,8 +403,8 @@ It includes fixes to various editors, improvements to tests and fixes to the
 demo application.</p>
 <p>Thanks to Ieva Cerny, Kit Choi, Mark Dickinson, Robert Kern, Eric Larson,
 Federico Miorelli, Joris Vankerschaver, Corran Webster.</p>
-<div class="section" id="id9">
-<h3>Fixes<a class="headerlink" href="#id9" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id10">
+<h3>Fixes<a class="headerlink" href="#id10" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix error from true division of integers for Qt RangeEditor and BoundsEditor
 (#999, #1000)</p></li>
@@ -412,8 +424,8 @@ items (#875)</p></li>
 <li><p>Fix error from example’s tutor.py script (#813)</p></li>
 </ul>
 </div>
-<div class="section" id="id10">
-<h3>Documentation<a class="headerlink" href="#id10" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id11">
+<h3>Documentation<a class="headerlink" href="#id11" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add links from TabularEditor and TreeEditor to adapter documentation (#917)</p></li>
 </ul>
@@ -457,8 +469,8 @@ unifying the demo viewer codebase.</p>
 Hancock, Sandhya Govindaraju, Midhun Madhusoodanan, Rob McMullen, Shoeb
 Mohammed, Eric Olsen, Roberto Preste, reckoner, Jonathan Rocher, Scott
 Talbert, Corran Webster.</p>
-<div class="section" id="id11">
-<h3>Enhancements<a class="headerlink" href="#id11" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id12">
+<h3>Enhancements<a class="headerlink" href="#id12" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Documentation improvements (#720, #724, #723, #778)</p></li>
 <li><p>WxPython 4 compatibility and support (#708, #736, #762, #772, #775, #776)</p></li>
@@ -475,8 +487,8 @@ Talbert, Corran Webster.</p>
 <li><p>Enhancements to CI and testing (#683, #714, #740)</p></li>
 </ul>
 </div>
-<div class="section" id="id12">
-<h3>Fixes<a class="headerlink" href="#id12" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id13">
+<h3>Fixes<a class="headerlink" href="#id13" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Documentation fixes (#546, #766)</p></li>
 <li><p>Fix cgi.escape for Python 3.8 (#780)</p></li>
@@ -502,8 +514,8 @@ TableEditor and TabularEditor for the Qt toolkit which didn’t match
 the advertised behaviour in the documentation.</p>
 <p>Thanks to Qi Chen, Vladimir Chukharev, Mark Dickinson, Sandhya Govindaraju,
 Maxwell Grady, Scott Maddox, Sean Parsons, Rahul Poruri, Corran Webster.</p>
-<div class="section" id="id13">
-<h3>Fixes<a class="headerlink" href="#id13" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id14">
+<h3>Fixes<a class="headerlink" href="#id14" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add “bool” to allowed types for TableColumn (#656)</p></li>
 <li><p>Fix tabular editor column widths (#652)</p></li>
@@ -532,8 +544,8 @@ Maxwell Grady, Scott Maddox, Sean Parsons, Rahul Poruri, Corran Webster.</p>
 the usability of Mayavi.</p>
 <p>Thanks to Mark Dickinson, Maxwell Grady, Prabhu Ramachandran, Matt Reay,
 Ajeet Vivekanandan, Corran Webster, John Wiggins.</p>
-<div class="section" id="id14">
-<h3>Fixes<a class="headerlink" href="#id14" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id15">
+<h3>Fixes<a class="headerlink" href="#id15" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix tree node copy failure to copy (#590)</p></li>
 <li><p>Fix/scroll to row preserve column (#588)</p></li>
@@ -552,8 +564,8 @@ Ajeet Vivekanandan, Corran Webster, John Wiggins.</p>
 <div class="section" id="release-6-1-1">
 <h2>Release 6.1.1<a class="headerlink" href="#release-6-1-1" title="Permalink to this headline">¶</a></h2>
 <p>A bugfix release to correct some critical issues with the TreeEditor.</p>
-<div class="section" id="id15">
-<h3>Fixes<a class="headerlink" href="#id15" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id16">
+<h3>Fixes<a class="headerlink" href="#id16" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix TreeNodeObject listener cache (#558).</p></li>
 <li><p>Fix tree node insertion (#561).</p></li>
@@ -603,8 +615,8 @@ Roger Serwy, Ajeet Vivekanandan, Corran Webster, John Wiggins.</p>
 <li><p>Allow drag move and drag copy modes on Qt TabularEditor (#363).</p></li>
 </ul>
 </div>
-<div class="section" id="id16">
-<h3>Fixes<a class="headerlink" href="#id16" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id17">
+<h3>Fixes<a class="headerlink" href="#id17" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fixes to README (#478).</p></li>
 <li><p>Documentation fixes (#471, #508).</p></li>
@@ -679,8 +691,8 @@ Pradyun Gedam, Robert Kern, Marika Murphy, Pankaj Pandey, Steve Peak,
 Prabhu Ramachandran, Jonathan Rocher, John Thacker, Gregor Thalhammer,
 Senganal Thirunavukkarasu, John Tyree, Ioannis Tziakos, Alona Varshal,
 Corran Webster, John Wiggins</p>
-<div class="section" id="id17">
-<h3>Enhancements<a class="headerlink" href="#id17" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id18">
+<h3>Enhancements<a class="headerlink" href="#id18" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Support for Qt5 (#347, #352, #350, #433)</p></li>
 <li><p>Remove TraitsUI Themes (#342)</p></li>
@@ -704,8 +716,8 @@ Corran Webster, John Wiggins</p>
 <li><p>Add codecov coverage reports (#285, #328)</p></li>
 </ul>
 </div>
-<div class="section" id="id18">
-<h3>Fixes<a class="headerlink" href="#id18" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id19">
+<h3>Fixes<a class="headerlink" href="#id19" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix some issues for newer WxPython (#418)</p></li>
 <li><p>Fix Wx simple FileEditor (#426)</p></li>
@@ -741,8 +753,8 @@ Corran Webster, John Wiggins</p>
 </div>
 <div class="section" id="release-5-2-0">
 <h2>Release 5.2.0<a class="headerlink" href="#release-5-2-0" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id19">
-<h3>Enhancements<a class="headerlink" href="#id19" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id20">
+<h3>Enhancements<a class="headerlink" href="#id20" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add support for multi-select in the DataFrameEditor (#413).</p></li>
 </ul>
@@ -750,8 +762,8 @@ Corran Webster, John Wiggins</p>
 </div>
 <div class="section" id="release-5-1-0">
 <h2>Release 5.1.0<a class="headerlink" href="#release-5-1-0" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id20">
-<h3>Enhancements<a class="headerlink" href="#id20" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id21">
+<h3>Enhancements<a class="headerlink" href="#id21" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Enthought Sphinx Theme Support (#219)</p></li>
 <li><p>Allow hiding groups in split layouts on Qt (#246)</p></li>
@@ -759,8 +771,8 @@ Corran Webster, John Wiggins</p>
 <li><p>Add toolbar in Qt UI panel (#263)</p></li>
 </ul>
 </div>
-<div class="section" id="id21">
-<h3>Fixes<a class="headerlink" href="#id21" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id22">
+<h3>Fixes<a class="headerlink" href="#id22" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix Qt TableEditor segfault on editing close (#277)</p></li>
 <li><p>Update tree nodes when adding children to am empty tree (#251)</p></li>
@@ -800,8 +812,8 @@ use explicitly.</p>
 (#196)</p></li>
 </ul>
 </div>
-<div class="section" id="id22">
-<h3>Enhancements<a class="headerlink" href="#id22" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id23">
+<h3>Enhancements<a class="headerlink" href="#id23" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Change the default backend from Wx to Qt (#212)</p></li>
 <li><p>Add a Qt version of the ProgressEditor (#217)</p></li>
@@ -810,8 +822,8 @@ use explicitly.</p>
 Editor. (#143)</p></li>
 </ul>
 </div>
-<div class="section" id="id23">
-<h3>Fixes<a class="headerlink" href="#id23" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id24">
+<h3>Fixes<a class="headerlink" href="#id24" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix failure to disconnect selection listeners for ListStrEditor in Qt (#223)</p></li>
 <li><p>Fix layout of TextEditors in some situations (#216)</p></li>
@@ -823,8 +835,8 @@ Editor. (#143)</p></li>
 </div>
 <div class="section" id="release-4-5-1">
 <h2>Release 4.5.1<a class="headerlink" href="#release-4-5-1" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id24">
-<h3>Fixes<a class="headerlink" href="#id24" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id25">
+<h3>Fixes<a class="headerlink" href="#id25" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix pypi installation problem (#206)</p></li>
 </ul>
@@ -832,8 +844,8 @@ Editor. (#143)</p></li>
 </div>
 <div class="section" id="release-4-5-0">
 <h2>Release 4.5.0<a class="headerlink" href="#release-4-5-0" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id25">
-<h3>Fixes<a class="headerlink" href="#id25" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id26">
+<h3>Fixes<a class="headerlink" href="#id26" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Application-modal Traits UI dialogs are correctly styled as
 application-modal under Qt. On Macs, they will now appear as independent
@@ -859,14 +871,14 @@ in Traits 4.4.0.  Other than that, there are a number of other minor changes,
 improvements and bugfixes.</p>
 <p>Corran Webster (corranwebster on GitHub) is now maintainer of TraitsUI.</p>
 <p>Change summary since 4.3.0</p>
-<div class="section" id="id26">
-<h3>New Features<a class="headerlink" href="#id26" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id27">
+<h3>New Features<a class="headerlink" href="#id27" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Changes for new Traits adaptation mechanism support (#113)</p></li>
 </ul>
 </div>
-<div class="section" id="id27">
-<h3>Enhancements<a class="headerlink" href="#id27" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id28">
+<h3>Enhancements<a class="headerlink" href="#id28" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add Travis-CI support.</p></li>
 <li><p>Remove the use of the deprecated PySimpleApp under Wx and several other
@@ -877,8 +889,8 @@ support.  Should be roughly on par with Wx support.  No API changes.
 <li><p>Improvements to PyMimeData coercion to better handle lists of items. (#127)</p></li>
 </ul>
 </div>
-<div class="section" id="id28">
-<h3>Fixes<a class="headerlink" href="#id28" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id29">
+<h3>Fixes<a class="headerlink" href="#id29" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fixes item selection issue #133 in ListStrEditor under Wx 2.9 (#137)</p></li>
 <li><p>Fixes to avoid asking for value of a Delegated Event (#123 and #136)</p></li>
@@ -894,8 +906,8 @@ before this file was created.</p>
 </div>
 <div class="section" id="traits-3-5-0-oct-15-2010">
 <h2>Traits 3.5.0 (Oct 15, 2010)<a class="headerlink" href="#traits-3-5-0-oct-15-2010" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id29">
-<h3>Enhancements<a class="headerlink" href="#id29" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id30">
+<h3>Enhancements<a class="headerlink" href="#id30" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>adding support for drop-down menu in Button traits, but only for qt backend</p></li>
 <li><p>adding ‘show_notebook_menu’ option to ListEditor so that the user can
@@ -904,8 +916,8 @@ right-click and show or hide the context menu (Qt)</p></li>
 selected text</p></li>
 </ul>
 </div>
-<div class="section" id="id30">
-<h3>Fixes<a class="headerlink" href="#id30" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id31">
+<h3>Fixes<a class="headerlink" href="#id31" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>fixed null color editor to work with tuples</p></li>
 <li><p>bug when opening a view with the ToolbarButton</p></li>
@@ -914,14 +926,14 @@ selected text</p></li>
 </div>
 <div class="section" id="traits-3-4-0-may-26-2010">
 <h2>Traits 3.4.0 (May 26, 2010)<a class="headerlink" href="#traits-3-4-0-may-26-2010" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id31">
-<h3>Enhancements<a class="headerlink" href="#id31" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id32">
+<h3>Enhancements<a class="headerlink" href="#id32" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>adding new example to make testing rgb color editor easier</p></li>
 </ul>
 </div>
-<div class="section" id="id32">
-<h3>Fixes<a class="headerlink" href="#id32" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id33">
+<h3>Fixes<a class="headerlink" href="#id33" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>fixed NumericColumn to not expect object to have model_selection attribute,
 and removed more dead theming code</p></li>
@@ -936,8 +948,8 @@ first before using os.path.isfile()</p></li>
 </div>
 <div class="section" id="traits-3-3-0-feb-24-2010">
 <h2>Traits 3.3.0 (Feb 24, 2010)<a class="headerlink" href="#traits-3-3-0-feb-24-2010" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id33">
-<h3>Enhancements<a class="headerlink" href="#id33" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id34">
+<h3>Enhancements<a class="headerlink" href="#id34" title="Permalink to this headline">¶</a></h3>
 <p>The major enhancement this release is that the entire Traits package has been
 changed to use relative imports so that it can be installed as a sub-package
 inside another larger library or package.  This was not previously possible,
@@ -945,8 +957,8 @@ since the various modules inside Traits would import each other directly
 through “traits.[module]”.  Many thanks to Darren Dale for the
 patch.</p>
 </div>
-<div class="section" id="id34">
-<h3>Fixes<a class="headerlink" href="#id34" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id35">
+<h3>Fixes<a class="headerlink" href="#id35" title="Permalink to this headline">¶</a></h3>
 <p>There have been numerous minor bugfixes since the last release.  The most notable
 ones are:</p>
 <ul class="simple">
@@ -964,8 +976,8 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
 </div>
 <div class="section" id="traits-3-2-0-july-15-2009">
 <h2>Traits 3.2.0 (July 15, 2009)<a class="headerlink" href="#traits-3-2-0-july-15-2009" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id35">
-<h3>Enhancements<a class="headerlink" href="#id35" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id36">
+<h3>Enhancements<a class="headerlink" href="#id36" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Implemented editable_labels attribute in the TabularEditor for enabling editing of the labels (i.e. the first column)</p></li>
 <li><p>Saving/restoring window positions works with multiple displays of different sizes</p></li>
@@ -983,8 +995,8 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
 <li><p>Removed sys.exit() call from SaveHandler.exit()</p></li>
 </ul>
 </div>
-<div class="section" id="id36">
-<h3>Fixes<a class="headerlink" href="#id36" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id37">
+<h3>Fixes<a class="headerlink" href="#id37" title="Permalink to this headline">¶</a></h3>
 </div>
 </div>
 </div>
@@ -1001,6 +1013,10 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
   <h3><a href="index.html">Table of Contents</a></h3>
   <ul>
 <li><a class="reference internal" href="#">Traits UI Changelog</a><ul>
+<li><a class="reference internal" href="#release-7-2-1">Release 7.2.1</a><ul>
+<li><a class="reference internal" href="#build-and-continuous-integration">Build and continuous integration</a></li>
+</ul>
+</li>
 <li><a class="reference internal" href="#release-7-2-0">Release 7.2.0</a><ul>
 <li><a class="reference internal" href="#highlights-of-this-release">Highlights of this release</a></li>
 <li><a class="reference internal" href="#notes-on-upgrading">Notes on upgrading</a></li>
@@ -1008,108 +1024,108 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
 <li><a class="reference internal" href="#enhancements">Enhancements</a></li>
 <li><a class="reference internal" href="#fixes">Fixes</a></li>
 <li><a class="reference internal" href="#documentation">Documentation</a></li>
-<li><a class="reference internal" href="#build-and-continuous-integration">Build and continuous integration</a></li>
+<li><a class="reference internal" href="#id1">Build and continuous integration</a></li>
 <li><a class="reference internal" href="#test-suite">Test suite</a></li>
 <li><a class="reference internal" href="#maintenance-and-code-organization">Maintenance and code organization</a></li>
 <li><a class="reference internal" href="#removals">Removals</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-1-1">Release 7.1.1</a><ul>
-<li><a class="reference internal" href="#id1">Fixes</a></li>
+<li><a class="reference internal" href="#id2">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-1-0">Release 7.1.0</a><ul>
-<li><a class="reference internal" href="#id2">Highlights of this release</a></li>
-<li><a class="reference internal" href="#id3">Notes on upgrading</a></li>
+<li><a class="reference internal" href="#id3">Highlights of this release</a></li>
+<li><a class="reference internal" href="#id4">Notes on upgrading</a></li>
 <li><a class="reference internal" href="#future-removals">Future removals</a></li>
-<li><a class="reference internal" href="#id4">Detailed changes</a></li>
+<li><a class="reference internal" href="#id5">Detailed changes</a></li>
 <li><a class="reference internal" href="#features">Features</a></li>
-<li><a class="reference internal" href="#id5">Fixes</a></li>
-<li><a class="reference internal" href="#id6">Documentation</a></li>
-<li><a class="reference internal" href="#id7">Build and continuous integration</a></li>
-<li><a class="reference internal" href="#id8">Maintenance and code organization</a></li>
+<li><a class="reference internal" href="#id6">Fixes</a></li>
+<li><a class="reference internal" href="#id7">Documentation</a></li>
+<li><a class="reference internal" href="#id8">Build and continuous integration</a></li>
+<li><a class="reference internal" href="#id9">Maintenance and code organization</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-0-1">Release 7.0.1</a><ul>
-<li><a class="reference internal" href="#id9">Fixes</a></li>
-<li><a class="reference internal" href="#id10">Documentation</a></li>
+<li><a class="reference internal" href="#id10">Fixes</a></li>
+<li><a class="reference internal" href="#id11">Documentation</a></li>
 <li><a class="reference internal" href="#tests">Tests</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-0-0">Release 7.0.0</a><ul>
-<li><a class="reference internal" href="#id11">Enhancements</a></li>
-<li><a class="reference internal" href="#id12">Fixes</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#release-6-1-3">Release 6.1.3</a><ul>
+<li><a class="reference internal" href="#id12">Enhancements</a></li>
 <li><a class="reference internal" href="#id13">Fixes</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#release-6-1-2">Release 6.1.2</a><ul>
+<li><a class="reference internal" href="#release-6-1-3">Release 6.1.3</a><ul>
 <li><a class="reference internal" href="#id14">Fixes</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#release-6-1-1">Release 6.1.1</a><ul>
+<li><a class="reference internal" href="#release-6-1-2">Release 6.1.2</a><ul>
 <li><a class="reference internal" href="#id15">Fixes</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#release-6-1-1">Release 6.1.1</a><ul>
+<li><a class="reference internal" href="#id16">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-6-1-0">Release 6.1.0</a><ul>
 <li><a class="reference internal" href="#enhancemenrs">Enhancemenrs</a></li>
-<li><a class="reference internal" href="#id16">Fixes</a></li>
+<li><a class="reference internal" href="#id17">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-6-0-0">Release 6.0.0</a><ul>
-<li><a class="reference internal" href="#id17">Enhancements</a></li>
-<li><a class="reference internal" href="#id18">Fixes</a></li>
+<li><a class="reference internal" href="#id18">Enhancements</a></li>
+<li><a class="reference internal" href="#id19">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-5-2-0">Release 5.2.0</a><ul>
-<li><a class="reference internal" href="#id19">Enhancements</a></li>
+<li><a class="reference internal" href="#id20">Enhancements</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-5-1-0">Release 5.1.0</a><ul>
-<li><a class="reference internal" href="#id20">Enhancements</a></li>
-<li><a class="reference internal" href="#id21">Fixes</a></li>
+<li><a class="reference internal" href="#id21">Enhancements</a></li>
+<li><a class="reference internal" href="#id22">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-5-0-0">Release 5.0.0</a><ul>
 <li><a class="reference internal" href="#new-features">New Features</a></li>
-<li><a class="reference internal" href="#id22">Enhancements</a></li>
-<li><a class="reference internal" href="#id23">Fixes</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#release-4-5-1">Release 4.5.1</a><ul>
+<li><a class="reference internal" href="#id23">Enhancements</a></li>
 <li><a class="reference internal" href="#id24">Fixes</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#release-4-5-0">Release 4.5.0</a><ul>
+<li><a class="reference internal" href="#release-4-5-1">Release 4.5.1</a><ul>
 <li><a class="reference internal" href="#id25">Fixes</a></li>
 </ul>
 </li>
+<li><a class="reference internal" href="#release-4-5-0">Release 4.5.0</a><ul>
+<li><a class="reference internal" href="#id26">Fixes</a></li>
+</ul>
+</li>
 <li><a class="reference internal" href="#release-4-4-0">Release 4.4.0</a><ul>
-<li><a class="reference internal" href="#id26">New Features</a></li>
-<li><a class="reference internal" href="#id27">Enhancements</a></li>
-<li><a class="reference internal" href="#id28">Fixes</a></li>
+<li><a class="reference internal" href="#id27">New Features</a></li>
+<li><a class="reference internal" href="#id28">Enhancements</a></li>
+<li><a class="reference internal" href="#id29">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-5-0-oct-15-2010">Traits 3.5.0 (Oct 15, 2010)</a><ul>
-<li><a class="reference internal" href="#id29">Enhancements</a></li>
-<li><a class="reference internal" href="#id30">Fixes</a></li>
+<li><a class="reference internal" href="#id30">Enhancements</a></li>
+<li><a class="reference internal" href="#id31">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-4-0-may-26-2010">Traits 3.4.0 (May 26, 2010)</a><ul>
-<li><a class="reference internal" href="#id31">Enhancements</a></li>
-<li><a class="reference internal" href="#id32">Fixes</a></li>
+<li><a class="reference internal" href="#id32">Enhancements</a></li>
+<li><a class="reference internal" href="#id33">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-3-0-feb-24-2010">Traits 3.3.0 (Feb 24, 2010)</a><ul>
-<li><a class="reference internal" href="#id33">Enhancements</a></li>
-<li><a class="reference internal" href="#id34">Fixes</a></li>
+<li><a class="reference internal" href="#id34">Enhancements</a></li>
+<li><a class="reference internal" href="#id35">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-2-0-july-15-2009">Traits 3.2.0 (July 15, 2009)</a><ul>
-<li><a class="reference internal" href="#id35">Enhancements</a></li>
-<li><a class="reference internal" href="#id36">Fixes</a></li>
+<li><a class="reference internal" href="#id36">Enhancements</a></li>
+<li><a class="reference internal" href="#id37">Fixes</a></li>
 </ul>
 </li>
 </ul>

--- a/7.2/demos/index.html
+++ b/7.2/demos/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/genindex.html
+++ b/7.2/genindex.html
@@ -15,7 +15,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/index.html
+++ b/7.2/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',
@@ -107,6 +107,7 @@
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="changelog.html">Traits UI Changelog</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-2-1">Release 7.2.1</a></li>
 <li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-2-0">Release 7.2.0</a></li>
 <li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-1-1">Release 7.1.1</a></li>
 <li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-1-0">Release 7.1.0</a></li>

--- a/7.2/py-modindex.html
+++ b/7.2/py-modindex.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/search.html
+++ b/7.2/search.html
@@ -15,7 +15,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_dev_guide/index.html
+++ b/7.2/traitsui_dev_guide/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_dev_guide/testing.html
+++ b/7.2/traitsui_dev_guide/testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/adapters.html
+++ b/7.2/traitsui_user_manual/adapters.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/advanced_view.html
+++ b/7.2/traitsui_user_manual/advanced_view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/custom_view.html
+++ b/7.2/traitsui_user_manual/custom_view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/factories_advanced_extra.html
+++ b/7.2/traitsui_user_manual/factories_advanced_extra.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/factories_basic.html
+++ b/7.2/traitsui_user_manual/factories_basic.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/factory_intro.html
+++ b/7.2/traitsui_user_manual/factory_intro.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/glossary.html
+++ b/7.2/traitsui_user_manual/glossary.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/handler.html
+++ b/7.2/traitsui_user_manual/handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/index.html
+++ b/7.2/traitsui_user_manual/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/intro.html
+++ b/7.2/traitsui_user_manual/intro.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/predefined_traits.html
+++ b/7.2/traitsui_user_manual/predefined_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing.html
+++ b/7.2/traitsui_user_manual/testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/discussions/automated_vs_manual_test.html
+++ b/7.2/traitsui_user_manual/testing/discussions/automated_vs_manual_test.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/discussions/compatibility_pyface_testing.html
+++ b/7.2/traitsui_user_manual/testing/discussions/compatibility_pyface_testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/discussions/debugging-gui-tests-at-runtime.html
+++ b/7.2/traitsui_user_manual/testing/discussions/debugging-gui-tests-at-runtime.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/discussions/event_loop_and_exceptions.html
+++ b/7.2/traitsui_user_manual/testing/discussions/event_loop_and_exceptions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/discussions/target_interaction_location.html
+++ b/7.2/traitsui_user_manual/testing/discussions/target_interaction_location.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/discussions/working_of_extensions.html
+++ b/7.2/traitsui_user_manual/testing/discussions/working_of_extensions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/howtos/add_new_interaction.html
+++ b/7.2/traitsui_user_manual/testing/howtos/add_new_interaction.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/howtos/add_new_location.html
+++ b/7.2/traitsui_user_manual/testing/howtos/add_new_location.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/references/examples.html
+++ b/7.2/traitsui_user_manual/testing/references/examples.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/substitutions.html
+++ b/7.2/traitsui_user_manual/testing/substitutions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/tutorials/first_test.html
+++ b/7.2/traitsui_user_manual/testing/tutorials/first_test.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/testing/tutorials/test_with_nested_object.html
+++ b/7.2/traitsui_user_manual/testing/tutorials/test_with_nested_object.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/tips.html
+++ b/7.2/traitsui_user_manual/tips.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/traitsui_user_manual/view.html
+++ b/7.2/traitsui_user_manual/view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/tutorials/index.html
+++ b/7.2/tutorials/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/7.2/tutorials/traits_ui_scientific_app.html
+++ b/7.2/tutorials/traits_ui_scientific_app.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/index.html
+++ b/_modules/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/pyface/action/group.html
+++ b/_modules/pyface/action/group.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/pyface/ui/qt4/action/menu_bar_manager.html
+++ b/_modules/pyface/ui/qt4/action/menu_bar_manager.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traits/trait_types.html
+++ b/_modules/traits/trait_types.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/api.html
+++ b/_modules/traitsui/api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/base_panel.html
+++ b/_modules/traitsui/base_panel.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/basic_editor_factory.html
+++ b/_modules/traitsui/basic_editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/color_column.html
+++ b/_modules/traitsui/color_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/context_value.html
+++ b/_modules/traitsui/context_value.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/delegating_handler.html
+++ b/_modules/traitsui/delegating_handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/dock_window_theme.html
+++ b/_modules/traitsui/dock_window_theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/dockable_view_element.html
+++ b/_modules/traitsui/dockable_view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editor.html
+++ b/_modules/traitsui/editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editor_factory.html
+++ b/_modules/traitsui/editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/array_editor.html
+++ b/_modules/traitsui/editors/array_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/boolean_editor.html
+++ b/_modules/traitsui/editors/boolean_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/button_editor.html
+++ b/_modules/traitsui/editors/button_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/check_list_editor.html
+++ b/_modules/traitsui/editors/check_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/code_editor.html
+++ b/_modules/traitsui/editors/code_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/color_editor.html
+++ b/_modules/traitsui/editors/color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/compound_editor.html
+++ b/_modules/traitsui/editors/compound_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/csv_list_editor.html
+++ b/_modules/traitsui/editors/csv_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/custom_editor.html
+++ b/_modules/traitsui/editors/custom_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/date_editor.html
+++ b/_modules/traitsui/editors/date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/date_range_editor.html
+++ b/_modules/traitsui/editors/date_range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/datetime_editor.html
+++ b/_modules/traitsui/editors/datetime_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/default_override.html
+++ b/_modules/traitsui/editors/default_override.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/directory_editor.html
+++ b/_modules/traitsui/editors/directory_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/dnd_editor.html
+++ b/_modules/traitsui/editors/dnd_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/drop_editor.html
+++ b/_modules/traitsui/editors/drop_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/enum_editor.html
+++ b/_modules/traitsui/editors/enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/file_editor.html
+++ b/_modules/traitsui/editors/file_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/font_editor.html
+++ b/_modules/traitsui/editors/font_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/history_editor.html
+++ b/_modules/traitsui/editors/history_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/html_editor.html
+++ b/_modules/traitsui/editors/html_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/image_editor.html
+++ b/_modules/traitsui/editors/image_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/image_enum_editor.html
+++ b/_modules/traitsui/editors/image_enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/instance_editor.html
+++ b/_modules/traitsui/editors/instance_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/key_binding_editor.html
+++ b/_modules/traitsui/editors/key_binding_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/list_editor.html
+++ b/_modules/traitsui/editors/list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/list_str_editor.html
+++ b/_modules/traitsui/editors/list_str_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/null_editor.html
+++ b/_modules/traitsui/editors/null_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/popup_editor.html
+++ b/_modules/traitsui/editors/popup_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/progress_editor.html
+++ b/_modules/traitsui/editors/progress_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/range_editor.html
+++ b/_modules/traitsui/editors/range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/rgb_color_editor.html
+++ b/_modules/traitsui/editors/rgb_color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/scrubber_editor.html
+++ b/_modules/traitsui/editors/scrubber_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/search_editor.html
+++ b/_modules/traitsui/editors/search_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/set_editor.html
+++ b/_modules/traitsui/editors/set_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/shell_editor.html
+++ b/_modules/traitsui/editors/shell_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/styled_date_editor.html
+++ b/_modules/traitsui/editors/styled_date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/table_editor.html
+++ b/_modules/traitsui/editors/table_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/tabular_editor.html
+++ b/_modules/traitsui/editors/tabular_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/text_editor.html
+++ b/_modules/traitsui/editors/text_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/time_editor.html
+++ b/_modules/traitsui/editors/time_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/title_editor.html
+++ b/_modules/traitsui/editors/title_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/tree_editor.html
+++ b/_modules/traitsui/editors/tree_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/tuple_editor.html
+++ b/_modules/traitsui/editors/tuple_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/value_editor.html
+++ b/_modules/traitsui/editors/value_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/editors/video_editor.html
+++ b/_modules/traitsui/editors/video_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/extras/checkbox_column.html
+++ b/_modules/traitsui/extras/checkbox_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/extras/edit_column.html
+++ b/_modules/traitsui/extras/edit_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/extras/has_dynamic_views.html
+++ b/_modules/traitsui/extras/has_dynamic_views.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/extras/progress_column.html
+++ b/_modules/traitsui/extras/progress_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/extras/saving.html
+++ b/_modules/traitsui/extras/saving.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/file_dialog.html
+++ b/_modules/traitsui/file_dialog.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/group.html
+++ b/_modules/traitsui/group.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/handler.html
+++ b/_modules/traitsui/handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/help.html
+++ b/_modules/traitsui/help.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/help_template.html
+++ b/_modules/traitsui/help_template.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/helper.html
+++ b/_modules/traitsui/helper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/include.html
+++ b/_modules/traitsui/include.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/instance_choice.html
+++ b/_modules/traitsui/instance_choice.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/item.html
+++ b/_modules/traitsui/item.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/key_bindings.html
+++ b/_modules/traitsui/key_bindings.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/list_str_adapter.html
+++ b/_modules/traitsui/list_str_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/menu.html
+++ b/_modules/traitsui/menu.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/message.html
+++ b/_modules/traitsui/message.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/null/color_trait.html
+++ b/_modules/traitsui/null/color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/null/font_trait.html
+++ b/_modules/traitsui/null/font_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/null/rgb_color_trait.html
+++ b/_modules/traitsui/null/rgb_color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/null/toolkit.html
+++ b/_modules/traitsui/null/toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/table_column.html
+++ b/_modules/traitsui/table_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/table_filter.html
+++ b/_modules/traitsui/table_filter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/tabular_adapter.html
+++ b/_modules/traitsui/tabular_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/testing/tester/command.html
+++ b/_modules/traitsui/testing/tester/command.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/testing/tester/exceptions.html
+++ b/_modules/traitsui/testing/tester/exceptions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/testing/tester/locator.html
+++ b/_modules/traitsui/testing/tester/locator.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/testing/tester/query.html
+++ b/_modules/traitsui/testing/tester/query.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/testing/tester/target_registry.html
+++ b/_modules/traitsui/testing/tester/target_registry.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/testing/tester/ui_tester.html
+++ b/_modules/traitsui/testing/tester/ui_tester.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/testing/tester/ui_wrapper.html
+++ b/_modules/traitsui/testing/tester/ui_wrapper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/theme.html
+++ b/_modules/traitsui/theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/toolkit.html
+++ b/_modules/traitsui/toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/toolkit_traits.html
+++ b/_modules/traitsui/toolkit_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/tree_node.html
+++ b/_modules/traitsui/tree_node.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/tree_node_renderer.html
+++ b/_modules/traitsui/tree_node_renderer.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/ui.html
+++ b/_modules/traitsui/ui.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/ui_editor.html
+++ b/_modules/traitsui/ui_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/ui_editors/array_view_editor.html
+++ b/_modules/traitsui/ui_editors/array_view_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/ui_editors/data_frame_editor.html
+++ b/_modules/traitsui/ui_editors/data_frame_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/ui_info.html
+++ b/_modules/traitsui/ui_info.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/ui_traits.html
+++ b/_modules/traitsui/ui_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/undo.html
+++ b/_modules/traitsui/undo.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/value_tree.html
+++ b/_modules/traitsui/value_tree.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/view.html
+++ b/_modules/traitsui/view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/view_element.html
+++ b/_modules/traitsui/view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_modules/traitsui/view_elements.html
+++ b/_modules/traitsui/view_elements.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/_static/documentation_options.js
+++ b/_static/documentation_options.js
@@ -1,6 +1,6 @@
 var DOCUMENTATION_OPTIONS = {
     URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
-    VERSION: '7.2.0',
+    VERSION: '7.2.1',
     LANGUAGE: 'None',
     COLLAPSE_INDEX: false,
     BUILDER: 'html',

--- a/api/index.html
+++ b/api/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.api.html
+++ b/api/traitsui.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.base_panel.html
+++ b/api/traitsui.base_panel.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.basic_editor_factory.html
+++ b/api/traitsui.basic_editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.color_column.html
+++ b/api/traitsui.color_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.context_value.html
+++ b/api/traitsui.context_value.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.default_dock_window_theme.html
+++ b/api/traitsui.default_dock_window_theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.delegating_handler.html
+++ b/api/traitsui.delegating_handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.dock_window_theme.html
+++ b/api/traitsui.dock_window_theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.dockable_view_element.html
+++ b/api/traitsui.dockable_view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editor.html
+++ b/api/traitsui.editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editor_factory.html
+++ b/api/traitsui.editor_factory.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.api.html
+++ b/api/traitsui.editors.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.array_editor.html
+++ b/api/traitsui.editors.array_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.boolean_editor.html
+++ b/api/traitsui.editors.boolean_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.button_editor.html
+++ b/api/traitsui.editors.button_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.check_list_editor.html
+++ b/api/traitsui.editors.check_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.code_editor.html
+++ b/api/traitsui.editors.code_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.color_editor.html
+++ b/api/traitsui.editors.color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.compound_editor.html
+++ b/api/traitsui.editors.compound_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.csv_list_editor.html
+++ b/api/traitsui.editors.csv_list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.custom_editor.html
+++ b/api/traitsui.editors.custom_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.date_editor.html
+++ b/api/traitsui.editors.date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.date_range_editor.html
+++ b/api/traitsui.editors.date_range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.datetime_editor.html
+++ b/api/traitsui.editors.datetime_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.default_override.html
+++ b/api/traitsui.editors.default_override.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.directory_editor.html
+++ b/api/traitsui.editors.directory_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.dnd_editor.html
+++ b/api/traitsui.editors.dnd_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.drop_editor.html
+++ b/api/traitsui.editors.drop_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.enum_editor.html
+++ b/api/traitsui.editors.enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.file_editor.html
+++ b/api/traitsui.editors.file_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.font_editor.html
+++ b/api/traitsui.editors.font_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.history_editor.html
+++ b/api/traitsui.editors.history_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.html
+++ b/api/traitsui.editors.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.html_editor.html
+++ b/api/traitsui.editors.html_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.image_editor.html
+++ b/api/traitsui.editors.image_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.image_enum_editor.html
+++ b/api/traitsui.editors.image_enum_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.instance_editor.html
+++ b/api/traitsui.editors.instance_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.key_binding_editor.html
+++ b/api/traitsui.editors.key_binding_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.list_editor.html
+++ b/api/traitsui.editors.list_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.list_str_editor.html
+++ b/api/traitsui.editors.list_str_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.null_editor.html
+++ b/api/traitsui.editors.null_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.popup_editor.html
+++ b/api/traitsui.editors.popup_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.progress_editor.html
+++ b/api/traitsui.editors.progress_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.range_editor.html
+++ b/api/traitsui.editors.range_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.rgb_color_editor.html
+++ b/api/traitsui.editors.rgb_color_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.scrubber_editor.html
+++ b/api/traitsui.editors.scrubber_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.search_editor.html
+++ b/api/traitsui.editors.search_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.set_editor.html
+++ b/api/traitsui.editors.set_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.shell_editor.html
+++ b/api/traitsui.editors.shell_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.styled_date_editor.html
+++ b/api/traitsui.editors.styled_date_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.table_editor.html
+++ b/api/traitsui.editors.table_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.tabular_editor.html
+++ b/api/traitsui.editors.tabular_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.text_editor.html
+++ b/api/traitsui.editors.text_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.time_editor.html
+++ b/api/traitsui.editors.time_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.title_editor.html
+++ b/api/traitsui.editors.title_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.tree_editor.html
+++ b/api/traitsui.editors.tree_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.tuple_editor.html
+++ b/api/traitsui.editors.tuple_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.value_editor.html
+++ b/api/traitsui.editors.value_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.editors.video_editor.html
+++ b/api/traitsui.editors.video_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.api.html
+++ b/api/traitsui.extras.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.checkbox_column.html
+++ b/api/traitsui.extras.checkbox_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.demo.html
+++ b/api/traitsui.extras.demo.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.edit_column.html
+++ b/api/traitsui.extras.edit_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.has_dynamic_views.html
+++ b/api/traitsui.extras.has_dynamic_views.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.html
+++ b/api/traitsui.extras.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.progress_column.html
+++ b/api/traitsui.extras.progress_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.extras.saving.html
+++ b/api/traitsui.extras.saving.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.file_dialog.html
+++ b/api/traitsui.file_dialog.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.group.html
+++ b/api/traitsui.group.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.handler.html
+++ b/api/traitsui.handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.help.html
+++ b/api/traitsui.help.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.help_template.html
+++ b/api/traitsui.help_template.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.helper.html
+++ b/api/traitsui.helper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.html
+++ b/api/traitsui.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.include.html
+++ b/api/traitsui.include.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.instance_choice.html
+++ b/api/traitsui.instance_choice.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.item.html
+++ b/api/traitsui.item.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.key_bindings.html
+++ b/api/traitsui.key_bindings.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.list_str_adapter.html
+++ b/api/traitsui.list_str_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.menu.html
+++ b/api/traitsui.menu.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.message.html
+++ b/api/traitsui.message.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.mimedata.html
+++ b/api/traitsui.mimedata.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.null.color_trait.html
+++ b/api/traitsui.null.color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.null.font_trait.html
+++ b/api/traitsui.null.font_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.null.html
+++ b/api/traitsui.null.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.null.rgb_color_trait.html
+++ b/api/traitsui.null.rgb_color_trait.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.null.toolkit.html
+++ b/api/traitsui.null.toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.table_column.html
+++ b/api/traitsui.table_column.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.table_filter.html
+++ b/api/traitsui.table_filter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.tabular_adapter.html
+++ b/api/traitsui.tabular_adapter.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.api.html
+++ b/api/traitsui.testing.api.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.html
+++ b/api/traitsui.testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.command.html
+++ b/api/traitsui.testing.tester.command.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.exceptions.html
+++ b/api/traitsui.testing.tester.exceptions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.html
+++ b/api/traitsui.testing.tester.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.locator.html
+++ b/api/traitsui.testing.tester.locator.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.query.html
+++ b/api/traitsui.testing.tester.query.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.target_registry.html
+++ b/api/traitsui.testing.tester.target_registry.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.ui_tester.html
+++ b/api/traitsui.testing.tester.ui_tester.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.testing.tester.ui_wrapper.html
+++ b/api/traitsui.testing.tester.ui_wrapper.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.theme.html
+++ b/api/traitsui.theme.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.toolkit.html
+++ b/api/traitsui.toolkit.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.toolkit_traits.html
+++ b/api/traitsui.toolkit_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.tree_node.html
+++ b/api/traitsui.tree_node.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.tree_node_renderer.html
+++ b/api/traitsui.tree_node_renderer.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.ui.html
+++ b/api/traitsui.ui.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.ui_editor.html
+++ b/api/traitsui.ui_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.ui_editors.array_view_editor.html
+++ b/api/traitsui.ui_editors.array_view_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.ui_editors.data_frame_editor.html
+++ b/api/traitsui.ui_editors.data_frame_editor.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.ui_editors.html
+++ b/api/traitsui.ui_editors.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.ui_info.html
+++ b/api/traitsui.ui_info.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.ui_traits.html
+++ b/api/traitsui.ui_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.undo.html
+++ b/api/traitsui.undo.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.value_tree.html
+++ b/api/traitsui.value_tree.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.view.html
+++ b/api/traitsui.view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.view_element.html
+++ b/api/traitsui.view_element.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/api/traitsui.view_elements.html
+++ b/api/traitsui.view_elements.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/changelog.html
+++ b/changelog.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',
@@ -86,6 +86,17 @@
             
   <div class="section" id="traits-ui-changelog">
 <h1>Traits UI Changelog<a class="headerlink" href="#traits-ui-changelog" title="Permalink to this headline">¶</a></h1>
+<div class="section" id="release-7-2-1">
+<h2>Release 7.2.1<a class="headerlink" href="#release-7-2-1" title="Permalink to this headline">¶</a></h2>
+<p>TraitsUI 7.2.1 is a bugfix release which updates TraitsUI to explicitly require
+Traits 6.2+ and Pyface 7.3+.</p>
+<div class="section" id="build-and-continuous-integration">
+<h3>Build and continuous integration<a class="headerlink" href="#build-and-continuous-integration" title="Permalink to this headline">¶</a></h3>
+<ul class="simple">
+<li><p>Explicitly require traits 6.2 and pyface 7.3 (#1666, #1668)</p></li>
+</ul>
+</div>
+</div>
 <div class="section" id="release-7-2-0">
 <h2>Release 7.2.0<a class="headerlink" href="#release-7-2-0" title="Permalink to this headline">¶</a></h2>
 <p>TraitsUI 7.2.0 is a minor release which includes numerous bug fixes,
@@ -94,7 +105,7 @@ documentation improvements, code maintenance changes, and enhancements.</p>
 <h3>Highlights of this release<a class="headerlink" href="#highlights-of-this-release" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>The migration from <code class="docutils literal notranslate"><span class="pre">on_trait_change</span></code> to <code class="docutils literal notranslate"><span class="pre">observe</span></code> is underway. As a
-result, TraitsUI now requires Traits &gt;= 6.1.</p></li>
+result, TraitsUI now requires Traits &gt;= 6.2.</p></li>
 <li><p>New display-only VideoEditor (currently only on Qt backend).</p></li>
 <li><p>Exapnsion of features for the new <code class="docutils literal notranslate"><span class="pre">UITester</span></code> including the ability to
 inspect UI object visibility / enabledness. Also documentation for testing
@@ -104,14 +115,15 @@ has been updated.</p></li>
 <div class="section" id="notes-on-upgrading">
 <h3>Notes on upgrading<a class="headerlink" href="#notes-on-upgrading" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
-<li><p>This release of TraitsUI now depends on Traits 6.1+. Also, deprecated code /
-modules have been removed. Namely, the <code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.image</span></code>
-module which was moved to <code class="docutils literal notranslate"><span class="pre">pyface.image</span></code>, <code class="docutils literal notranslate"><span class="pre">editors_gen</span></code> modules, Editor
-and EditorFactory factory methods on Toolkit objects, and more.  For a
-complete list, see PRs in the “Removals” section below.  These were all
-generally unused / deprecated for sometime. Also, importing directly from
-<code class="docutils literal notranslate"><span class="pre">traitsui.editors</span></code> has been deprecated. Please update imports to import
-directly from <a class="reference internal" href="api/traitsui.api.html#module-traitsui.api" title="traitsui.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.api</span></code></a> or <a class="reference internal" href="api/traitsui.editors.api.html#module-traitsui.editors.api" title="traitsui.editors.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.editors.api</span></code></a>.</p></li>
+<li><p>This release of TraitsUI now depends on Traits 6.2+ and pyface 7.3+. Also,
+deprecated code / modules have been removed. Namely, the
+<code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.image</span></code> module which was moved to
+<code class="docutils literal notranslate"><span class="pre">pyface.image</span></code>, <code class="docutils literal notranslate"><span class="pre">editors_gen</span></code> modules, Editor and EditorFactory factory
+methods on Toolkit objects, and more.  For a complete list, see PRs in the
+“Removals” section below.  These were all generally unused / deprecated for
+sometime. Also, importing directly from <code class="docutils literal notranslate"><span class="pre">traitsui.editors</span></code> has been
+deprecated. Please update imports to import directly from <a class="reference internal" href="api/traitsui.api.html#module-traitsui.api" title="traitsui.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.api</span></code></a>
+or <a class="reference internal" href="api/traitsui.editors.api.html#module-traitsui.editors.api" title="traitsui.editors.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.editors.api</span></code></a>.</p></li>
 </ul>
 </div>
 <div class="section" id="detailed-changes">
@@ -175,8 +187,8 @@ directly from <a class="reference internal" href="api/traitsui.api.html#module-t
 <li><p>Format code examples in the user documentation (#1640)</p></li>
 </ul>
 </div>
-<div class="section" id="build-and-continuous-integration">
-<h3>Build and continuous integration<a class="headerlink" href="#build-and-continuous-integration" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id1">
+<h3>Build and continuous integration<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix cron job not installing additional dependencies (#1427)</p></li>
 <li><p>Remove job on Travis for testing against Traits 6.0 (#1430)</p></li>
@@ -214,7 +226,7 @@ directly from <a class="reference internal" href="api/traitsui.api.html#module-t
 <li><p>Remove clause that deviates from PEP8 backward compatibility convention in the testing package (#1481)</p></li>
 <li><p>Formal editor interface for tooltips (#1493</p></li>
 <li><p>Add instance choice classes to traitsui.api (#1495)</p></li>
-<li><p>Undo/Redo cleanup (#1510</p></li>
+<li><p>Undo/Redo cleanup (#1510)</p></li>
 <li><p>start on_trait_change to observe migration (#1519, #1520, #1523, #1525, #1545, #1622, #1644)</p></li>
 <li><p>Refactor TreeEditor _new_actions and _menu_new_node to avoid hacky eval (#1524)</p></li>
 <li><p>Refactor _add_items method of _GroupPanel object (#1549)</p></li>
@@ -248,8 +260,8 @@ directly from <a class="reference internal" href="api/traitsui.api.html#module-t
 <h2>Release 7.1.1<a class="headerlink" href="#release-7-1-1" title="Permalink to this headline">¶</a></h2>
 <p>This is a bugfix release that fixes a number of issues since the 7.1.0 release.
 Thanks to Corran Webster and Kit Choi for the patches.</p>
-<div class="section" id="id1">
-<h3>Fixes<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id2">
+<h3>Fixes<a class="headerlink" href="#id2" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix <code class="docutils literal notranslate"><span class="pre">scrollable</span></code> trait of a Group not being implemented on Qt (#1406)</p></li>
 <li><p>Fix icon button’s clickable area too small for FileEditor and RangeEditor on
@@ -268,8 +280,8 @@ be installed separately).</p>
 <p>This release should be compatible with Traits 6.0+. Users are encouraged to
 upgrade to Traits 6.1+ to stay current as future releases of TraitsUI will
 stop supporting Traits 6.0.</p>
-<div class="section" id="id2">
-<h3>Highlights of this release<a class="headerlink" href="#id2" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id3">
+<h3>Highlights of this release<a class="headerlink" href="#id3" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>A new <a class="reference internal" href="api/traitsui.testing.api.html#module-traitsui.testing.api" title="traitsui.testing.api"><code class="xref py py-mod docutils literal notranslate"><span class="pre">traitsui.testing.api</span></code></a> module has been introduced for testing
 GUI applications built using TraitsUI. See
@@ -285,8 +297,8 @@ changed as an attempt to resolve AttributeError that occurs while a nested
 UI is removed.</p></li>
 </ul>
 </div>
-<div class="section" id="id3">
-<h3>Notes on upgrading<a class="headerlink" href="#id3" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id4">
+<h3>Notes on upgrading<a class="headerlink" href="#id4" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>On the issue about Qt button not causing views to update on OSX, projects
 that have been working around the issue by adding <code class="docutils literal notranslate"><span class="pre">GUI().process_events()</span></code>
@@ -309,8 +321,8 @@ ago and has since been deprecated. Previously it was scheduled to be removed
 in TraitsUI 6.0. This planned removal is now deferred to TraitsUI 7.2.</p></li>
 </ul>
 </div>
-<div class="section" id="id4">
-<h3>Detailed changes<a class="headerlink" href="#id4" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id5">
+<h3>Detailed changes<a class="headerlink" href="#id5" title="Permalink to this headline">¶</a></h3>
 <p>More than 100 PRs went into this release. Thanks to:</p>
 <ul class="simple">
 <li><p>Aaron Ayres</p></li>
@@ -335,8 +347,8 @@ been omitted.</p>
 applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 </ul>
 </div>
-<div class="section" id="id5">
-<h3>Fixes<a class="headerlink" href="#id5" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id6">
+<h3>Fixes<a class="headerlink" href="#id6" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix AttributeError when a nested UI is disposed (#1286)</p></li>
 <li><p>Fix wx error due to use of alignment flag wxEXPAND (#1095)</p></li>
@@ -351,8 +363,8 @@ applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 <li><p>Fix deprecation warnings from using ABC in collections (#1103, #1129)</p></li>
 </ul>
 </div>
-<div class="section" id="id6">
-<h3>Documentation<a class="headerlink" href="#id6" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id7">
+<h3>Documentation<a class="headerlink" href="#id7" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Make demo examples as package data (#1088)</p></li>
 <li><p>Add UITester documentation in User Manual (#1263)</p></li>
@@ -361,8 +373,8 @@ applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 <li><p>Generate API documentation automatically (#1368)</p></li>
 </ul>
 </div>
-<div class="section" id="id7">
-<h3>Build and continuous integration<a class="headerlink" href="#id7" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id8">
+<h3>Build and continuous integration<a class="headerlink" href="#id8" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add a CI job for testing against traits 6.0 (#1108)</p></li>
 <li><p>Move MacOS CI build from Travis to Appveyor (#1160)</p></li>
@@ -371,8 +383,8 @@ applications (#1107, #1157, #1171, #1175, #1179, #1201, #1207, #1269)</p></li>
 <li><p>Explicitly require a minimum version for Traits (#1323)</p></li>
 </ul>
 </div>
-<div class="section" id="id8">
-<h3>Maintenance and code organization<a class="headerlink" href="#id8" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id9">
+<h3>Maintenance and code organization<a class="headerlink" href="#id9" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Relax constraint on PySide2 version (#1146)</p></li>
 <li><p>Update edm version in travis and appveyor config files (#1049)</p></li>
@@ -391,8 +403,8 @@ It includes fixes to various editors, improvements to tests and fixes to the
 demo application.</p>
 <p>Thanks to Ieva Cerny, Kit Choi, Mark Dickinson, Robert Kern, Eric Larson,
 Federico Miorelli, Joris Vankerschaver, Corran Webster.</p>
-<div class="section" id="id9">
-<h3>Fixes<a class="headerlink" href="#id9" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id10">
+<h3>Fixes<a class="headerlink" href="#id10" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix error from true division of integers for Qt RangeEditor and BoundsEditor
 (#999, #1000)</p></li>
@@ -412,8 +424,8 @@ items (#875)</p></li>
 <li><p>Fix error from example’s tutor.py script (#813)</p></li>
 </ul>
 </div>
-<div class="section" id="id10">
-<h3>Documentation<a class="headerlink" href="#id10" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id11">
+<h3>Documentation<a class="headerlink" href="#id11" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add links from TabularEditor and TreeEditor to adapter documentation (#917)</p></li>
 </ul>
@@ -457,8 +469,8 @@ unifying the demo viewer codebase.</p>
 Hancock, Sandhya Govindaraju, Midhun Madhusoodanan, Rob McMullen, Shoeb
 Mohammed, Eric Olsen, Roberto Preste, reckoner, Jonathan Rocher, Scott
 Talbert, Corran Webster.</p>
-<div class="section" id="id11">
-<h3>Enhancements<a class="headerlink" href="#id11" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id12">
+<h3>Enhancements<a class="headerlink" href="#id12" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Documentation improvements (#720, #724, #723, #778)</p></li>
 <li><p>WxPython 4 compatibility and support (#708, #736, #762, #772, #775, #776)</p></li>
@@ -475,8 +487,8 @@ Talbert, Corran Webster.</p>
 <li><p>Enhancements to CI and testing (#683, #714, #740)</p></li>
 </ul>
 </div>
-<div class="section" id="id12">
-<h3>Fixes<a class="headerlink" href="#id12" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id13">
+<h3>Fixes<a class="headerlink" href="#id13" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Documentation fixes (#546, #766)</p></li>
 <li><p>Fix cgi.escape for Python 3.8 (#780)</p></li>
@@ -502,8 +514,8 @@ TableEditor and TabularEditor for the Qt toolkit which didn’t match
 the advertised behaviour in the documentation.</p>
 <p>Thanks to Qi Chen, Vladimir Chukharev, Mark Dickinson, Sandhya Govindaraju,
 Maxwell Grady, Scott Maddox, Sean Parsons, Rahul Poruri, Corran Webster.</p>
-<div class="section" id="id13">
-<h3>Fixes<a class="headerlink" href="#id13" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id14">
+<h3>Fixes<a class="headerlink" href="#id14" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add “bool” to allowed types for TableColumn (#656)</p></li>
 <li><p>Fix tabular editor column widths (#652)</p></li>
@@ -532,8 +544,8 @@ Maxwell Grady, Scott Maddox, Sean Parsons, Rahul Poruri, Corran Webster.</p>
 the usability of Mayavi.</p>
 <p>Thanks to Mark Dickinson, Maxwell Grady, Prabhu Ramachandran, Matt Reay,
 Ajeet Vivekanandan, Corran Webster, John Wiggins.</p>
-<div class="section" id="id14">
-<h3>Fixes<a class="headerlink" href="#id14" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id15">
+<h3>Fixes<a class="headerlink" href="#id15" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix tree node copy failure to copy (#590)</p></li>
 <li><p>Fix/scroll to row preserve column (#588)</p></li>
@@ -552,8 +564,8 @@ Ajeet Vivekanandan, Corran Webster, John Wiggins.</p>
 <div class="section" id="release-6-1-1">
 <h2>Release 6.1.1<a class="headerlink" href="#release-6-1-1" title="Permalink to this headline">¶</a></h2>
 <p>A bugfix release to correct some critical issues with the TreeEditor.</p>
-<div class="section" id="id15">
-<h3>Fixes<a class="headerlink" href="#id15" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id16">
+<h3>Fixes<a class="headerlink" href="#id16" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix TreeNodeObject listener cache (#558).</p></li>
 <li><p>Fix tree node insertion (#561).</p></li>
@@ -603,8 +615,8 @@ Roger Serwy, Ajeet Vivekanandan, Corran Webster, John Wiggins.</p>
 <li><p>Allow drag move and drag copy modes on Qt TabularEditor (#363).</p></li>
 </ul>
 </div>
-<div class="section" id="id16">
-<h3>Fixes<a class="headerlink" href="#id16" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id17">
+<h3>Fixes<a class="headerlink" href="#id17" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fixes to README (#478).</p></li>
 <li><p>Documentation fixes (#471, #508).</p></li>
@@ -679,8 +691,8 @@ Pradyun Gedam, Robert Kern, Marika Murphy, Pankaj Pandey, Steve Peak,
 Prabhu Ramachandran, Jonathan Rocher, John Thacker, Gregor Thalhammer,
 Senganal Thirunavukkarasu, John Tyree, Ioannis Tziakos, Alona Varshal,
 Corran Webster, John Wiggins</p>
-<div class="section" id="id17">
-<h3>Enhancements<a class="headerlink" href="#id17" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id18">
+<h3>Enhancements<a class="headerlink" href="#id18" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Support for Qt5 (#347, #352, #350, #433)</p></li>
 <li><p>Remove TraitsUI Themes (#342)</p></li>
@@ -704,8 +716,8 @@ Corran Webster, John Wiggins</p>
 <li><p>Add codecov coverage reports (#285, #328)</p></li>
 </ul>
 </div>
-<div class="section" id="id18">
-<h3>Fixes<a class="headerlink" href="#id18" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id19">
+<h3>Fixes<a class="headerlink" href="#id19" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix some issues for newer WxPython (#418)</p></li>
 <li><p>Fix Wx simple FileEditor (#426)</p></li>
@@ -741,8 +753,8 @@ Corran Webster, John Wiggins</p>
 </div>
 <div class="section" id="release-5-2-0">
 <h2>Release 5.2.0<a class="headerlink" href="#release-5-2-0" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id19">
-<h3>Enhancements<a class="headerlink" href="#id19" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id20">
+<h3>Enhancements<a class="headerlink" href="#id20" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add support for multi-select in the DataFrameEditor (#413).</p></li>
 </ul>
@@ -750,8 +762,8 @@ Corran Webster, John Wiggins</p>
 </div>
 <div class="section" id="release-5-1-0">
 <h2>Release 5.1.0<a class="headerlink" href="#release-5-1-0" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id20">
-<h3>Enhancements<a class="headerlink" href="#id20" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id21">
+<h3>Enhancements<a class="headerlink" href="#id21" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Enthought Sphinx Theme Support (#219)</p></li>
 <li><p>Allow hiding groups in split layouts on Qt (#246)</p></li>
@@ -759,8 +771,8 @@ Corran Webster, John Wiggins</p>
 <li><p>Add toolbar in Qt UI panel (#263)</p></li>
 </ul>
 </div>
-<div class="section" id="id21">
-<h3>Fixes<a class="headerlink" href="#id21" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id22">
+<h3>Fixes<a class="headerlink" href="#id22" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix Qt TableEditor segfault on editing close (#277)</p></li>
 <li><p>Update tree nodes when adding children to am empty tree (#251)</p></li>
@@ -800,8 +812,8 @@ use explicitly.</p>
 (#196)</p></li>
 </ul>
 </div>
-<div class="section" id="id22">
-<h3>Enhancements<a class="headerlink" href="#id22" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id23">
+<h3>Enhancements<a class="headerlink" href="#id23" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Change the default backend from Wx to Qt (#212)</p></li>
 <li><p>Add a Qt version of the ProgressEditor (#217)</p></li>
@@ -810,8 +822,8 @@ use explicitly.</p>
 Editor. (#143)</p></li>
 </ul>
 </div>
-<div class="section" id="id23">
-<h3>Fixes<a class="headerlink" href="#id23" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id24">
+<h3>Fixes<a class="headerlink" href="#id24" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix failure to disconnect selection listeners for ListStrEditor in Qt (#223)</p></li>
 <li><p>Fix layout of TextEditors in some situations (#216)</p></li>
@@ -823,8 +835,8 @@ Editor. (#143)</p></li>
 </div>
 <div class="section" id="release-4-5-1">
 <h2>Release 4.5.1<a class="headerlink" href="#release-4-5-1" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id24">
-<h3>Fixes<a class="headerlink" href="#id24" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id25">
+<h3>Fixes<a class="headerlink" href="#id25" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fix pypi installation problem (#206)</p></li>
 </ul>
@@ -832,8 +844,8 @@ Editor. (#143)</p></li>
 </div>
 <div class="section" id="release-4-5-0">
 <h2>Release 4.5.0<a class="headerlink" href="#release-4-5-0" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id25">
-<h3>Fixes<a class="headerlink" href="#id25" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id26">
+<h3>Fixes<a class="headerlink" href="#id26" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Application-modal Traits UI dialogs are correctly styled as
 application-modal under Qt. On Macs, they will now appear as independent
@@ -859,14 +871,14 @@ in Traits 4.4.0.  Other than that, there are a number of other minor changes,
 improvements and bugfixes.</p>
 <p>Corran Webster (corranwebster on GitHub) is now maintainer of TraitsUI.</p>
 <p>Change summary since 4.3.0</p>
-<div class="section" id="id26">
-<h3>New Features<a class="headerlink" href="#id26" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id27">
+<h3>New Features<a class="headerlink" href="#id27" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Changes for new Traits adaptation mechanism support (#113)</p></li>
 </ul>
 </div>
-<div class="section" id="id27">
-<h3>Enhancements<a class="headerlink" href="#id27" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id28">
+<h3>Enhancements<a class="headerlink" href="#id28" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Add Travis-CI support.</p></li>
 <li><p>Remove the use of the deprecated PySimpleApp under Wx and several other
@@ -877,8 +889,8 @@ support.  Should be roughly on par with Wx support.  No API changes.
 <li><p>Improvements to PyMimeData coercion to better handle lists of items. (#127)</p></li>
 </ul>
 </div>
-<div class="section" id="id28">
-<h3>Fixes<a class="headerlink" href="#id28" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id29">
+<h3>Fixes<a class="headerlink" href="#id29" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Fixes item selection issue #133 in ListStrEditor under Wx 2.9 (#137)</p></li>
 <li><p>Fixes to avoid asking for value of a Delegated Event (#123 and #136)</p></li>
@@ -894,8 +906,8 @@ before this file was created.</p>
 </div>
 <div class="section" id="traits-3-5-0-oct-15-2010">
 <h2>Traits 3.5.0 (Oct 15, 2010)<a class="headerlink" href="#traits-3-5-0-oct-15-2010" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id29">
-<h3>Enhancements<a class="headerlink" href="#id29" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id30">
+<h3>Enhancements<a class="headerlink" href="#id30" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>adding support for drop-down menu in Button traits, but only for qt backend</p></li>
 <li><p>adding ‘show_notebook_menu’ option to ListEditor so that the user can
@@ -904,8 +916,8 @@ right-click and show or hide the context menu (Qt)</p></li>
 selected text</p></li>
 </ul>
 </div>
-<div class="section" id="id30">
-<h3>Fixes<a class="headerlink" href="#id30" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id31">
+<h3>Fixes<a class="headerlink" href="#id31" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>fixed null color editor to work with tuples</p></li>
 <li><p>bug when opening a view with the ToolbarButton</p></li>
@@ -914,14 +926,14 @@ selected text</p></li>
 </div>
 <div class="section" id="traits-3-4-0-may-26-2010">
 <h2>Traits 3.4.0 (May 26, 2010)<a class="headerlink" href="#traits-3-4-0-may-26-2010" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id31">
-<h3>Enhancements<a class="headerlink" href="#id31" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id32">
+<h3>Enhancements<a class="headerlink" href="#id32" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>adding new example to make testing rgb color editor easier</p></li>
 </ul>
 </div>
-<div class="section" id="id32">
-<h3>Fixes<a class="headerlink" href="#id32" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id33">
+<h3>Fixes<a class="headerlink" href="#id33" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>fixed NumericColumn to not expect object to have model_selection attribute,
 and removed more dead theming code</p></li>
@@ -936,8 +948,8 @@ first before using os.path.isfile()</p></li>
 </div>
 <div class="section" id="traits-3-3-0-feb-24-2010">
 <h2>Traits 3.3.0 (Feb 24, 2010)<a class="headerlink" href="#traits-3-3-0-feb-24-2010" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id33">
-<h3>Enhancements<a class="headerlink" href="#id33" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id34">
+<h3>Enhancements<a class="headerlink" href="#id34" title="Permalink to this headline">¶</a></h3>
 <p>The major enhancement this release is that the entire Traits package has been
 changed to use relative imports so that it can be installed as a sub-package
 inside another larger library or package.  This was not previously possible,
@@ -945,8 +957,8 @@ since the various modules inside Traits would import each other directly
 through “traits.[module]”.  Many thanks to Darren Dale for the
 patch.</p>
 </div>
-<div class="section" id="id34">
-<h3>Fixes<a class="headerlink" href="#id34" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id35">
+<h3>Fixes<a class="headerlink" href="#id35" title="Permalink to this headline">¶</a></h3>
 <p>There have been numerous minor bugfixes since the last release.  The most notable
 ones are:</p>
 <ul class="simple">
@@ -964,8 +976,8 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
 </div>
 <div class="section" id="traits-3-2-0-july-15-2009">
 <h2>Traits 3.2.0 (July 15, 2009)<a class="headerlink" href="#traits-3-2-0-july-15-2009" title="Permalink to this headline">¶</a></h2>
-<div class="section" id="id35">
-<h3>Enhancements<a class="headerlink" href="#id35" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id36">
+<h3>Enhancements<a class="headerlink" href="#id36" title="Permalink to this headline">¶</a></h3>
 <ul class="simple">
 <li><p>Implemented editable_labels attribute in the TabularEditor for enabling editing of the labels (i.e. the first column)</p></li>
 <li><p>Saving/restoring window positions works with multiple displays of different sizes</p></li>
@@ -983,8 +995,8 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
 <li><p>Removed sys.exit() call from SaveHandler.exit()</p></li>
 </ul>
 </div>
-<div class="section" id="id36">
-<h3>Fixes<a class="headerlink" href="#id36" title="Permalink to this headline">¶</a></h3>
+<div class="section" id="id37">
+<h3>Fixes<a class="headerlink" href="#id37" title="Permalink to this headline">¶</a></h3>
 </div>
 </div>
 </div>
@@ -1001,6 +1013,10 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
   <h3><a href="index.html">Table of Contents</a></h3>
   <ul>
 <li><a class="reference internal" href="#">Traits UI Changelog</a><ul>
+<li><a class="reference internal" href="#release-7-2-1">Release 7.2.1</a><ul>
+<li><a class="reference internal" href="#build-and-continuous-integration">Build and continuous integration</a></li>
+</ul>
+</li>
 <li><a class="reference internal" href="#release-7-2-0">Release 7.2.0</a><ul>
 <li><a class="reference internal" href="#highlights-of-this-release">Highlights of this release</a></li>
 <li><a class="reference internal" href="#notes-on-upgrading">Notes on upgrading</a></li>
@@ -1008,108 +1024,108 @@ been eliminated and normalized (tabs/spaces, line endings).</p></li>
 <li><a class="reference internal" href="#enhancements">Enhancements</a></li>
 <li><a class="reference internal" href="#fixes">Fixes</a></li>
 <li><a class="reference internal" href="#documentation">Documentation</a></li>
-<li><a class="reference internal" href="#build-and-continuous-integration">Build and continuous integration</a></li>
+<li><a class="reference internal" href="#id1">Build and continuous integration</a></li>
 <li><a class="reference internal" href="#test-suite">Test suite</a></li>
 <li><a class="reference internal" href="#maintenance-and-code-organization">Maintenance and code organization</a></li>
 <li><a class="reference internal" href="#removals">Removals</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-1-1">Release 7.1.1</a><ul>
-<li><a class="reference internal" href="#id1">Fixes</a></li>
+<li><a class="reference internal" href="#id2">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-1-0">Release 7.1.0</a><ul>
-<li><a class="reference internal" href="#id2">Highlights of this release</a></li>
-<li><a class="reference internal" href="#id3">Notes on upgrading</a></li>
+<li><a class="reference internal" href="#id3">Highlights of this release</a></li>
+<li><a class="reference internal" href="#id4">Notes on upgrading</a></li>
 <li><a class="reference internal" href="#future-removals">Future removals</a></li>
-<li><a class="reference internal" href="#id4">Detailed changes</a></li>
+<li><a class="reference internal" href="#id5">Detailed changes</a></li>
 <li><a class="reference internal" href="#features">Features</a></li>
-<li><a class="reference internal" href="#id5">Fixes</a></li>
-<li><a class="reference internal" href="#id6">Documentation</a></li>
-<li><a class="reference internal" href="#id7">Build and continuous integration</a></li>
-<li><a class="reference internal" href="#id8">Maintenance and code organization</a></li>
+<li><a class="reference internal" href="#id6">Fixes</a></li>
+<li><a class="reference internal" href="#id7">Documentation</a></li>
+<li><a class="reference internal" href="#id8">Build and continuous integration</a></li>
+<li><a class="reference internal" href="#id9">Maintenance and code organization</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-0-1">Release 7.0.1</a><ul>
-<li><a class="reference internal" href="#id9">Fixes</a></li>
-<li><a class="reference internal" href="#id10">Documentation</a></li>
+<li><a class="reference internal" href="#id10">Fixes</a></li>
+<li><a class="reference internal" href="#id11">Documentation</a></li>
 <li><a class="reference internal" href="#tests">Tests</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-7-0-0">Release 7.0.0</a><ul>
-<li><a class="reference internal" href="#id11">Enhancements</a></li>
-<li><a class="reference internal" href="#id12">Fixes</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#release-6-1-3">Release 6.1.3</a><ul>
+<li><a class="reference internal" href="#id12">Enhancements</a></li>
 <li><a class="reference internal" href="#id13">Fixes</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#release-6-1-2">Release 6.1.2</a><ul>
+<li><a class="reference internal" href="#release-6-1-3">Release 6.1.3</a><ul>
 <li><a class="reference internal" href="#id14">Fixes</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#release-6-1-1">Release 6.1.1</a><ul>
+<li><a class="reference internal" href="#release-6-1-2">Release 6.1.2</a><ul>
 <li><a class="reference internal" href="#id15">Fixes</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#release-6-1-1">Release 6.1.1</a><ul>
+<li><a class="reference internal" href="#id16">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-6-1-0">Release 6.1.0</a><ul>
 <li><a class="reference internal" href="#enhancemenrs">Enhancemenrs</a></li>
-<li><a class="reference internal" href="#id16">Fixes</a></li>
+<li><a class="reference internal" href="#id17">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-6-0-0">Release 6.0.0</a><ul>
-<li><a class="reference internal" href="#id17">Enhancements</a></li>
-<li><a class="reference internal" href="#id18">Fixes</a></li>
+<li><a class="reference internal" href="#id18">Enhancements</a></li>
+<li><a class="reference internal" href="#id19">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-5-2-0">Release 5.2.0</a><ul>
-<li><a class="reference internal" href="#id19">Enhancements</a></li>
+<li><a class="reference internal" href="#id20">Enhancements</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-5-1-0">Release 5.1.0</a><ul>
-<li><a class="reference internal" href="#id20">Enhancements</a></li>
-<li><a class="reference internal" href="#id21">Fixes</a></li>
+<li><a class="reference internal" href="#id21">Enhancements</a></li>
+<li><a class="reference internal" href="#id22">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#release-5-0-0">Release 5.0.0</a><ul>
 <li><a class="reference internal" href="#new-features">New Features</a></li>
-<li><a class="reference internal" href="#id22">Enhancements</a></li>
-<li><a class="reference internal" href="#id23">Fixes</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#release-4-5-1">Release 4.5.1</a><ul>
+<li><a class="reference internal" href="#id23">Enhancements</a></li>
 <li><a class="reference internal" href="#id24">Fixes</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#release-4-5-0">Release 4.5.0</a><ul>
+<li><a class="reference internal" href="#release-4-5-1">Release 4.5.1</a><ul>
 <li><a class="reference internal" href="#id25">Fixes</a></li>
 </ul>
 </li>
+<li><a class="reference internal" href="#release-4-5-0">Release 4.5.0</a><ul>
+<li><a class="reference internal" href="#id26">Fixes</a></li>
+</ul>
+</li>
 <li><a class="reference internal" href="#release-4-4-0">Release 4.4.0</a><ul>
-<li><a class="reference internal" href="#id26">New Features</a></li>
-<li><a class="reference internal" href="#id27">Enhancements</a></li>
-<li><a class="reference internal" href="#id28">Fixes</a></li>
+<li><a class="reference internal" href="#id27">New Features</a></li>
+<li><a class="reference internal" href="#id28">Enhancements</a></li>
+<li><a class="reference internal" href="#id29">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-5-0-oct-15-2010">Traits 3.5.0 (Oct 15, 2010)</a><ul>
-<li><a class="reference internal" href="#id29">Enhancements</a></li>
-<li><a class="reference internal" href="#id30">Fixes</a></li>
+<li><a class="reference internal" href="#id30">Enhancements</a></li>
+<li><a class="reference internal" href="#id31">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-4-0-may-26-2010">Traits 3.4.0 (May 26, 2010)</a><ul>
-<li><a class="reference internal" href="#id31">Enhancements</a></li>
-<li><a class="reference internal" href="#id32">Fixes</a></li>
+<li><a class="reference internal" href="#id32">Enhancements</a></li>
+<li><a class="reference internal" href="#id33">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-3-0-feb-24-2010">Traits 3.3.0 (Feb 24, 2010)</a><ul>
-<li><a class="reference internal" href="#id33">Enhancements</a></li>
-<li><a class="reference internal" href="#id34">Fixes</a></li>
+<li><a class="reference internal" href="#id34">Enhancements</a></li>
+<li><a class="reference internal" href="#id35">Fixes</a></li>
 </ul>
 </li>
 <li><a class="reference internal" href="#traits-3-2-0-july-15-2009">Traits 3.2.0 (July 15, 2009)</a><ul>
-<li><a class="reference internal" href="#id35">Enhancements</a></li>
-<li><a class="reference internal" href="#id36">Fixes</a></li>
+<li><a class="reference internal" href="#id36">Enhancements</a></li>
+<li><a class="reference internal" href="#id37">Fixes</a></li>
 </ul>
 </li>
 </ul>

--- a/demos/index.html
+++ b/demos/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/genindex.html
+++ b/genindex.html
@@ -15,7 +15,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',
@@ -107,6 +107,7 @@
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="changelog.html">Traits UI Changelog</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-2-1">Release 7.2.1</a></li>
 <li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-2-0">Release 7.2.0</a></li>
 <li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-1-1">Release 7.1.1</a></li>
 <li class="toctree-l2"><a class="reference internal" href="changelog.html#release-7-1-0">Release 7.1.0</a></li>

--- a/py-modindex.html
+++ b/py-modindex.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/search.html
+++ b/search.html
@@ -15,7 +15,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    './',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_dev_guide/index.html
+++ b/traitsui_dev_guide/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_dev_guide/testing.html
+++ b/traitsui_dev_guide/testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/adapters.html
+++ b/traitsui_user_manual/adapters.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/advanced_view.html
+++ b/traitsui_user_manual/advanced_view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/custom_view.html
+++ b/traitsui_user_manual/custom_view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/factories_advanced_extra.html
+++ b/traitsui_user_manual/factories_advanced_extra.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/factories_basic.html
+++ b/traitsui_user_manual/factories_basic.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/factory_intro.html
+++ b/traitsui_user_manual/factory_intro.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/glossary.html
+++ b/traitsui_user_manual/glossary.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/handler.html
+++ b/traitsui_user_manual/handler.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/index.html
+++ b/traitsui_user_manual/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/intro.html
+++ b/traitsui_user_manual/intro.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/predefined_traits.html
+++ b/traitsui_user_manual/predefined_traits.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing.html
+++ b/traitsui_user_manual/testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/discussions/automated_vs_manual_test.html
+++ b/traitsui_user_manual/testing/discussions/automated_vs_manual_test.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/discussions/compatibility_pyface_testing.html
+++ b/traitsui_user_manual/testing/discussions/compatibility_pyface_testing.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/discussions/debugging-gui-tests-at-runtime.html
+++ b/traitsui_user_manual/testing/discussions/debugging-gui-tests-at-runtime.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/discussions/event_loop_and_exceptions.html
+++ b/traitsui_user_manual/testing/discussions/event_loop_and_exceptions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/discussions/target_interaction_location.html
+++ b/traitsui_user_manual/testing/discussions/target_interaction_location.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/discussions/working_of_extensions.html
+++ b/traitsui_user_manual/testing/discussions/working_of_extensions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/howtos/add_new_interaction.html
+++ b/traitsui_user_manual/testing/howtos/add_new_interaction.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/howtos/add_new_location.html
+++ b/traitsui_user_manual/testing/howtos/add_new_location.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/references/examples.html
+++ b/traitsui_user_manual/testing/references/examples.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/substitutions.html
+++ b/traitsui_user_manual/testing/substitutions.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/tutorials/first_test.html
+++ b/traitsui_user_manual/testing/tutorials/first_test.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/testing/tutorials/test_with_nested_object.html
+++ b/traitsui_user_manual/testing/tutorials/test_with_nested_object.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../../../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/tips.html
+++ b/traitsui_user_manual/tips.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/traitsui_user_manual/view.html
+++ b/traitsui_user_manual/view.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/tutorials/index.html
+++ b/tutorials/index.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',

--- a/tutorials/traits_ui_scientific_app.html
+++ b/tutorials/traits_ui_scientific_app.html
@@ -14,7 +14,7 @@
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
         URL_ROOT:    '../',
-        VERSION:     '7.2.0',
+        VERSION:     '7.2.1',
         COLLAPSE_INDEX: false,
         FILE_SUFFIX: '.html',
         LINK_SUFFIX: '',


### PR DESCRIPTION
Targeting [gh-pages]

The steps taken followed those described on #1425 

```
git clean -ffxd
git checkout 7.2.1
python etstool.py install --toolkit=pyqt5
python etstool.py docs --toolkit=pyqt5
git checkout gh-pages
git pull
git checkout -b gh-pages-7.2.1
rm -rf 7.2
mkdir 7.2
rsync -r --exclude="\.buildinfo" docs/build/html/* 7.2/
rm -r `ls -d [![:digit:]]*`
cp -r 7.2/* .
```

To test:
```
python -m http.server
```
I checked the changelog is updated and tried search.  In general there are no documentation changes in 7.2.1 from 7.2.0

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~