### PR TITLE
Use ubuntu-latest instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,9 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        # Note that Ubuntu 20 cannot be used because its SWIG version is 4.0
-        # (enthought/enable#360)
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         toolkit: ['pyside2']
         # Dependencies include chaco/enable, whose installation fails
         # on Python 3.8 and 3.9

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,8 @@
 name: Integration tests
 
 on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
   schedule:
     - cron:  '0 0 * * 4'
 


### PR DESCRIPTION
We were unable to use `ubuntu-latest` earlier because it shipped with swig 4 by default and enable didnt support swig 4. But the issue got fixed in enable so we should be able to use `ubuntu-latest` now.

Fixes #1660 
Xref https://github.com/enthought/enable/issues/360


**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~