### PR TITLE
Add RangeEditor support for format_func

### DIFF
--- a/docs/releases/upcoming/1684.bugfix.rst
+++ b/docs/releases/upcoming/1684.bugfix.rst
@@ -1,0 +1,1 @@
+Add RangeEditor support for format_func (#1684)

--- a/docs/releases/upcoming/1684.bugfix.rst
+++ b/docs/releases/upcoming/1684.bugfix.rst
@@ -1,1 +1,2 @@
-Add RangeEditor support for format_func (#1684)
+Add RangeEditor support for format_func and deprecate ``format`` trait on
+RangeEditor factory / toolkit specific Editor implementations (#1684)

--- a/traitsui/editors/range_editor.py
+++ b/traitsui/editors/range_editor.py
@@ -69,6 +69,7 @@ class RangeEditor(EditorFactory):
     format_str = Str("%s")
 
     #: Deprecated: Please use ``format_str`` instead.
+    #: See enthought/traitsui#1704
     #: Formatting string used to format value and labels.
     format = Property(Str, observe='format_str')
 

--- a/traitsui/editors/range_editor.py
+++ b/traitsui/editors/range_editor.py
@@ -10,6 +10,7 @@
 
 """ Defines the range editor factory for all traits user interface toolkits.
 """
+import warnings
 
 from types import CodeType
 
@@ -64,8 +65,11 @@ class RangeEditor(EditorFactory):
     #: The name of an [object.]trait that defines the high value for the range
     high_name = Str()
 
-    #: Formatting string used to format value and labels
-    format = Str("%s")
+    # set format_str default
+    format_str = Str("%s")
+
+    #: Deprecated: Formatting string used to format value and labels
+    format = Property(Str, observe='format_str')
 
     #: Is the range for floating pointer numbers (vs. integers)?
     is_float = Bool(Undefined)
@@ -194,6 +198,23 @@ class RangeEditor(EditorFactory):
     # -------------------------------------------------------------------------
     #  Property getters.
     # -------------------------------------------------------------------------
+
+    def _get_format(self):
+        warnings.warn(
+            "Use of format trait is deprecated. Use format_str instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.format_str
+
+    def _set_format(self, format_string):
+        warnings.warn(
+            "Use of format trait is deprecated. Use format_str instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.format_str = format_string
+
     def _get_simple_editor_class(self):
         """ Returns the editor class to use for a simple style.
 
@@ -283,30 +304,6 @@ class RangeEditor(EditorFactory):
             ui
         )
         return super().custom_editor(ui, object, name, description, parent)
-
-    def string_value(self, value, format_func=None):
-        """ Returns the text representation of a specified object trait value.
-
-        If the **format_func** attribute is set on the editor factory, then
-        this method calls that function to do the formatting.  If the
-        **format** attribute is set on the editor factory, then this
-        method uses that string for formatting. If neither attribute is
-        set, then this method just calls the appropriate text type to format.
-
-        This is slightly modified for the base EditorFactory inplementation to
-        use this class' ``format`` trait, as opposed to the ``format_str``
-        trait defined on the base class.
-        """
-        if self.format_func is not None:
-            return self.format_func(value)
-
-        if self.format != "":
-            return self.format % value
-
-        if format_func is not None:
-            return format_func(value)
-
-        return str(value)
 
 
 # This alias is deprecated and will be removed in TraitsUI 8.

--- a/traitsui/editors/range_editor.py
+++ b/traitsui/editors/range_editor.py
@@ -301,7 +301,7 @@ class RangeEditor(EditorFactory):
             return self.format_func(value)
 
         if self.format != "":
-            return self.format_str % value
+            return self.format % value
 
         if format_func is not None:
             return format_func(value)

--- a/traitsui/editors/range_editor.py
+++ b/traitsui/editors/range_editor.py
@@ -284,6 +284,30 @@ class RangeEditor(EditorFactory):
         )
         return super().custom_editor(ui, object, name, description, parent)
 
+    def string_value(self, value, format_func=None):
+        """ Returns the text representation of a specified object trait value.
+
+        If the **format_func** attribute is set on the editor factory, then
+        this method calls that function to do the formatting.  If the
+        **format** attribute is set on the editor factory, then this
+        method uses that string for formatting. If neither attribute is
+        set, then this method just calls the appropriate text type to format.
+
+        This is slightly modified for the base EditorFactory inplementation to
+        use this class' ``format`` trait, as opposed to the ``format_str``
+        trait defined on the base class.
+        """
+        if self.format_func is not None:
+            return self.format_func(value)
+
+        if self.format != "":
+            return self.format_str % value
+
+        if format_func is not None:
+            return format_func(value)
+
+        return str(value)
+
 
 # This alias is deprecated and will be removed in TraitsUI 8.
 ToolkitEditorFactory = RangeEditor

--- a/traitsui/editors/range_editor.py
+++ b/traitsui/editors/range_editor.py
@@ -65,10 +65,11 @@ class RangeEditor(EditorFactory):
     #: The name of an [object.]trait that defines the high value for the range
     high_name = Str()
 
-    # set format_str default
+    #: Formatting string used to format value and labels
     format_str = Str("%s")
 
-    #: Deprecated: Formatting string used to format value and labels
+    #: Deprecated: Please use ``format_str`` instead.
+    #: Formatting string used to format value and labels.
     format = Property(Str, observe='format_str')
 
     #: Is the range for floating pointer numbers (vs. integers)?

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -111,7 +111,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         try:
             if not (self.low <= fvalue <= self.high):
                 fvalue = self.low
-            fvalue_text = self.format % fvalue
+            fvalue_text = self.factory.string_value(fvalue)
         except:
             fvalue_text = ""
             fvalue = self.low
@@ -153,11 +153,11 @@ class SimpleSliderEditor(BaseRangeEditor):
 
         low_label = factory.low_label
         if factory.low_name != "":
-            low_label = self.format % self.low
+            low_label = self.factory.string_value(self.low)
 
         high_label = factory.high_label
         if factory.high_name != "":
-            high_label = self.format % self.high
+            high_label = self.factory.string_value(self.high)
 
         self._label_lo.setText(low_label)
         self._label_hi.setText(high_label)
@@ -171,7 +171,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         """ Handles the user changing the current slider value.
         """
         value = self._convert_from_slider(pos)
-        self.control.text.setText(self.format % value)
+        self.control.text.setText(self.factory.string_value(value))
         try:
             self.value = value
         except Exception as exc:
@@ -221,7 +221,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         low = self.low
         high = self.high
         try:
-            text = self.format % value
+            text = self.factory.string_value(value)
             1 / (low <= value <= high)
         except:
             text = ""
@@ -250,7 +250,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(low)
 
         if self._label_lo is not None:
-            self._label_lo.setText(self.format % low)
+            self._label_lo.setText(self.factory.string_value(low))
             self.update_editor()
 
     def _high_changed(self, high):
@@ -261,7 +261,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(high)
 
         if self._label_hi is not None:
-            self._label_hi.setText(self.format % high)
+            self._label_hi.setText(self.factory.string_value(high))
             self.update_editor()
 
     def _convert_to_slider(self, value):

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -80,7 +80,7 @@ class SimpleSliderEditor(BaseRangeEditor):
     #: High value for the slider range
     high = Any()
 
-    #: Deprecated: This trait is no longer used.
+    #: Deprecated: This trait is no longer used. See enthought/traitsui#1704
     format = Str()
 
     def init(self, parent):

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -80,7 +80,7 @@ class SimpleSliderEditor(BaseRangeEditor):
     #: High value for the slider range
     high = Any()
 
-    #: Formatting string used to format value and labels
+    #: Deprecated: This trait is no longer used.
     format = Str()
 
     def init(self, parent):
@@ -93,8 +93,6 @@ class SimpleSliderEditor(BaseRangeEditor):
 
         if not factory.high_name:
             self.high = factory.high
-
-        self.format = factory.format
 
         self.evaluate = factory.evaluate
         self.sync_value(factory.evaluate_name, "evaluate", "from")

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -109,7 +109,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         try:
             if not (self.low <= fvalue <= self.high):
                 fvalue = self.low
-            fvalue_text = self.factory.string_value(fvalue)
+            fvalue_text = self.string_value(fvalue)
         except:
             fvalue_text = ""
             fvalue = self.low
@@ -151,11 +151,11 @@ class SimpleSliderEditor(BaseRangeEditor):
 
         low_label = factory.low_label
         if factory.low_name != "":
-            low_label = self.factory.string_value(self.low)
+            low_label = self.string_value(self.low)
 
         high_label = factory.high_label
         if factory.high_name != "":
-            high_label = self.factory.string_value(self.high)
+            high_label = self.string_value(self.high)
 
         self._label_lo.setText(low_label)
         self._label_hi.setText(high_label)
@@ -169,7 +169,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         """ Handles the user changing the current slider value.
         """
         value = self._convert_from_slider(pos)
-        self.control.text.setText(self.factory.string_value(value))
+        self.control.text.setText(self.string_value(value))
         try:
             self.value = value
         except Exception as exc:
@@ -219,7 +219,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         low = self.low
         high = self.high
         try:
-            text = self.factory.string_value(value)
+            text = self.string_value(value)
             1 / (low <= value <= high)
         except:
             text = ""
@@ -248,7 +248,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(low)
 
         if self._label_lo is not None:
-            self._label_lo.setText(self.factory.string_value(low))
+            self._label_lo.setText(self.string_value(low))
             self.update_editor()
 
     def _high_changed(self, high):
@@ -259,7 +259,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(high)
 
         if self._label_hi is not None:
-            self._label_hi.setText(self.factory.string_value(high))
+            self._label_hi.setText(self.string_value(high))
             self.update_editor()
 
     def _convert_to_slider(self, value):

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -352,13 +352,16 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             )
 
     def test_format(self):
+        # format trait has been deprecated in favor of format_str. However,
+        # behavior should be unchanged.
         model = RangeModel()
-        view = View(
-            Item(
-                "float_value",
-                editor=RangeEditor(format="%s ...")
+        with self.assertWarns(DeprecationWarning):
+            view = View(
+                Item(
+                    "float_value",
+                    editor=RangeEditor(format="%s ...")
+                )
             )
-        )
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             float_value_field = tester.find_by_name(ui, "float_value")

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -320,3 +320,34 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             displayed = text.inspect(DisplayedText())
             self.assertEqual(model.float_value, 10.0)
             self.assertEqual(displayed, str(model.float_value))
+
+    def test_format_func(self):
+
+        def num_to_time(num):
+            minutes = int(num / 60)
+            if minutes < 10:
+                minutes_str = '0' + str(minutes)
+            else:
+                minutes_str = str(minutes)
+            seconds = num % 60
+            if seconds < 10:
+                seconds_str = '0' + str(seconds)
+            else:
+                seconds_str = str(seconds)
+            return minutes_str + ':' + seconds_str
+
+        model = RangeModel()
+        view = View(
+            Item(
+                "float_value",
+                editor=RangeEditor(format_func=num_to_time)
+            )
+        )
+        model.configure_traits(view=view)
+        tester = UITester()
+        with tester.create_ui(model, dict(view=view)) as ui:
+            float_value_field = tester.find_by_name(ui, "float_value")
+            float_value_text = float_value_field.locate(Textbox())
+            self.assertEqual(
+                float_value_text.inspect(DisplayedText()), "00:00.1"
+            )

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -343,7 +343,6 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
                 editor=RangeEditor(format_func=num_to_time)
             )
         )
-        model.configure_traits(view=view)
         tester = UITester()
         with tester.create_ui(model, dict(view=view)) as ui:
             float_value_field = tester.find_by_name(ui, "float_value")

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -356,7 +356,7 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
         view = View(
             Item(
                 "float_value",
-                editor=RangeEditor(format="%s:%s")
+                editor=RangeEditor(format="%s ...")
             )
         )
         tester = UITester()
@@ -364,5 +364,5 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             float_value_field = tester.find_by_name(ui, "float_value")
             float_value_text = float_value_field.locate(Textbox())
             self.assertEqual(
-                float_value_text.inspect(DisplayedText()), "0.1:0.1"
+                float_value_text.inspect(DisplayedText()), "0.1 ..."
             )

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -351,9 +351,11 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
                 float_value_text.inspect(DisplayedText()), "00:00.1"
             )
 
-    def test_format(self):
-        # format trait has been deprecated in favor of format_str. However,
-        # behavior should be unchanged.
+    def test_editor_factory_format(self):
+        """
+        format trait on RangeEditor editor factory has been deprecated in
+        favor of format_str. However, behavior should be unchanged.
+        """
         model = RangeModel()
         with self.assertWarns(DeprecationWarning):
             view = View(
@@ -368,4 +370,27 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             float_value_text = float_value_field.locate(Textbox())
             self.assertEqual(
                 float_value_text.inspect(DisplayedText()), "0.1 ..."
+            )
+
+    def test_editor_format(self):
+        """
+        The format trait on an Editor instance previously potentially
+        could override the factory. Now that is not the case.
+        """
+        model = RangeModel()
+        with self.assertWarns(DeprecationWarning):
+            view = View(
+                Item(
+                    "float_value",
+                    editor=RangeEditor(format="%s ...")
+                )
+            )
+        tester = UITester()
+        with tester.create_ui(model, dict(view=view)) as ui:
+            float_value_field = tester.find_by_name(ui, "float_value")
+            float_value_field._target.format = "%s +++"
+            model.float_value = 0.2
+            float_value_text = float_value_field.locate(Textbox())
+            self.assertEqual(
+                float_value_text.inspect(DisplayedText()), "0.2 ..."
             )

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -350,3 +350,19 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(
                 float_value_text.inspect(DisplayedText()), "00:00.1"
             )
+
+    def test_format(self):
+        model = RangeModel()
+        view = View(
+            Item(
+                "float_value",
+                editor=RangeEditor(format="%s:%s")
+            )
+        )
+        tester = UITester()
+        with tester.create_ui(model, dict(view=view)) as ui:
+            float_value_field = tester.find_by_name(ui, "float_value")
+            float_value_text = float_value_field.locate(Textbox())
+            self.assertEqual(
+                float_value_text.inspect(DisplayedText()), "0.1:0.1"
+            )

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -109,7 +109,7 @@ class SimpleSliderEditor(BaseRangeEditor):
             fvalue = self.low
         else:
             try:
-                fvalue_text = self.factory.string_value(fvalue)
+                fvalue_text = self.string_value(fvalue)
             except (ValueError, TypeError) as e:
                 fvalue_text = ""
 
@@ -155,11 +155,11 @@ class SimpleSliderEditor(BaseRangeEditor):
 
         low_label = factory.low_label
         if factory.low_name != "":
-            low_label = self.factory.string_value(self.low)
+            low_label = self.string_value(self.low)
 
         high_label = factory.high_label
         if factory.high_name != "":
-            high_label = self.factory.string_value(self.high)
+            high_label = self.string_value(self.high)
 
         self._label_lo.SetLabel(low_label)
         self._label_hi.SetLabel(high_label)
@@ -189,7 +189,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         ):
             try:
                 self.ui_changing = True
-                self.control.text.SetValue(self.factory.string_value(value))
+                self.control.text.SetValue(self.string_value(value))
                 self.value = value
             except TraitError:
                 pass
@@ -251,7 +251,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         """
         value = self.value
         try:
-            text = self.factory.string_value(value)
+            text = self.string_value(value)
             1 // (self.low <= value <= self.high)
         except:
             text = ""
@@ -294,7 +294,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(low)
 
         if self._label_lo is not None:
-            self._label_lo.SetLabel(self.factory.string_value(low))
+            self._label_lo.SetLabel(self.string_value(low))
             self.update_editor()
 
     def _high_changed(self, high):
@@ -305,7 +305,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(high)
 
         if self._label_hi is not None:
-            self._label_hi.SetLabel(self.factory.string_value(high))
+            self._label_hi.SetLabel(self.string_value(high))
             self.update_editor()
 
 

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -74,7 +74,7 @@ class SimpleSliderEditor(BaseRangeEditor):
     #: High value for the slider range
     high = Any()
 
-    #: Deprecated: This trait is no longer used.  
+    #: Deprecated: This trait is no longer used. See enthought/traitsui#1704
     format = Str()
 
     #: Flag indicating that the UI is in the process of being updated

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -91,8 +91,6 @@ class SimpleSliderEditor(BaseRangeEditor):
         if not factory.high_name:
             self.high = factory.high
 
-        self.format = factory.format
-
         self.evaluate = factory.evaluate
         self.sync_value(factory.evaluate_name, "evaluate", "from")
 

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -74,7 +74,7 @@ class SimpleSliderEditor(BaseRangeEditor):
     #: High value for the slider range
     high = Any()
 
-    #: Formatting string used to format value and labels
+    #: Deprecated: This trait is no longer used.  
     format = Str()
 
     #: Flag indicating that the UI is in the process of being updated

--- a/traitsui/wx/range_editor.py
+++ b/traitsui/wx/range_editor.py
@@ -111,7 +111,7 @@ class SimpleSliderEditor(BaseRangeEditor):
             fvalue = self.low
         else:
             try:
-                fvalue_text = self.format % fvalue
+                fvalue_text = self.factory.string_value(fvalue)
             except (ValueError, TypeError) as e:
                 fvalue_text = ""
 
@@ -157,11 +157,11 @@ class SimpleSliderEditor(BaseRangeEditor):
 
         low_label = factory.low_label
         if factory.low_name != "":
-            low_label = self.format % self.low
+            low_label = self.factory.string_value(self.low)
 
         high_label = factory.high_label
         if factory.high_name != "":
-            high_label = self.format % self.high
+            high_label = self.factory.string_value(self.high)
 
         self._label_lo.SetLabel(low_label)
         self._label_hi.SetLabel(high_label)
@@ -191,7 +191,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         ):
             try:
                 self.ui_changing = True
-                self.control.text.SetValue(self.format % value)
+                self.control.text.SetValue(self.factory.string_value(value))
                 self.value = value
             except TraitError:
                 pass
@@ -253,7 +253,7 @@ class SimpleSliderEditor(BaseRangeEditor):
         """
         value = self.value
         try:
-            text = self.format % value
+            text = self.factory.string_value(value)
             1 // (self.low <= value <= self.high)
         except:
             text = ""
@@ -296,7 +296,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(low)
 
         if self._label_lo is not None:
-            self._label_lo.SetLabel(self.format % low)
+            self._label_lo.SetLabel(self.factory.string_value(low))
             self.update_editor()
 
     def _high_changed(self, high):
@@ -307,7 +307,7 @@ class SimpleSliderEditor(BaseRangeEditor):
                 self.value = int(high)
 
         if self._label_hi is not None:
-            self._label_hi.SetLabel(self.format % high)
+            self._label_hi.SetLabel(self.factory.string_value(high))
             self.update_editor()
 
 


### PR DESCRIPTION
closes #1650 

This PR adds support for `format_func` for the `SimpleSliderEditor` `RangeEditor`.  It does so by calling the `string_value` method defined on the factory, rather than just `self.format % _____`.  See method definition here:
https://github.com/enthought/traitsui/blob/e2521b4cf3ca882591c68ff57e795867964725ec/traitsui/editor_factory.py#L190-L208

I am just realizing while opening this that although the base `EditorFactory` class defines a `format_str` trait, the `RangeEditor` defines its own `format` trait to hold the format string instead.  I suspect this will cause problems, hence the WIP for now.  I would like to rename `format` to `format_str` but that is part of the public api... 
Perhaps I will need to redefine the `string_value` method on `RangeEditor` and have it be exactly the same as the base class just replacing `format_str` with `format`... 🤔 

EDIT: I went with the approach mentioned of "redefine the `string_value` method on `RangeEditor` ...".  It smells a bit, but seems necessary (?) I am not sure why RangeEditor chose to use its own trait there previously rather than using `format_str`. 
**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)