### PR TITLE
Make it possible to manually trigger bleeding edge tests

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -5,6 +5,8 @@ name: ETS from source
 on:
   schedule:
     - cron:  '0 0 * * 4'
+  # Make it possible to manually trigger the workflow
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This PR makes it possible to manually trigger the bleeding edge github actions - using `workflow_dispatch` like we did earlier.


One more step towards https://github.com/enthought/ets/issues/68

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~