### PR TITLE
Expose TreeEditor actions and IconSize in `traitsui.editors.api`

### DIFF
--- a/traitsui/editors/api.py
+++ b/traitsui/editors/api.py
@@ -59,6 +59,16 @@ is the preferred module for imports.
 - :attr:`~.TupleEditor`
 - :attr:`~.ValueEditor`
 
+Tree Editor Actions / Traits
+----------------------------
+- :attr:`~.CopyAction`
+- :attr:`~.CutAction`
+- :attr:`~.DeleteAction`
+- :attr:`~.IconSize`
+- :attr:`~.NewAction`
+- :attr:`~.PasteAction`
+- :attr:`~.RenameAction`
+
 """
 
 from ..toolkit import toolkit
@@ -124,3 +134,13 @@ from .scrubber_editor import ScrubberEditor
 from .tabular_editor import TabularEditor
 from .progress_editor import ProgressEditor
 from .search_editor import SearchEditor
+
+from traitsui.editors.tree_editor import (
+    CopyAction,
+    CutAction,
+    DeleteAction,
+    IconSize,
+    NewAction,
+    PasteAction,
+    RenameAction,
+)


### PR DESCRIPTION
closes #1647 
This PR simply exposes the objects mentioned on the issue in `traitsui.editors.api`

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)