### PR TITLE
Fix separator alignment

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1010,13 +1010,10 @@ class _GroupPanel(object):
 
         # See if the layout is a grid.
         if row >= 0:
-            # Move to the start of the next row if necessary.
+            # Move to the start of the row if necessary.
             if col > 0:
                 col = 0
-                row += 1
 
-            # Skip the row we are about to do.
-            row += 1
 
             # Allow for the columns.
             if show_labels:


### PR DESCRIPTION
This issue was observed when working on #1691, and again while working on addressing #1312.

Previously I remember having run the example code in #1312 without this issue... I recently updated to macOS Big Sur, but I am unsure if that is related.  I do not know what changed to cause this, especially since it appears to be an off by one error (which somehow wasn't a problem before ?).  
In any case, running the example code given in #1312 without this fix I see:
<img width="207" alt="pre_fix" src="https://user-images.githubusercontent.com/36972686/123272610-8632f900-d4c7-11eb-84d6-b7445eb59564.png">
and with this change:
<img width="207" alt="post_fix" src="https://user-images.githubusercontent.com/36972686/123272641-8c28da00-d4c7-11eb-8365-a38953aa8071.png">


**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)