### PR TITLE
Update note in docs as we now have pyqt5 screenshots

### DIFF
--- a/docs/source/traitsui_user_manual/factories_basic.rst
+++ b/docs/source/traitsui_user_manual/factories_basic.rst
@@ -16,8 +16,8 @@ interfaces or that are designed to be used along with complex editors.
 .. NOTE:: Examples are toolkit-specific.
 
    The exact appearance of the editors depends on the underlying GUI toolkit.
-   The screenshots and descriptions in this chapter are based on wxWindows.
-   Another supported GUI toolkit is Qt, from TrollTech.
+   The screenshots and descriptions in this chapter contain a mix of both wx
+   and Qt.
 
 Rather than trying to memorize all the information in this chapter, you might
 skim it to get a general idea of the available trait editors and their


### PR DESCRIPTION
This PR simply updates a note in the documentation as we now have screenshots using pyqt5.  Some still have the old wx screenshots though which will progressively be updated over time. 

**Checklist**
~- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ Too minor to warrant a news fragment