### PR TITLE
Skip remaining tabular editor tests on wx as they are failing

### DIFF
--- a/traitsui/tests/editors/test_tabular_editor.py
+++ b/traitsui/tests/editors/test_tabular_editor.py
@@ -352,6 +352,7 @@ class TestTabularEditor(BaseTestMixin, UnittestTools, unittest.TestCase):
             self.assertEqual(sorted(get_selected_rows(editor)), [1, 2])
             self.assertEqual(sorted(report.selected_rows), [1, 2])
 
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_selected_reacts_to_model_changes(self):
         with self.report_and_editor(get_view()) as (report, editor):
             people = report.people
@@ -375,6 +376,7 @@ class TestTabularEditor(BaseTestMixin, UnittestTools, unittest.TestCase):
             self.assertIsNone(report.selected)
             self.assertEqual(report.selected_row, -1)
 
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_event_synchronization(self):
         with self.report_and_editor(get_view()) as (report, editor):
             with self.assertTraitChanges(editor, "refresh", count=1):
@@ -388,6 +390,7 @@ class TestTabularEditor(BaseTestMixin, UnittestTools, unittest.TestCase):
             with self.assertTraitChanges(editor, "update", count=1):
                 report.update = True
 
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_adapter_columns_changes(self):
         # Regression test for enthought/traitsui#894
         with reraise_exceptions(), \
@@ -404,6 +407,7 @@ class TestTabularEditor(BaseTestMixin, UnittestTools, unittest.TestCase):
             editor.adapter.columns = [("Name", "name")]
             process_cascade_events()
 
+    @unittest.skipIf(is_wx(), "Issue enthought/traitsui#752")
     def test_view_column_resized_attribute_error_workaround(self):
         # This tests the workaround which checks if `factory` is None before
         # using it while resizing the columns.


### PR DESCRIPTION
Part of #1533 

This PR skips the remaining tests for TabularEditor on wx (some were skipped already, see #752)

When running the test suite on master, I see 9 tests run with 3 failures and 1 error:
<details>

```
======================================================================
ERROR: test_adapter_columns_changes (traitsui.tests.editors.test_tabular_editor.TestTabularEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/_exception_handling.py", line 64, in reraise_exceptions
    yield
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/tester/ui_tester.py", line 123, in create_ui
    process_cascade_events()
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/_gui.py", line 40, in process_cascade_events
    GUI.process_events()
  File "/Users/aayres/Desktop/pyface/pyface/ui/wx/gui.py", line 79, in process_events
    wx.GetApp().Yield(True)
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(470) in ~wxWindowBase(): any pushed event handlers must have been removed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 405, in test_adapter_columns_changes
    process_cascade_events()
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 431, in report_and_editor
    yield report, editor
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/tester/ui_tester.py", line 123, in create_ui
    process_cascade_events()
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 99, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/_exception_handling.py", line 74, in reraise_exceptions
    raise RuntimeError(msg)
RuntimeError: Uncaught exceptions found.
=== Exception (type: <class 'AttributeError'>, value: 'NoneType' object has no attribute 'name') ===
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/tabular_editor.py", line 194, in OnGetItemText
    return editor.adapter.get_text(editor.object, editor.name, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 405, in get_text
    return self._result_for("get_text", object, trait, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 739, in _result_for
    return handler()
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 747, in <lambda>
    return lambda: getattr(self, name)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 560, in _get_text
    ) % self.get_content(self.object, self.name, self.row, self.column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 410, in get_content
    return self._result_for("get_content", object, trait, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 739, in _result_for
    return handler()
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 747, in <lambda>
    return lambda: getattr(self, name)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 582, in _get_content
    return getattr(self.item, self.column_id)
AttributeError: 'NoneType' object has no attribute 'name'

=== Exception (type: <class 'AttributeError'>, value: 'NoneType' object has no attribute 'name') ===
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/tabular_editor.py", line 194, in OnGetItemText
    return editor.adapter.get_text(editor.object, editor.name, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 405, in get_text
    return self._result_for("get_text", object, trait, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 683, in _result_for
    return handler()
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 747, in <lambda>
    return lambda: getattr(self, name)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 560, in _get_text
    ) % self.get_content(self.object, self.name, self.row, self.column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 410, in get_content
    return self._result_for("get_content", object, trait, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 683, in _result_for
    return handler()
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 747, in <lambda>
    return lambda: getattr(self, name)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 582, in _get_content
    return getattr(self.item, self.column_id)
AttributeError: 'NoneType' object has no attribute 'name'

=== Exception (type: <class 'AttributeError'>, value: 'NoneType' object has no attribute 'name') ===
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/wx/tabular_editor.py", line 194, in OnGetItemText
    return editor.adapter.get_text(editor.object, editor.name, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 405, in get_text
    return self._result_for("get_text", object, trait, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 683, in _result_for
    return handler()
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 747, in <lambda>
    return lambda: getattr(self, name)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 560, in _get_text
    ) % self.get_content(self.object, self.name, self.row, self.column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 410, in get_content
    return self._result_for("get_content", object, trait, row, column)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 683, in _result_for
    return handler()
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 747, in <lambda>
    return lambda: getattr(self, name)
  File "/Users/aayres/Desktop/traitsui/traitsui/tabular_adapter.py", line 582, in _get_content
    return getattr(self.item, self.column_id)
AttributeError: 'NoneType' object has no attribute 'name'


======================================================================
FAIL: test_event_synchronization (traitsui.tests.editors.test_tabular_editor.TestTabularEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 389, in test_event_synchronization
    report.update = True
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 431, in report_and_editor
    yield report, editor
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/tester/ui_tester.py", line 123, in create_ui
    process_cascade_events()
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/_gui.py", line 40, in process_cascade_events
    GUI.process_events()
  File "/Users/aayres/Desktop/pyface/pyface/ui/wx/gui.py", line 79, in process_events
    wx.GetApp().Yield(True)
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(470) in ~wxWindowBase(): any pushed event handlers must have been removed

======================================================================
FAIL: test_selected_reacts_to_model_changes (traitsui.tests.editors.test_tabular_editor.TestTabularEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 376, in test_selected_reacts_to_model_changes
    self.assertEqual(report.selected_row, -1)
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 431, in report_and_editor
    yield report, editor
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/tester/ui_tester.py", line 123, in create_ui
    process_cascade_events()
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/_gui.py", line 40, in process_cascade_events
    GUI.process_events()
  File "/Users/aayres/Desktop/pyface/pyface/ui/wx/gui.py", line 79, in process_events
    wx.GetApp().Yield(True)
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(470) in ~wxWindowBase(): any pushed event handlers must have been removed

======================================================================
FAIL: test_view_column_resized_attribute_error_workaround (traitsui.tests.editors.test_tabular_editor.TestTabularEditor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 414, in test_view_column_resized_attribute_error_workaround
    editor.adapter.columns = [("Name", "name")]
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/tests/editors/test_tabular_editor.py", line 431, in report_and_editor
    yield report, editor
  File "/Users/aayres/.edm/envs/traitsui-test-3.6-wx/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/tester/ui_tester.py", line 123, in create_ui
    process_cascade_events()
  File "/Users/aayres/Desktop/traitsui/traitsui/testing/_gui.py", line 40, in process_cascade_events
    GUI.process_events()
  File "/Users/aayres/Desktop/pyface/pyface/ui/wx/gui.py", line 79, in process_events
    wx.GetApp().Yield(True)
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(470) in ~wxWindowBase(): any pushed event handlers must have been removed

----------------------------------------------------------------------
Ran 9 tests in 0.388s

FAILED (failures=3, errors=1, skipped=5)
```

</details>

All of these tracebacks contain the ...`any pushed event handlers must have been removed` line like what is mentioned on #752

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)