### PR TITLE
Remove support for PyQt in etstool helpers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,9 +75,8 @@ If you want to run traitsui, you must also install:
 
 You will also need one of the following backends:
 
-- PyQt
 - wxPython
-- PySide
+- PySide2
 - PyQt5
 
 Backends have additional dependencies and there are optional dependencies on

--- a/ets-demo/etstool.py
+++ b/ets-demo/etstool.py
@@ -60,7 +60,7 @@ using::
     python etstool.py test_all
 
 Currently supported runtime values are ``3.6``, and currently
-supported toolkits are ``null``, ``pyqt``, ``pyqt5``, ``pyside2`` and ``wx``.
+supported toolkits are ``null``, ``pyqt5``, ``pyside2`` and ``wx``.
 Not all combinations of toolkits and runtimes will work, but the tasks will
 fail with a clear error if that is the case.
 
@@ -90,7 +90,7 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '3.6': {'pyside2', 'pyqt', 'pyqt5', 'wx', 'null'},
+    '3.6': {'pyside2', 'pyqt5', 'wx', 'null'},
 }
 
 # Default Python version to use in the comamnds below if none is specified.
@@ -119,10 +119,6 @@ extra_dependencies = {
     'pyside2': {
         "pygments",
     },
-    'pyqt': {
-        'pyqt<4.12',  # FIXME: build 1 of 4.12.1 appears to be bad
-        'pygments',
-    },
     'pyqt5': {
         'pyqt5',
         'pygments',
@@ -138,7 +134,6 @@ doc_dependencies = {}
 
 environment_vars = {
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
-    "pyqt": {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
     'pyqt5': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt5"},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null'},

--- a/etstool.py
+++ b/etstool.py
@@ -52,7 +52,7 @@ using::
     python etstool.py test_all
 
 Currently supported runtime values are ``3.6``, and currently
-supported toolkits are ``null``, ``pyqt``, ``pyqt5``, ``pyside`` and ``wx``.
+supported toolkits are ``null``, ``pyqt5``, ``pyside2`` and ``wx``.
 Not all combinations of toolkits and runtimes will work, but the tasks will
 fail with a clear error if that is the case.
 
@@ -103,7 +103,7 @@ from tempfile import mkdtemp
 import click
 
 supported_combinations = {
-    '3.6': {'pyside2', 'pyqt', 'pyqt5', 'wx', 'null'},
+    '3.6': {'pyside2', 'pyqt5', 'wx', 'null'},
 }
 
 # Default Python version to use in the comamnds below if none is specified.
@@ -131,10 +131,6 @@ source_dependencies = {
 extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': {
-        'pygments',
-    },
-    'pyqt': {
-        'pyqt<4.12',  # FIXME: build 1 of 4.12.1 appears to be bad
         'pygments',
     },
     'pyqt5': {
@@ -187,7 +183,6 @@ doc_ignore = {
 
 environment_vars = {
     'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
-    'pyqt': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt"},
     'pyqt5': {"ETS_TOOLKIT": "qt4", "QT_API": "pyqt5"},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null'},


### PR DESCRIPTION
This PR removes support for the `PyQt` toolkit in the `etstool.py` helper modules - because we dont test against `PyQt` on CI any longer (ref #1686 ). Note that the `README` has also been updated to not mention `PyQt`.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ This change in itself isn't newsworthy.