### PR TITLE
Add news fragment for PR 1690

### DIFF
--- a/docs/releases/upcoming/1690.feature.rst
+++ b/docs/releases/upcoming/1690.feature.rst
@@ -1,0 +1,1 @@
+Expose TreeEditor actions and IconSize in traitsui.editors.api (#1690)


### PR DESCRIPTION
Given #1690 involved a change to an api module, it feels relevant to users and should get a changelog entry.  I would have tagged this as 'maintenance', but we don't have that as an option so I went with feature.
**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~