### PR TITLE
fix Dynamic_EnumEditor_demo.py on qt

### DIFF
--- a/docs/releases/upcoming/1719.bugfix.rst
+++ b/docs/releases/upcoming/1719.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Dynamic EnumEditor on qt (#1719)

--- a/traitsui/examples/demo/Advanced/Dynamic_EnumEditor_demo.py
+++ b/traitsui/examples/demo/Advanced/Dynamic_EnumEditor_demo.py
@@ -57,7 +57,7 @@ Notes:
 """
 
 
-from traits.api import Enum, HasPrivateTraits, List, Constant
+from traits.api import Enum, HasPrivateTraits, Instance, List
 
 from traitsui.api import (
     View, Item, VGroup, HSplit, EnumEditor, CheckListEditor
@@ -97,7 +97,7 @@ class OrderMenu(HasPrivateTraits):
     entree = Enum(values='capabilities.available')
 
     # Reference to the restaurant's current entree capabilities:
-    capabilities = Constant(kitchen_capabilities)
+    capabilities = Instance(kitchen_capabilities, args=())
 
     # The user interface view:
     view = View(

--- a/traitsui/examples/demo/Advanced/Dynamic_EnumEditor_demo.py
+++ b/traitsui/examples/demo/Advanced/Dynamic_EnumEditor_demo.py
@@ -97,7 +97,10 @@ class OrderMenu(HasPrivateTraits):
     entree = Enum(values='capabilities.available')
 
     # Reference to the restaurant's current entree capabilities:
-    capabilities = Instance(kitchen_capabilities, args=())
+    capabilities = Instance(KitchenCapabilities)
+
+    def _capabilities_default(self):
+        return kitchen_capabilities
 
     # The user interface view:
     view = View(

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -90,13 +90,15 @@ class BaseEditor(Editor):
             )
             self.values_changed()
             self._object.observe(
-                self._values_updated, self._name + '.items', dispatch="ui"
+                self._update_values_and_rebuild_editor,
+                self._name + '.items',
+                dispatch="ui"
             )
         else:
             self._value = lambda: self.factory.values
             self.values_changed()
             factory.observe(
-                self._values_updated, "values", dispatch="ui"
+                self._update_values_and_rebuild_editor, "values", dispatch="ui"
             )
 
     def dispose(self):
@@ -104,14 +106,17 @@ class BaseEditor(Editor):
         """
         if self._object is not None:
             self._object.observe(
-                self._values_updated,
+                self._update_values_and_rebuild_editor,
                 self._name + '.items',
                 remove=True,
                 dispatch="ui"
             )
         else:
             self.factory.observe(
-                self._values_updated, "values", remove=True, dispatch="ui"
+                self._update_values_and_rebuild_editor,
+                "values",
+                remove=True,
+                dispatch="ui"
             )
 
         super().dispose()
@@ -139,7 +144,7 @@ class BaseEditor(Editor):
 
     # Trait change handlers --------------------------------------------------
 
-    def _values_updated(self, event=None):
+    def _update_values_and_rebuild_editor(self, event):
         """ Handles the underlying object model's enumeration set or factory's
             values being changed.
         """

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -90,13 +90,13 @@ class BaseEditor(Editor):
             )
             self.values_changed()
             self._object.observe(
-                self._values_changed, " " + self._name, dispatch="ui"
+                self._values_updated, self._name + '.items', dispatch="ui"
             )
         else:
             self._value = lambda: self.factory.values
             self.values_changed()
             factory.observe(
-                self._values_changed, "values", dispatch="ui"
+                self._values_updated, "values", dispatch="ui"
             )
 
     def dispose(self):
@@ -104,14 +104,14 @@ class BaseEditor(Editor):
         """
         if self._object is not None:
             self._object.observe(
-                self._values_changed,
-                " " + self._name,
+                self._values_updated,
+                self._name + '.items',
                 remove=True,
                 dispatch="ui"
             )
         else:
             self.factory.observe(
-                self._values_changed, "values", remove=True, dispatch="ui"
+                self._values_updated, "values", remove=True, dispatch="ui"
             )
 
         super().dispose()
@@ -139,7 +139,7 @@ class BaseEditor(Editor):
 
     # Trait change handlers --------------------------------------------------
 
-    def _values_changed(self, event=None):
+    def _values_updated(self, event=None):
         """ Handles the underlying object model's enumeration set or factory's
             values being changed.
         """


### PR DESCRIPTION
closes #1676 

For thee full saga see this comment:
https://github.com/enthought/traitsui/issues/1676#issuecomment-876585259

This PR fixes the example, by fixing a bug in EnumEditor itself.  In order to fully fix the issue, it also additionally updates the example to use an `Instance` rather than a `Constant` trait, since `Constant` doesn't seem to work with observe (?)
I will write up a MWE and open an issue (which can quickly be closed if this is in fact intentional).

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)