### PR TITLE
UI tester updates table editor

### DIFF
--- a/traitsui/examples/demo/Standard_Editors/tests/test_TableEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_TableEditor_demo.py
@@ -1,0 +1,49 @@
+"""
+This example demonstrates how to test interacting with a TableEditor.
+
+The GUI being tested is written in the demo under the same name (minus the
+preceding 'test') in the outer directory.
+"""
+
+import os
+import runpy
+import unittest
+
+
+from traitsui.testing.api import (
+    Cell, KeyClick, KeySequence, MouseClick, UITester
+)
+
+#: Filename of the demo script
+FILENAME = "TableEditor_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestTableEditorDemo(unittest.TestCase):
+
+    def test_list_editor_demo(self):
+        demo = runpy.run_path(DEMO_PATH)["demo"]
+
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            employees_table = tester.find_by_name(ui, "employees")
+
+            # clicking a cell enters edit mode and selcts full text
+            cell_21 = employees_table.locate(Cell(2,1))
+            cell_21.perform(MouseClick())
+            cell_21.perform(KeySequence("Jones"))
+            cell_21.perform(KeyClick("Enter"))
+
+            self.assertEqual(demo.employees[0].last_name, 'Jones')
+
+            # third column corresponds to Full Name property
+            cell_32 = employees_table.locate(Cell(3,2))
+            cell_32.perform(MouseClick())
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestTableEditorDemo)
+)

--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -59,6 +59,7 @@ Exceptions
 
 from .tester.command import (
     MouseClick,
+    MouseDClick,
     KeyClick,
     KeySequence
 )
@@ -71,6 +72,7 @@ from .tester.exceptions import (
 )
 
 from .tester.locator import (
+    Cell,
     Index,
     TargetById,
     TargetByName,
@@ -84,6 +86,7 @@ from .tester.query import (
     DisplayedText,
     IsChecked,
     IsEnabled,
+    Selected,
     SelectedText
 )
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
@@ -204,6 +204,127 @@ def mouse_click_item_view(model, view, index, delay):
     )
 
 
+def mouse_dclick_item_view(model, view, index, delay):
+    """ Perform mouse double click on the given QAbstractItemModel (model) and
+    QAbstractItemView (view) with the given row and column.
+
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and key sequence be performed.
+    index : QModelIndex
+
+    Raises
+    ------
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    rect = view.visualRect(index)
+    QTest.mouseDClick(
+        view.viewport(),
+        QtCore.Qt.LeftButton,
+        QtCore.Qt.NoModifier,
+        rect.center(),
+        delay=delay,
+    )
+
+
+def key_sequence_item_view(model, view, index, sequence, delay=0):
+    """ Perform mouse click on the given QAbstractItemModel (model) and
+    QAbstractItemView (view) with the given row and column.
+
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and key sequence be performed.
+    index : QModelIndex
+    sequence : str
+        Sequence of characters to be inserted to the widget identifed
+        by the row and column.
+
+    Raises
+    ------
+    Disabled
+        If the widget cannot be edited.
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    widget = view.indexWidget(index)
+    if widget is None:
+        raise Disabled(
+            "No editable widget for item at row {!r} and column {!r}".format(
+                index.row(), index.column()
+            )
+        )
+    QTest.keyClicks(widget, sequence, delay=delay)
+
+
+def key_click_item_view(model, view, index, key, delay=0):
+    """ Perform key press on the given QAbstractItemModel (model) and
+    QAbstractItemView (view) with the given row and column.
+
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and key press be performed.
+    index : int
+    key : str
+        Key to be pressed.
+
+    Raises
+    ------
+    Disabled
+        If the widget cannot be edited.
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    widget = view.indexWidget(index)
+    if widget is None:
+        raise Disabled(
+            "No editable widget for item at row {!r} and column {!r}".format(
+                index.row(), index.column()
+            )
+        )
+    key_click(widget, key=key, delay=delay)
+
+
+def get_display_text_item_view(model, view, index):
+    """ Return the textural representation for the given model, row and column.
+
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and key press be performed.
+    index : int
+
+    Raises
+    ------
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    return model.data(index, QtCore.Qt.DisplayRole)
+
+
 def mouse_click_combobox(combobox, index, delay):
     """ Perform a mouse click on a QComboBox at a given index.
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/table_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/table_editor.py
@@ -1,0 +1,104 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+from traitsui.qt4.table_editor import SimpleEditor
+
+from traitsui.testing.api import (
+    Cell,
+    DisplayedText,
+    MouseClick,
+    MouseDClick,
+    KeyClick,
+    KeySequence,
+    Selected,
+)
+from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
+    BaseSourceWithLocation
+)
+from traitsui.testing.tester._ui_tester_registry.qt4 import (
+    _interaction_helpers,
+    _registry_helper
+)
+
+
+class _SimpleEditorWithCell(BaseSourceWithLocation):
+    source_class = SimpleEditor
+    locator_class = Cell
+    handlers = [
+        (MouseClick, lambda wrapper, _: wrapper._target._mouse_click(
+            delay=wrapper.delay)),
+        (KeyClick, lambda wrapper, interaction: wrapper._target._key_click(
+            key=interaction.key,
+            delay=wrapper.delay,)),
+        (KeySequence, lambda wrapper, interaction: wrapper._target._key_sequence(
+            sequence=interaction.sequence,
+            delay=wrapper.delay,)),
+        (DisplayedText, lambda wrapper, _: wrapper._target._get_displayed_text()),
+        (MouseDClick, lambda wrapper, _: wrapper._target._mouse_dclick(
+            delay=wrapper.delay,)),
+    ]
+
+    def _get_model_view_index(self):
+        table_view = self.source.table_view
+        return dict(
+            model=table_view.model(),
+            view=table_view,
+            index=table_view.model().index(self.location.row, self.location.column),
+        )
+
+    def _mouse_click(self, delay=0):
+        _interaction_helpers.mouse_click_item_view(
+            **self._get_model_view_index(),
+            delay=delay,
+        )
+
+    def _mouse_dclick(self, delay=0):
+        _interaction_helpers.mouse_dclick_item_view(
+            **self._get_model_view_index(),
+            delay=delay,
+        )
+
+    def _key_sequence(self, sequence, delay=0):
+        _interaction_helpers.key_sequence_item_view(
+            **self._get_model_view_index(),
+            sequence=sequence,
+            delay=delay,
+        )
+
+    def _key_click(self, key, delay=0):
+        _interaction_helpers.key_click_item_view(
+            **self._get_model_view_index(),
+            key=key,
+            delay=delay,
+        )
+
+    def _get_displayed_text(self):
+        return _interaction_helpers.get_display_text_item_view(
+            **self._get_model_view_index(),
+        )
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    _SimpleEditorWithCell.register(registry)
+    registry.register_interaction(
+        target_class=SimpleEditor,
+        interaction_class=Selected,
+        handler=lambda wrapper, _: wrapper._target.selected
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -20,6 +20,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     instance_editor,
     list_editor,
     range_editor,
+    table_editor,
     text_editor,
     ui_base,
 )
@@ -68,5 +69,8 @@ def get_default_registry():
 
     # Editor Factory
     editor_factory.register(registry)
+
+    # TableEditor
+    table_editor.register(registry)
 
     return registry

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_interaction_helpers.py
@@ -40,6 +40,28 @@ def _create_event(event_type, control):
     return event
 
 
+def _create_grid_event(event_type, control, *args, **kwargs):
+    """ Creates a wxGridEvent of a given type.
+
+    Parameters
+    ----------
+    event_type : wxEventType
+        The type of the event to be created
+    control :
+        The wx control the event is occurring on.
+
+    Returns
+    -------
+    wxGridEvent
+        The created event, of the given type, with the given control set as
+        the event object.
+    """
+    event = wx.grid.GridEvent(
+        control.GetId(), event_type, control, *args, **kwargs
+    )
+    return event
+
+
 def mouse_click(func):
     """ Decorator function for mouse clicks. Decorated functions will return
     if they are not enabled. Additionally, this handles the delay for the
@@ -184,6 +206,14 @@ def mouse_click_object(control, delay):
     if not control.HasFocus():
         control.SetFocus()
     click_event = _create_event(wx.wxEVT_COMMAND_LEFT_CLICK, control)
+    control.ProcessWindowEvent(click_event)
+
+
+@mouse_click
+def mouse_click_cell_in_grid(control, cell, delay):
+    click_event = _create_grid_event(
+        wx.grid.wxEVT_GRID_CELL_LEFT_CLICK, control, row=cell.row, col=cell.column
+    )
     control.ProcessWindowEvent(click_event)
 
 

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/table_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/table_editor.py
@@ -1,0 +1,55 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+from traitsui.wx.table_editor import SimpleEditor
+
+from traitsui.testing.api import (
+    Cell,
+    DisplayedText,
+    MouseClick,
+    MouseDClick,
+    KeyClick,
+    KeySequence,
+    Selected,
+)
+from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
+    BaseSourceWithLocation
+)
+from traitsui.testing.tester._ui_tester_registry.wx import (
+    _interaction_helpers,
+    _registry_helper
+)
+
+
+class _SimpleEditorWithCell(BaseSourceWithLocation):
+    source_class = SimpleEditor
+    locator_class = Cell
+    handlers = [
+        (MouseClick,
+            (lambda wrapper, interaction:
+                _interaction_helpers.mouse_click_cell_in_grid(
+                    control=wrapper._target.source.grid.control,
+                    cell=wrapper._target.location,
+                    delay=wrapper.delay))),
+    ]
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    _SimpleEditorWithCell.register(registry)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -20,6 +20,7 @@ from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
     instance_editor,
     list_editor,
     range_editor,
+    table_editor,
     text_editor,
     ui_base,
 )
@@ -68,5 +69,8 @@ def get_default_registry():
 
     # Editor Factory
     editor_factory.register(registry)
+
+    # TableEditor
+    table_editor.register(registry)
 
     return registry

--- a/traitsui/testing/tester/command.py
+++ b/traitsui/testing/tester/command.py
@@ -28,6 +28,17 @@ class MouseClick:
     pass
 
 
+class MouseDClick:
+    """ An object representing the user double clicking a mouse button.
+    Currently the left mouse button is assumed.
+
+    In most circumstances, a widget can still be clicked on even if it is
+    disabled. Therefore unlike key events, if the widget is disabled,
+    implementations should not raise an exception.
+    """
+    pass
+
+
 class KeySequence:
     """ An object representing the user typing a sequence of keys.
 

--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -18,6 +18,23 @@ applied.
 """
 
 
+class Cell:
+    """ A locator for locating a target uniquely specified by a row index and a
+    column index.
+    
+    Attributes
+    ----------
+    row : int
+        0-based index
+    column : int
+        0-based index
+    """
+
+    def __init__(self, row, column):
+        self.row = row
+        self.column = column
+
+
 class Index:
     """ A locator for locating a target that is uniquely specified by a single
     0-based index.

--- a/traitsui/testing/tester/query.py
+++ b/traitsui/testing/tester/query.py
@@ -17,6 +17,16 @@ without incurring side-effects.
 """
 
 
+class Selected:
+    """ An object representing an interaction to obtain the object which is
+    currently selected.
+
+    Implementations should return the selected object, or None if nothing is
+    selected.
+    """
+    pass
+
+
 class SelectedText:
     """ An object representing an interaction to obtain the displayed (echoed)
     plain text which is currently selected.

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -315,10 +315,12 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-        object_list.selected = object_list.values[5]
 
-        tester = UITester()
+        tester = UITester(delay=10000)
         with tester.create_ui(object_list, dict(view=select_row_view)) as ui:
+            # click the first cell in the 6th row to select the row
+            tester.find_by_name(ui, "values").locate(Cell(5,0)).perform(MouseClick())
+
             editor = ui.get_editors("values")[0]
             if is_qt():
                 selected = editor.selected
@@ -326,6 +328,7 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
                 selected = editor.selected_row
 
         self.assertIs(selected, object_list.values[5])
+        self.assertIs(object_list.selected, selected)
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_rows(self):

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -83,6 +83,7 @@ select_row_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -99,6 +100,7 @@ select_rows_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[ObjectColumn(name="value")],
             selection_mode="rows",
             selected="selections",
@@ -112,6 +114,7 @@ select_row_index_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -128,6 +131,7 @@ select_row_indices_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -144,6 +148,7 @@ select_column_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -160,6 +165,7 @@ select_columns_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -176,6 +182,7 @@ select_column_index_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -192,6 +199,7 @@ select_column_indices_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -208,6 +216,7 @@ select_cell_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -224,6 +233,7 @@ select_cells_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -240,6 +250,7 @@ select_cell_index_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
@@ -256,6 +267,7 @@ select_cell_indices_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -15,6 +15,15 @@ from traitsui.tests._tools import (
     reraise_exceptions,
     ToolkitName,
 )
+from traitsui.testing.api import (
+    Cell,
+    DisplayedText,
+    KeySequence,
+    KeyClick,
+    MouseClick,
+    Selected,
+    UITester,
+)
 
 
 class ListItem(HasTraits):
@@ -61,11 +70,12 @@ filtered_view = View(
         "values",
         show_label=False,
         editor=TableEditor(
+            sortable=False,
             columns=[
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
             ],
-            filter=EvalTableFilter(expression="other_value >= 2"),
+            filter=EvalTableFilter(expression="value > 4"),
         ),
     ),
     buttons=["OK"],
@@ -274,26 +284,20 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=simple_view)) as ui:
-            process_cascade_events()
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=simple_view)):
+            pass
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_filtered_table_editor(self):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=filtered_view)) as ui:
-            process_cascade_events()
-
+        object_list.configure_traits(view=filtered_view)
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=filtered_view)) as ui:
             filter = ui.get_editors("values")[0].filter
-
-            process_cascade_events()
-
-        self.assertIsNotNone(filter)
+            self.assertIsNotNone(filter)
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_row(self):
@@ -477,6 +481,108 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
             process_cascade_events()
 
         self.assertEqual(selected, (object_list.values[5], "value"))
+
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
+    def test_table_editor_select_row_index_with_tester(self):
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        view = View(
+            Item(
+                "values",
+                show_label=False,
+                editor=TableEditor(
+                    sortable=False,      # switch off sorting by first column
+                    columns=[
+                        ObjectColumn(name="value"),
+                        ObjectColumn(name="other_value"),
+                    ],
+                    selection_mode="row",
+                    selected="selected",
+                ),
+            ),
+        )
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=view)) as ui:
+            wrapper = tester.find_by_name(ui, "values")
+
+            wrapper.locate(Cell(5, 0)).perform(MouseClick())
+            self.assertEqual(object_list.selected.value, str(5 ** 2))
+
+            wrapper.locate(Cell(6, 0)).perform(MouseClick())
+            self.assertEqual(object_list.selected.value, str(6 ** 2))
+
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
+    def test_table_editor_modify_cell_with_tester(self):
+        object_list = ObjectListWithSelection(
+            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+        )
+        view = View(
+            Item(
+                "values",
+                show_label=False,
+                editor=TableEditor(
+                    sortable=False,      # switch off sorting by first column
+                    columns=[
+                        ObjectColumn(name="value"),
+                        ObjectColumn(name="other_value"),
+                    ],
+                    selection_mode="row",
+                    selected="selected",
+                ),
+            ),
+        )
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=view)) as ui:
+            wrapper = tester.find_by_name(ui, "values").locate(Cell(5, 0))
+            wrapper.perform(MouseClick())             # activate edit mode
+            wrapper.perform(KeySequence("abc"))
+            self.assertEqual(object_list.selected.value, "abc")
+
+            # second column refers to an Int type
+            original = object_list.selected.other_value
+            wrapper = tester.find_by_name(ui, "values").locate(Cell(5, 1))
+            wrapper.perform(MouseClick())
+            wrapper.perform(KeySequence("abc"))       # invalid
+            self.assertEqual(object_list.selected.other_value, original)
+
+            for _ in range(3):
+                wrapper.perform(KeyClick("Backspace"))
+            wrapper.perform(KeySequence("12"))  # now ok
+            self.assertEqual(object_list.selected.other_value, 12)
+
+    @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
+    def test_table_editor_check_display_with_tester(self):
+        object_list = ObjectListWithSelection(
+            values=[ListItem(other_value=0)]
+        )
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_row_view)) as ui:
+            wrapper = tester.find_by_name(ui, "values").locate(Cell(0, 1))
+
+            actual = wrapper.inspect(DisplayedText())
+            self.assertEqual(actual, "0")
+
+            object_list.values[0].other_value = 123
+
+            actual = wrapper.inspect(DisplayedText())
+            self.assertEqual(actual, "123")
+
+    @requires_toolkit([ToolkitName.qt])
+    def test_table_editor_escape_retain_edit(self):
+        object_list = ObjectListWithSelection(
+            values=[ListItem(other_value=0)]
+        )
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_row_view)) as ui:
+            cell = tester.find_by_name(ui, "values").locate(Cell(0, 1))
+
+            cell.perform(MouseClick())
+            cell.perform(KeySequence("123"))
+            #cell.perform(KeyClick("Esc"))  # exit edit mode, did not revert
+
+            self.assertEqual(object_list.values[0].other_value, 123)
+
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_cells(self):

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -75,7 +75,7 @@ filtered_view = View(
                 ObjectColumn(name="value"),
                 ObjectColumn(name="other_value"),
             ],
-            filter=EvalTableFilter(expression="value > 4"),
+            filter=EvalTableFilter(expression="other_value > 4"),
         ),
     ),
     buttons=["OK"],
@@ -291,13 +291,15 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_filtered_table_editor(self):
         object_list = ObjectListWithSelection(
-            values=[ListItem(value=str(i ** 2)) for i in range(10)]
+            values=[ListItem(other_value=i ** 2) for i in range(10)]
         )
-        object_list.configure_traits(view=filtered_view)
         tester = UITester()
         with tester.create_ui(object_list, dict(view=filtered_view)) as ui:
-            filter = ui.get_editors("values")[0].filter
+            values = tester.find_by_name(ui, "values")
+            filter = values._target.filter
+            num_filtered_indices = len(values._target.filtered_indices)
             self.assertIsNotNone(filter)
+            self.assertEqual(num_filtered_indices, 7)
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_row(self):
@@ -507,10 +509,10 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
             wrapper = tester.find_by_name(ui, "values")
 
             wrapper.locate(Cell(5, 0)).perform(MouseClick())
-            self.assertEqual(object_list.selected.value, str(5 ** 2))
+            #self.assertEqual(object_list.selected.value, str(5 ** 2))
 
             wrapper.locate(Cell(6, 0)).perform(MouseClick())
-            self.assertEqual(object_list.selected.value, str(6 ** 2))
+            #self.assertEqual(object_list.selected.value, str(6 ** 2))
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_modify_cell_with_tester(self):
@@ -651,7 +653,6 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
                 selected = editor.selected_cell_indices
 
             process_cascade_events()
-
         self.assertEqual(selected, [(5, 0), (6, 1), (8, 0)])
 
     @requires_toolkit([ToolkitName.qt])

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -316,7 +316,7 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
 
-        tester = UITester(delay=10000)
+        tester = UITester()
         with tester.create_ui(object_list, dict(view=select_row_view)) as ui:
             # click the first cell in the 6th row to select the row
             tester.find_by_name(ui, "values").locate(Cell(5,0)).perform(MouseClick())
@@ -387,10 +387,12 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-        object_list.selected_column = "value"
 
         tester = UITester()
         with tester.create_ui(object_list, dict(view=select_column_view)) as ui:
+            # click a cell in the first column (the "value" column)
+            tester.find_by_name(ui, "values").locate(Cell(0,0)).perform(MouseClick())
+
             editor = ui.get_editors("values")[0]
             if is_qt():
                 selected = editor.selected
@@ -398,6 +400,7 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
                 selected = editor.selected_column
 
         self.assertEqual(selected, "value")
+        self.assertEqual(selected, object_list.selected_column)
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_columns(self):
@@ -421,11 +424,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-        object_list.selected_index = 1
 
         view = select_column_index_view
         tester = UITester()
         with tester.create_ui(object_list, dict(view=view)) as ui:
+            # click a cell in the index 1 column
+            tester.find_by_name(ui, "values").locate(Cell(0,1)).perform(MouseClick())
+
             editor = ui.get_editors("values")[0]
             if is_qt():
                 selected = editor.selected_indices
@@ -433,6 +438,7 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
                 selected = editor.selected_column_index
 
         self.assertEqual(selected, 1)
+        self.assertEqual(selected, object_list.selected_index)
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_column_indices(self):
@@ -457,10 +463,12 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-        object_list.selected_cell = (object_list.values[5], "value")
 
         tester = UITester()
         with tester.create_ui(object_list, dict(view=select_cell_view)) as ui:
+            # click the cell at (5,0)
+            tester.find_by_name(ui, "values").locate(Cell(5,0)).perform(MouseClick())
+
             editor = ui.get_editors("values")[0]
             if is_qt():
                 selected = editor.selected
@@ -468,6 +476,7 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
                 selected = editor.selected_cell
 
         self.assertEqual(selected, (object_list.values[5], "value"))
+        self.assertEqual(selected, object_list.selected_cell)
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_row_index_with_tester(self):
@@ -601,11 +610,12 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list = ObjectListWithSelection(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-        object_list.selected_cell_index = (5, 1)
 
         view = select_cell_index_view
         tester = UITester()
         with tester.create_ui(object_list, dict(view=view)) as ui:
+            # click the cell at (5,1)
+            tester.find_by_name(ui, "values").locate(Cell(5,1)).perform(MouseClick())
             editor = ui.get_editors("values")[0]
             if is_qt():
                 selected = editor.selected_indices
@@ -613,6 +623,7 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
                 selected = editor.selected_cell_index
 
         self.assertEqual(selected, (5, 1))
+        self.assertEqual(selected, object_list.selected_cell_index)
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_select_cell_indices(self):

--- a/traitsui/tests/editors/test_table_editor.py
+++ b/traitsui/tests/editors/test_table_editor.py
@@ -6,13 +6,10 @@ from traits.api import HasTraits, Instance, Int, List, Str, Tuple
 from traitsui.api import Action, EvalTableFilter, Item, ObjectColumn, TableEditor, View
 from traitsui.tests._tools import (
     BaseTestMixin,
-    create_ui,
     is_qt,
     is_wx,
-    process_cascade_events,
     press_ok_button,
     requires_toolkit,
-    reraise_exceptions,
     ToolkitName,
 )
 from traitsui.testing.api import (
@@ -308,16 +305,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         )
         object_list.selected = object_list.values[5]
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=select_row_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_row_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected
             elif is_wx():
                 selected = editor.selected_row
-
-            process_cascade_events()
 
         self.assertIs(selected, object_list.values[5])
 
@@ -328,16 +322,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         )
         object_list.selections = object_list.values[5:7]
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=select_rows_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_rows_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected
             elif is_wx():
                 selected = editor.selected_rows
-
-            process_cascade_events()
 
         self.assertEqual(selected, object_list.values[5:7])
 
@@ -348,16 +339,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         )
         object_list.selected_index = 5
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=select_row_index_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_row_index_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected_indices
             elif is_wx():
                 selected = editor.selected_row_index
-
-            process_cascade_events()
 
         self.assertEqual(selected, 5)
 
@@ -369,16 +357,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list.selected_indices = [5, 7, 8]
 
         view = select_row_indices_view
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected_indices
             elif is_wx():
                 selected = editor.selected_row_indices
-
-            process_cascade_events()
 
         self.assertEqual(selected, [5, 7, 8])
 
@@ -389,16 +374,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         )
         object_list.selected_column = "value"
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=select_column_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_column_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected
             elif is_wx():
                 selected = editor.selected_column
-
-            process_cascade_events()
 
         self.assertEqual(selected, "value")
 
@@ -409,16 +391,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         )
         object_list.selected_columns = ["value", "other_value"]
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=select_columns_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_columns_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected
             elif is_wx():
                 selected = editor.selected_columns
-
-            process_cascade_events()
 
         self.assertEqual(selected, ["value", "other_value"])
 
@@ -430,16 +409,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list.selected_index = 1
 
         view = select_column_index_view
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected_indices
             elif is_wx():
                 selected = editor.selected_column_index
-
-            process_cascade_events()
 
         self.assertEqual(selected, 1)
 
@@ -451,16 +427,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list.selected_indices = [0, 1]
 
         view = select_column_indices_view
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected_indices
             elif is_wx():
                 selected = editor.selected_column_indices
-
-            process_cascade_events()
 
         self.assertEqual(selected, [0, 1])
 
@@ -471,16 +444,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         )
         object_list.selected_cell = (object_list.values[5], "value")
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=select_cell_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_cell_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected
             elif is_wx():
                 selected = editor.selected_cell
-
-            process_cascade_events()
 
         self.assertEqual(selected, (object_list.values[5], "value"))
 
@@ -509,10 +479,10 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
             wrapper = tester.find_by_name(ui, "values")
 
             wrapper.locate(Cell(5, 0)).perform(MouseClick())
-            #self.assertEqual(object_list.selected.value, str(5 ** 2))
+            self.assertEqual(object_list.selected.value, str(5 ** 2))
 
             wrapper.locate(Cell(6, 0)).perform(MouseClick())
-            #self.assertEqual(object_list.selected.value, str(6 ** 2))
+            self.assertEqual(object_list.selected.value, str(6 ** 2))
 
     @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
     def test_table_editor_modify_cell_with_tester(self):
@@ -597,16 +567,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
             (object_list.values[8], "value"),
         ]
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=select_cells_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=select_cells_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected
             elif is_wx():
                 selected = editor.selected_cells
-
-            process_cascade_events()
 
         self.assertEqual(selected, [
             (object_list.values[5], "value"),
@@ -622,16 +589,13 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list.selected_cell_index = (5, 1)
 
         view = select_cell_index_view
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected_indices
             elif is_wx():
                 selected = editor.selected_cell_index
-
-            process_cascade_events()
 
         self.assertEqual(selected, (5, 1))
 
@@ -643,16 +607,14 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list.selected_cell_indices = [(5, 0), (6, 1), (8, 0)]
 
         view = select_cell_indices_view
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             if is_qt():
                 selected = editor.selected_indices
             elif is_wx():
                 selected = editor.selected_cell_indices
 
-            process_cascade_events()
         self.assertEqual(selected, [(5, 0), (6, 1), (8, 0)])
 
     @requires_toolkit([ToolkitName.qt])
@@ -675,10 +637,9 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         object_list = ObjectList(
             values=[ListItem(value=str(i ** 2)) for i in range(10)]
         )
-
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=progress_view)) as ui:
-            process_cascade_events()
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=progress_view)) as ui:
+            pass
 
     @requires_toolkit([ToolkitName.qt])
     def test_on_perform_action(self):
@@ -690,10 +651,9 @@ class TestTableEditor(BaseTestMixin, unittest.TestCase):
         mock_function = Mock()
         action = Action(on_perform=mock_function)
 
-        with reraise_exceptions(), \
-                create_ui(object_list, dict(view=simple_view)) as ui:
+        tester = UITester()
+        with tester.create_ui(object_list, dict(view=simple_view)) as ui:
             editor = ui.get_editors("values")[0]
-            process_cascade_events()
             editor.set_menu_context(None, None, None)
             editor.perform(action)
         mock_function.assert_called_once()


### PR DESCRIPTION
These are old local changes I had made a _while_ back to add UITester support for TableEditor.  I am openning this PR for reference now, but will close immediately.  
The plan is to pull the useful bits into a new PR that is intended to be merged, hopefully coming soon

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)