### PR TITLE
Dont test against PyQt4 on CI

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        toolkit: ['pyqt', 'pyqt5', 'pyside2']
+        toolkit: ['pyqt5', 'pyside2']
         include:
           - os: ubuntu-latest
             toolkit: 'null'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="null"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt5 pyside2"
     - env: RUNTIME=3.6 TOOLKITS="wx"
   allow_failures:
     - env: RUNTIME=3.6 TOOLKITS="wx"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,6 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKIT: "pyqt"
-    - RUNTIME: '3.6'
       TOOLKIT: "pyqt5"
 
 matrix:

--- a/docs/releases/upcoming/1686.test.rst
+++ b/docs/releases/upcoming/1686.test.rst
@@ -1,0 +1,1 @@
+Stop testing against pyqt4 on CI (#1686)


### PR DESCRIPTION
part of https://github.com/enthought/ets/issues/57

This PR removes testing with pyqt4 from CI

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)