### PR TITLE
Use "ubuntu-latest" for GitHub Actions CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,9 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        # Note that Ubuntu 20 cannot be used because its SWIG version is 4.0
-        # (enthought/enable#360)
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
         toolkit: ['pyside2']
         # Dependencies include chaco/enable, whose installation fails
         # on Python 3.8 and 3.9


### PR DESCRIPTION
This PR updates GitHub Actions CI to use `ubuntu-latest` instead of an older `ubuntu-*` version for integration tests. This is possible because the enable issue in question which necessitated an older ubuntu has been fixed. Ref enthought/enable#360

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~