### PR TITLE
Fix ArrayEditor data type check

### DIFF
--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -72,7 +72,7 @@ class ArrayStructure(HasTraits):
         # Determine the correct trait type to use for each element:
         trait = Float()
 
-        if object.dtype.type == "i":
+        if object.dtype.kind == "i":
             trait = Int()
 
         if len(object.shape) == 1:


### PR DESCRIPTION
This PR was motivated by this comment:
https://github.com/enthought/traitsui/pull/1691#pullrequestreview-688037697
specifically the second bullet.

Note that adding `print(object.dtype.type)` while running `ArrayEditor_demo.py` previously was giving `<class 'numpy.int64'>`, whereas `kind` gives `"i"` as we expect.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)