### PR TITLE
Address some deprecation warnings with python 3.8 and pyqt5

### DIFF
--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -100,7 +100,7 @@ def position_window(window, width=None, height=None, parent=None):
 
     if parent is None:
         # Center the popup on the screen.
-        window.move(int((screen_dx - width) / 2), int((screen_dy - height) / 2))
+        window.move((screen_dx - width) // 2, (screen_dy - height) // 2)
         return
 
     # Calculate the desired size of the popup control:

--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -100,7 +100,7 @@ def position_window(window, width=None, height=None, parent=None):
 
     if parent is None:
         # Center the popup on the screen.
-        window.move((screen_dx - width) / 2, (screen_dy - height) / 2)
+        window.move(int((screen_dx - width) / 2), int((screen_dy - height) / 2))
         return
 
     # Calculate the desired size of the popup control:

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -202,9 +202,9 @@ class _StickyDialog(QtGui.QDialog):
         size = QtGui.QDialog.sizeHint(self)
         view = self._ui.view
         if view.width > 0:
-            size.setWidth(view.width)
+            size.setWidth(int(view.width))
         if view.height > 0:
-            size.setHeight(view.height)
+            size.setHeight(int(view.height))
         return size
 
     def done(self, r):

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -352,9 +352,9 @@ def _size_hint_wrapper(f, ui):
         size = f()
         if ui.view is not None:
             if ui.view.width > 0:
-                size.setWidth(ui.view.width)
+                size.setWidth(int(ui.view.width))
             if ui.view.height > 0:
-                size.setHeight(ui.view.height)
+                size.setHeight(int(ui.view.height))
         return size
 
     return sizeHint

--- a/traitsui/tests/test_splitter_prefs_restored.py
+++ b/traitsui/tests/test_splitter_prefs_restored.py
@@ -36,7 +36,7 @@ class TmpClass(Handler):
         """
         control = getattr(ui_info, "h_split").control
         width = control.width()
-        control.moveSplitter(int(width / 2), 1)
+        control.moveSplitter(width // 2, 1)
 
     def restore_prefs(self, ui_info):
         """ Apply the last saved ui preferences.

--- a/traitsui/tests/test_splitter_prefs_restored.py
+++ b/traitsui/tests/test_splitter_prefs_restored.py
@@ -36,7 +36,7 @@ class TmpClass(Handler):
         """
         control = getattr(ui_info, "h_split").control
         width = control.width()
-        control.moveSplitter(width / 2, 1)
+        control.moveSplitter(int(width / 2), 1)
 
     def restore_prefs(self, ui_info):
         """ Apply the last saved ui preferences.


### PR DESCRIPTION
part of #1578 
This PR addresses some of the warnings mentioned when running the testsuite with python 3.8 and pyqt5.

I was having a bit of trouble resolving the `ImageEnumEditor` related warnings:
<details>

```
test_simple_editor_combobox (traitsui.tests.editors.test_image_enum_editor.TestSimpleImageEnumEditor) ... /Users/aayres/Desktop/traitsui/traitsui/qt4/image_enum_editor.py:149: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  self.setModel(model)
/Users/aayres/Desktop/traitsui/traitsui/qt4/enum_editor.py:165: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  control.addItems(self.names)
/Users/aayres/Desktop/traitsui/traitsui/qt4/image_enum_editor.py:98: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  self.control.setModelColumn(col)
/Users/aayres/Desktop/traitsui/traitsui/qt4/image_enum_editor.py:99: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  self.control.setCurrentIndex(row)
/Users/aayres/Desktop/traitsui/traitsui/qt4/ui_base.py:202: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  size = QtGui.QDialog.sizeHint(self)
/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_image_enum_editor.py:367: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  editor.control.showPopup()
/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_image_enum_editor.py:370: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  editor.control.setCurrentIndex(1)
/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_image_enum_editor.py:371: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  editor.control.hidePopup()
ok
```

</details>

and decided to leave those for a future PR.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)