### PR TITLE
[WIP] UITester support for qt TreeEditor

### DIFF
--- a/traitsui/examples/demo/Standard_Editors/tests/test_TreeEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/tests/test_TreeEditor_demo.py
@@ -1,0 +1,85 @@
+# (C) Copyright 2004-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+This example demonstrates how to test interacting with a TreeEditor.
+
+The GUI being tested is written in the demo under the same name (minus the
+preceding 'test') in the outer directory.
+"""
+
+import os
+import runpy
+import unittest
+
+from traitsui.testing.api import (
+    DisplayedText,
+    KeyClick,
+    KeySequence,
+    MouseClick,
+    MouseDClick,
+    TreeNode,
+    UITester
+)
+from traitsui.tests._tools import requires_toolkit, ToolkitName
+
+#: Filename of the demo script
+FILENAME = "TreeEditor_demo.py"
+
+#: Path of the demo script
+DEMO_PATH = os.path.join(os.path.dirname(__file__), "..", FILENAME)
+
+
+class TestTreeEditorDemo(unittest.TestCase):
+
+    @requires_toolkit([ToolkitName.qt])
+    def test_tree_editor_demo(self):
+        demo = runpy.run_path(DEMO_PATH)["demo"]
+        tester = UITester()
+        with tester.create_ui(demo) as ui:
+            root_actor = tester.find_by_name(ui, "company")
+
+            # Enthought->Department->Business->(First employee)
+            node = root_actor.locate(TreeNode((0, 0, 0, 0), 0))
+            node.perform(MouseClick())
+
+            name_actor = node.find_by_name("name")
+            for _ in range(5):
+                name_actor.perform(KeyClick("Backspace"))
+            name_actor.perform(KeySequence("James"))
+            self.assertEqual(
+                demo.company.departments[0].employees[0].name,
+                "James",
+            )
+
+            # Enthought->Department->Scientific
+            demo.company.departments[1].name = "Scientific Group"
+            node = root_actor.locate(TreeNode((0, 0, 1), 0))
+            self.assertEqual(
+                node.inspect(DisplayedText()), "Scientific Group"
+            )
+
+            # Enthought->Department->Business
+            node = root_actor.locate(TreeNode((0, 0, 0), 0))
+            node.perform(MouseClick())
+            node.perform(MouseDClick())
+
+            name_actor = node.find_by_name("name")
+            name_actor.perform(KeySequence(" Group"))
+            self.assertEqual(
+                demo.company.departments[0].name,
+                "Business Group",
+            )
+
+
+# Run the test(s)
+unittest.TextTestRunner().run(
+    unittest.TestLoader().loadTestsFromTestCase(TestTreeEditorDemo)
+)

--- a/traitsui/testing/api.py
+++ b/traitsui/testing/api.py
@@ -22,6 +22,7 @@ Interactions (for changing GUI states)
 - :class:`~.KeyClick`
 - :class:`~.KeySequence`
 - :class:`~.MouseClick`
+- :class:`~.MouseDClick`
 
 Interactions (for getting GUI states)
 -------------------------------------
@@ -39,6 +40,8 @@ Locations (for locating GUI elements)
 - :class:`~.TargetById`
 - :class:`~.TargetByName`
 - :class:`~.Textbox`
+- :class:`~.TreeNode`
+- :class:`~.SelectedText`
 
 Advanced usage
 --------------
@@ -63,6 +66,7 @@ from .tester.ui_tester import UITester
 # Interactions (for changing GUI states)
 from .tester.command import (
     MouseClick,
+    MouseDClick,
     KeyClick,
     KeySequence
 )
@@ -82,6 +86,7 @@ from .tester.locator import (
     TargetById,
     TargetByName,
     Textbox,
+    TreeNode,
     Slider
 )
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_interaction_helpers.py
@@ -205,6 +205,119 @@ def mouse_click_item_view(model, view, index, delay):
     )
 
 
+def mouse_dclick_item_view(model, view, index, delay):
+    """ Perform mouse double click on the given QAbstractItemModel (model) and
+    QAbstractItemView (view) with the given row and column.
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and mouse double click be performed.
+    index : QModelIndex
+    Raises
+    ------
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    rect = view.visualRect(index)
+    QTest.mouseDClick(
+        view.viewport(),
+        QtCore.Qt.LeftButton,
+        QtCore.Qt.NoModifier,
+        rect.center(),
+        delay=delay,
+    )
+
+
+def key_sequence_item_view(model, view, index, sequence, delay=0):
+    """ Perform Key Sequence on the given QAbstractItemModel (model) and
+    QAbstractItemView (view) with the given row and column.
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and key sequence be performed.
+    index : QModelIndex
+    sequence : str
+        Sequence of characters to be inserted to the widget identifed
+        by the row and column.
+    Raises
+    ------
+    Disabled
+        If the widget cannot be edited.
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    widget = view.indexWidget(index)
+    if widget is None:
+        raise Disabled(
+            "No editable widget for item at row {!r} and column {!r}".format(
+                index.row(), index.column()
+            )
+        )
+    QTest.keyClicks(widget, sequence, delay=delay)
+
+
+def key_click_item_view(model, view, index, key, delay=0):
+    """ Perform key press on the given QAbstractItemModel (model) and
+    QAbstractItemView (view) with the given row and column.
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and key press be performed.
+    index : int
+    key : str
+        Key to be pressed.
+    Raises
+    ------
+    Disabled
+        If the widget cannot be edited.
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    widget = view.indexWidget(index)
+    if widget is None:
+        raise Disabled(
+            "No editable widget for item at row {!r} and column {!r}".format(
+                index.row(), index.column()
+            )
+        )
+    key_click(widget, key=key, delay=delay)
+
+
+def get_display_text_item_view(model, view, index):
+    """ Return the textural representation for the given model, row and column.
+    Parameters
+    ----------
+    model : QAbstractItemModel
+        Model from which QModelIndex will be obtained
+    view : QAbstractItemView
+        View from which the widget identified by the index will be
+        found and key press be performed.
+    index : int
+    Raises
+    ------
+    LookupError
+        If the index cannot be located.
+        Note that the index error provides more
+    """
+    check_q_model_index_valid(index)
+    return model.data(index, QtCore.Qt.DisplayRole)
+
+
 def mouse_click_combobox(combobox, index, delay):
     """ Perform a mouse click on a QComboBox at a given index.
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/tree_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/tree_editor.py
@@ -10,8 +10,16 @@
 #
 
 from traitsui.qt4.tree_editor import SimpleEditor
-from traitsui.testing.tester.qt4 import helpers
-from traitsui.testing.tester import command, locator, registry_helper, query
+
+
+from traitsui.testing.tester.command import (
+    MouseClick, MouseDClick, KeyClick, KeySequence
+)
+from traitsui.testing.tester.locator import TreeNode
+from traitsui.testing.tester.query import DisplayedText
+from traitsui.testing.tester._ui_tester_registry.qt4 import (
+    _interaction_helpers
+)
 
 from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
     BaseSourceWithLocation
@@ -22,21 +30,24 @@ from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
 
 class _SimpleEditorWithTreeNode(BaseSourceWithLocation):
     source_class = SimpleEditor
-    locator_class = locator.TreeNode
+    locator_class = TreeNode
     handlers = [
-        (command.MouseClick, lambda wrapper, interaction: _mouse_click(delay=wrapper.delay)),
-        (command.KeySequence,
-            lambda wrapper, action: _key_sequence(
+        (MouseClick, lambda wrapper, _: wrapper._target._mouse_click(
+            delay=wrapper.delay)),
+        (MouseDClick, lambda wrapper, _: wrapper._target._mouse_dclick(
+            delay=wrapper.delay)),
+        (KeySequence,
+            lambda wrapper, action: wrapper._target._key_sequence(
                 sequence=action.sequence,
                 delay=wrapper.delay,
             )),
-        (command.KeyClick,
-            lambda wrapper, action: _key_press(
+        (KeyClick,
+            lambda wrapper, action: wrapper._target._key_press(
                 key=action.key,
                 delay=wrapper.delay,
             )),
-        (query.DisplayedText,
-            lambda wrapper, _:  _get_displayed_text()),
+        (DisplayedText,
+            lambda wrapper, _:  wrapper._target._get_displayed_text()),
     ]
 
     @classmethod
@@ -73,33 +84,33 @@ class _SimpleEditorWithTreeNode(BaseSourceWithLocation):
         )
 
     def _mouse_click(self, delay=0):
-        helpers.mouse_click_item_view(
+        _interaction_helpers.mouse_click_item_view(
             **self._get_model_view_index(),
             delay=delay,
         )
 
     def _mouse_dclick(self, delay=0):
-        helpers.mouse_dclick_item_view(
+        _interaction_helpers.mouse_dclick_item_view(
             **self._get_model_view_index(),
             delay=delay,
         )
 
     def _key_press(self, key, delay=0):
-        helpers.key_press_item_view(
+        _interaction_helpers.key_press_item_view(
             **self._get_model_view_index(),
             key=key,
             delay=delay,
         )
 
     def _key_sequence(self, sequence, delay=0):
-        helpers.key_sequence_item_view(
+        _interaction_helpers.key_sequence_item_view(
             **self._get_model_view_index(),
             sequence=sequence,
             delay=delay,
         )
 
     def _get_displayed_text(self):
-        return helpers.get_display_text_item_view(
+        return _interaction_helpers.get_display_text_item_view(
             **self._get_model_view_index(),
         )
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/tree_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/tree_editor.py
@@ -70,16 +70,16 @@ class _SimpleEditorWithTreeNode(BaseSourceWithLocation):
         )
 
     def _get_model_view_index(self):
-        tree_view = self.source._tree
+        tree_widget = self.source._tree
         i_column = self.location.column
         i_rows = iter(self.location.row)
-        item = tree_view.topLevelItem(next(i_rows))
+        item = tree_widget.topLevelItem(next(i_rows))
         for i_row in i_rows:
             item = item.child(i_row)
-        q_model_index = tree_view.indexFromItem(item, i_column)
+        q_model_index = tree_widget.indexFromItem(item, i_column)
         return dict(
-            model=tree_view.model(),
-            view=tree_view,
+            model=tree_widget.model(),
+            view=tree_widget,
             index=q_model_index,
         )
 

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/tree_editor.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/_traitsui/tree_editor.py
@@ -1,0 +1,114 @@
+#  Copyright (c) 2005-2020, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+
+from traitsui.qt4.tree_editor import SimpleEditor
+from traitsui.testing.tester.qt4 import helpers
+from traitsui.testing.tester import command, locator, registry_helper, query
+
+from traitsui.testing.tester._ui_tester_registry._common_ui_targets import (
+    BaseSourceWithLocation
+)
+from traitsui.testing.tester._ui_tester_registry._traitsui_ui import (
+    register_traitsui_ui_solvers,
+)
+
+class _SimpleEditorWithTreeNode(BaseSourceWithLocation):
+    source_class = SimpleEditor
+    locator_class = locator.TreeNode
+    handlers = [
+        (command.MouseClick, lambda wrapper, interaction: _mouse_click(delay=wrapper.delay)),
+        (command.KeySequence,
+            lambda wrapper, action: _key_sequence(
+                sequence=action.sequence,
+                delay=wrapper.delay,
+            )),
+        (command.KeyClick,
+            lambda wrapper, action: _key_press(
+                key=action.key,
+                delay=wrapper.delay,
+            )),
+        (query.DisplayedText,
+            lambda wrapper, _:  _get_displayed_text()),
+    ]
+
+    @classmethod
+    def register(cls, registry):
+        """ Class method to register interactions on a
+        _SimpleEditorWithTreeNode for the given registry.
+
+        If there are any conflicts, an error will occur.
+
+        Parameters
+        ----------
+        registry : TargetRegistry
+            The registry being registered to.
+        """
+        super().register(registry)
+        register_traitsui_ui_solvers(
+            registry=registry,
+            target_class=cls,
+            traitsui_ui_getter=lambda target: target._get_nested_ui()
+        )
+
+    def _get_model_view_index(self):
+        tree_view = self.source._tree
+        i_column = self.location.column
+        i_rows = iter(self.location.row)
+        item = tree_view.topLevelItem(next(i_rows))
+        for i_row in i_rows:
+            item = item.child(i_row)
+        q_model_index = tree_view.indexFromItem(item, i_column)
+        return dict(
+            model=tree_view.model(),
+            view=tree_view,
+            index=q_model_index,
+        )
+
+    def _mouse_click(self, delay=0):
+        helpers.mouse_click_item_view(
+            **self._get_model_view_index(),
+            delay=delay,
+        )
+
+    def _mouse_dclick(self, delay=0):
+        helpers.mouse_dclick_item_view(
+            **self._get_model_view_index(),
+            delay=delay,
+        )
+
+    def _key_press(self, key, delay=0):
+        helpers.key_press_item_view(
+            **self._get_model_view_index(),
+            key=key,
+            delay=delay,
+        )
+
+    def _key_sequence(self, sequence, delay=0):
+        helpers.key_sequence_item_view(
+            **self._get_model_view_index(),
+            sequence=sequence,
+            delay=delay,
+        )
+
+    def _get_displayed_text(self):
+        return helpers.get_display_text_item_view(
+            **self._get_model_view_index(),
+        )
+
+    def _get_nested_ui(self):
+        """ Method to get the nested ui corresponding to the List element at
+        the given index.
+        """
+        return self.source._editor._node_ui
+
+
+def register(registry):
+    _SimpleEditorWithTreeNode.register(registry)

--- a/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/default_registry.py
@@ -21,6 +21,7 @@ from traitsui.testing.tester._ui_tester_registry.qt4._traitsui import (
     list_editor,
     range_editor,
     text_editor,
+    tree_editor,
     ui_base,
 )
 from ._control_widget_registry import get_widget_registry
@@ -72,6 +73,9 @@ def get_default_registries():
 
     # Editor Factory
     editor_factory.register(registry)
+
+    # TreeEditor
+    tree_editor.register(registry)
 
     # The more general registry goes after the more specific registry.
     return [

--- a/traitsui/testing/tester/command.py
+++ b/traitsui/testing/tester/command.py
@@ -27,6 +27,16 @@ class MouseClick:
     pass
 
 
+class MouseDClick:
+    """ An object representing the user double clicking a mouse button.
+    Currently the left mouse button is assumed.
+    In most circumstances, a widget can still be clicked on even if it is
+    disabled. Therefore unlike key events, if the widget is disabled,
+    implementations should not raise an exception.
+    """
+    pass
+
+
 class KeySequence:
     """ An object representing the user typing a sequence of keys.
 

--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -54,15 +54,8 @@ class TargetById:
 
 
 class TreeNode:
-    """ A locator for locating a target uniquely specified by a row index and a
-    column index.
-
-    Attributes
-    ----------
-    row : int
-        0-based index
-    column : int
-        0-based index
+    """ A locator for locating a target in a Tree uniquely specified by a row
+    and a column.
     """
 
     def __init__(self, row, column):

--- a/traitsui/testing/tester/locator.py
+++ b/traitsui/testing/tester/locator.py
@@ -53,6 +53,24 @@ class TargetById:
         self.id = id
 
 
+class TreeNode:
+    """ A locator for locating a target uniquely specified by a row index and a
+    column index.
+
+    Attributes
+    ----------
+    row : int
+        0-based index
+    column : int
+        0-based index
+    """
+
+    def __init__(self, row, column):
+        self.row = row
+        self.column = column
+
+
+
 class Slider:
     """ A locator for locating a nested slider widget within a UI.
     """


### PR DESCRIPTION
This PR adds UITester support for the qt `TreeEditor`.  Note that some of the changes made here are identical to those made in #1707 (ie _interaction_helpers that work with `QAbstractItemModel`). This PR also currently adds a simple test for the `TreeEditor_demo` but I have not yet updated actual Tree Editor tests.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)