### PR TITLE
UITester DirectoryEditor support

### DIFF
--- a/docs/releases/upcoming/1710.feature.rst
+++ b/docs/releases/upcoming/1710.feature.rst
@@ -1,0 +1,1 @@
+Add UITester DirectoryEditor support (#1710)

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/directory_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/directory_editor.py
@@ -1,0 +1,32 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traitsui.testing.tester._ui_tester_registry.qt4._registry_helper import (
+    register_editable_textbox_handlers,
+)
+from traitsui.qt4.directory_editor import SimpleEditor
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+
+    register_editable_textbox_handlers(
+        registry=registry,
+        target_class=SimpleEditor,
+        widget_getter=lambda wrapper: wrapper._target._file_name,
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -13,6 +13,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     boolean_editor,
     button_editor,
     check_list_editor,
+    directory_editor,
     editor_factory,
     enum_editor,
     file_editor,
@@ -45,6 +46,9 @@ def get_default_registries():
 
     # CheckListEditor
     check_list_editor.register(registry)
+
+    # DirectoryEditor
+    directory_editor.register(registry)
 
     # EnumEditor
     enum_editor.register(registry)

--- a/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/directory_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/_traitsui/directory_editor.py
@@ -1,0 +1,31 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traitsui.wx.directory_editor import SimpleEditor
+from traitsui.testing.tester._ui_tester_registry.wx._registry_helper import (
+    register_editable_textbox_handlers,
+)
+
+
+def register(registry):
+    """ Register interactions for the given registry.
+
+    If there are any conflicts, an error will occur.
+
+    Parameters
+    ----------
+    registry : TargetRegistry
+        The registry being registered to.
+    """
+    register_editable_textbox_handlers(
+        registry=registry,
+        target_class=SimpleEditor,
+        widget_getter=lambda wrapper: wrapper._target._file_name,
+    )

--- a/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/wx/default_registry.py
@@ -13,6 +13,7 @@ from traitsui.testing.tester._ui_tester_registry.wx._traitsui import (
     boolean_editor,
     button_editor,
     check_list_editor,
+    directory_editor,
     editor_factory,
     enum_editor,
     file_editor,
@@ -45,6 +46,9 @@ def get_default_registries():
 
     # CheckListEditor
     check_list_editor.register(registry)
+
+    # DirectoryEditor
+    directory_editor.register(registry)
 
     # EnumEditor
     enum_editor.register(registry)

--- a/traitsui/tests/editors/test_directory_editor.py
+++ b/traitsui/tests/editors/test_directory_editor.py
@@ -15,9 +15,7 @@ from traitsui.api import DirectoryEditor, Item, View
 from traitsui.testing.api import DisplayedText, KeyClick, KeySequence, UITester
 from traitsui.tests._tools import (
     BaseTestMixin,
-    create_ui,
     requires_toolkit,
-    reraise_exceptions,
     ToolkitName,
 )
 

--- a/traitsui/tests/editors/test_directory_editor.py
+++ b/traitsui/tests/editors/test_directory_editor.py
@@ -12,6 +12,7 @@ import unittest
 
 from traits.api import Directory, Event, HasTraits
 from traitsui.api import DirectoryEditor, Item, View
+from traitsui.testing.api import DisplayedText, KeyClick, KeySequence, UITester
 from traitsui.tests._tools import (
     BaseTestMixin,
     create_ui,
@@ -43,8 +44,7 @@ class TestDirectoryEditor(BaseTestMixin, unittest.TestCase):
         # Test init and dispose by opening and closing the UI
         view = View(Item("dir_path", editor=DirectoryEditor(), style=style))
         obj = DirectoryModel()
-        with reraise_exceptions(), \
-                create_ui(obj, dict(view=view)):
+        with UITester().create_ui(obj, dict(view=view)):
             pass
 
     def test_simple_editor_init_and_dispose(self):
@@ -64,8 +64,49 @@ class TestDirectoryEditor(BaseTestMixin, unittest.TestCase):
             ),
         )
         obj = DirectoryModel()
-        with reraise_exceptions():
-            with create_ui(obj, dict(view=view)):
-                pass
-            # should not fail.
-            obj.reload_event = True
+        with UITester().create_ui(obj, dict(view=view)):
+            pass
+        # should not fail.
+        obj.reload_event = True
+
+    # Behavior on wx may not be quite the same on other platforms.
+    @requires_toolkit([ToolkitName.qt])
+    def test_simple_editor_set_text_to_nonexisting_path(self):
+        # Test setting the editor to a nonexisting dirpath
+        # e.g. use case for creating a new file.
+        view = View(Item("dir_path", editor=DirectoryEditor()))
+        obj = DirectoryModel()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            dirpath_field = tester.find_by_name(ui, "dir_path")
+
+            dirpath_field.perform(KeySequence("some_dir"))
+            dirpath_field.perform(KeyClick("Enter"))
+
+            self.assertEqual(obj.dir_path, "some_dir")
+
+    def test_simple_editor_display_path(self):
+        # Test the filepath widget is updated to show path
+        view = View(Item("dir_path", editor=DirectoryEditor()))
+        obj = DirectoryModel()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            dirpath_field = tester.find_by_name(ui, "dir_path")
+            self.assertEqual(dirpath_field.inspect(DisplayedText()), "")
+
+            obj.dir_path = "some_dir"
+            self.assertEqual(
+                dirpath_field.inspect(DisplayedText()), "some_dir"
+            )
+
+    # Behavior on wx may not be quite the same on other platforms.
+    @requires_toolkit([ToolkitName.qt])
+    def test_simple_editor_auto_set_text(self):
+        # Test with auto_set set to True.
+        view = View(Item("dir_path", editor=DirectoryEditor(auto_set=True)))
+        obj = DirectoryModel()
+        tester = UITester()
+        with tester.create_ui(obj, dict(view=view)) as ui:
+            dirpath_field = tester.find_by_name(ui, "dir_path")
+            dirpath_field.perform(KeySequence("some_dir"))
+            self.assertEqual(obj.dir_path, "some_dir")


### PR DESCRIPTION
Start of #1337 

This PR adds very basic UITester support for `DirectoryEditor`.  It does effectively exactly the same as what currently exists for `FileEditor`.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)