### PR TITLE
Call HasPrivateTraits.__init__() in GroupEditor.__init__

### DIFF
--- a/docs/releases/upcoming/1674.bugfix.rst
+++ b/docs/releases/upcoming/1674.bugfix.rst
@@ -1,0 +1,1 @@
+Call HasPrivateTraits.__init__() in GroupEditor.__init__ (#1674)

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -28,7 +28,7 @@ import re
 
 from pyface.qt import QtCore, QtGui
 
-from traits.api import Any, Instance, Undefined, HasPrivateTraits
+from traits.api import Any, Instance, HasPrivateTraits, Undefined
 from traits.observation.api import match
 
 from traitsui.api import Group

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -28,7 +28,7 @@ import re
 
 from pyface.qt import QtCore, QtGui
 
-from traits.api import Any, Instance, Undefined
+from traits.api import Any, Instance, Undefined, HasPrivateTraits
 from traits.observation.api import match
 
 from traitsui.api import Group
@@ -1259,6 +1259,7 @@ class GroupEditor(Editor):
     def __init__(self, **traits):
         """ Initialise the object.
         """
+        HasPrivateTraits.__init__(self, **traits)
         self.trait_set(**traits)
 
 

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1259,6 +1259,9 @@ class GroupEditor(Editor):
     def __init__(self, **traits):
         """ Initialise the object.
         """
+        # We intentionally don't want to call Editor.__init__ here as
+        # GroupEditor does its own thing. However, we still want Traits
+        # machinery to be set up properly.
         HasPrivateTraits.__init__(self, **traits)
         self.trait_set(**traits)
 

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -28,7 +28,7 @@ import re
 
 from pyface.qt import QtCore, QtGui
 
-from traits.api import Any, Instance, HasPrivateTraits, Undefined
+from traits.api import Any, HasPrivateTraits, Instance, Undefined
 from traits.observation.api import match
 
 from traitsui.api import Group


### PR DESCRIPTION
Part of #1673 

This PR takes the simpler quick fix approach as mentioned in this comment: https://github.com/enthought/traitsui/issues/1673#issuecomment-843282178

It is certainly worth the investigation into the alternate approach described in that comment.  This was just a very simple fix that could be done in the short term

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)