### PR TITLE
Fix table editor with progress column

### DIFF
--- a/docs/releases/upcoming/1721.bugfix.rst
+++ b/docs/releases/upcoming/1721.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ProgressColumn bars overlapping with PyQt5 and PySide2 (#1721)

--- a/traitsui/qt4/extra/progress_renderer.py
+++ b/traitsui/qt4/extra/progress_renderer.py
@@ -43,7 +43,7 @@ class ProgressRenderer(TableDelegate):
         # Draw it
         style = QtGui.QApplication.instance().style()
         # save painter state, translate painter to cell location, and then
-        # restore painter state after ddrawing to solve enthought/traitsui#964
+        # restore painter state after drawing to solve enthought/traitsui#964
         # ref: https://forum.qt.io/topic/105375/qitemdelegate-for-drawing-progress-bar-working-but-won-t-move-off-origin  # noqa: E501
         painter.save()
         painter.translate(option.rect.left(), option.rect.top())

--- a/traitsui/qt4/extra/progress_renderer.py
+++ b/traitsui/qt4/extra/progress_renderer.py
@@ -42,6 +42,9 @@ class ProgressRenderer(TableDelegate):
 
         # Draw it
         style = QtGui.QApplication.instance().style()
+        # save painter state, translate painter to cell location, and then
+        # restore painter state after ddrawing to solve enthought/traitsui#964
+        # ref: https://forum.qt.io/topic/105375/qitemdelegate-for-drawing-progress-bar-working-but-won-t-move-off-origin  # noqa: E501
         painter.save()
         painter.translate(option.rect.left(), option.rect.top())
         style.drawControl(

--- a/traitsui/qt4/extra/progress_renderer.py
+++ b/traitsui/qt4/extra/progress_renderer.py
@@ -42,8 +42,9 @@ class ProgressRenderer(TableDelegate):
 
         # Draw it
         style = QtGui.QApplication.instance().style()
+        painter.save()
         painter.translate(option.rect.left(), option.rect.top())
         style.drawControl(
             QtGui.QStyle.CE_ProgressBar, progress_bar_option, painter
         )
-        painter.resetTransform()
+        painter.restore()

--- a/traitsui/qt4/extra/progress_renderer.py
+++ b/traitsui/qt4/extra/progress_renderer.py
@@ -42,6 +42,8 @@ class ProgressRenderer(TableDelegate):
 
         # Draw it
         style = QtGui.QApplication.instance().style()
+        painter.translate(option.rect.left(), option.rect.top())
         style.drawControl(
             QtGui.QStyle.CE_ProgressBar, progress_bar_option, painter
         )
+        painter.resetTransform()


### PR DESCRIPTION
closes #964 by following the advice on https://forum.qt.io/topic/105375/qitemdelegate-for-drawing-progress-bar-working-but-won-t-move-off-origin

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)