### PR TITLE
Enable manual triggering of cron job

### DIFF
--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -6,6 +6,8 @@ name: Test with PyPI
 on:
   schedule:
     - cron:  '0 3 * * 4'
+  # Make it possible to manually trigger the workflow
+  workflow_dispatch:
 
 jobs:
   # Tests against Qt/Python packages from PyPI


### PR DESCRIPTION
This PR enables us to manually trigger cron job (for now, only the test-with-pip job). This is done using `workflow_dispatch`. Ref 
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

This allows us to debug the changes we are making to the configurations easily. Note that we intend to make other cron jobs manually triggerable as well - which will happen in a later PR.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~