### PR TITLE
Fix selectable InstanceEditor combobox updates

### DIFF
--- a/docs/releases/upcoming/1725.bugfix.rst
+++ b/docs/releases/upcoming/1725.bugfix.rst
@@ -1,0 +1,1 @@
+Fix selectable InstanceEditor combobox updates (#1725)

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -28,6 +28,7 @@
 from pyface.qt import QtCore, QtGui
 
 from traits.api import HasTraits, Instance, Property
+from traits.observation.api import trait
 
 from traitsui.ui_traits import AView
 from traitsui.helper import user_name_for
@@ -187,7 +188,7 @@ class CustomEditor(Editor):
             # combobox. This change was added to fix enthought/traitsui#1641
             value.object.observe(
                 self.rebuild_items,
-                value.name_trait,
+                trait(value.name_trait, optional=True),
                 dispatch="ui"
             )
             items.append(value)

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -183,6 +183,13 @@ class CustomEditor(Editor):
         for value in values:
             if not isinstance(value, InstanceChoiceItem):
                 value = adapter(object=value)
+            # rebuild_items when an item's name changes so it is reflected by
+            # combobox. This change was added to fix enthought/traitsui#1641
+            value.object.observe(
+                self.rebuild_items,
+                value.name_trait,
+                dispatch="ui"
+            )
             items.append(value)
 
         self._items = items

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -45,7 +45,11 @@ class EditedInstance(HasTraits):
 class NamedInstance(HasTraits):
     name = Str()
     value = Str()
-    traits_view = View(Item("value"), buttons=["OK"])
+    traits_view = View(
+        Item("name"),
+        Item("value"),
+        buttons=["OK"]
+    )
 
 
 class ObjectWithInstance(HasTraits):
@@ -172,6 +176,31 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             instance = tester.find_by_name(ui, "inst")
             text = instance.inspect(SelectedText())
             self.assertEqual(text, obj.inst.name)
+
+    def test_custom_editor_with_selection_change_option_name(self):
+        obj = ObjectWithList()
+        tester = UITester()
+        with tester.create_ui(obj, {'view': selection_view}) as ui:
+            # test that the current object is None
+            self.assertIsNone(obj.inst)
+
+            # test that the displayed text is correct
+            instance = tester.find_by_name(ui, "inst")
+            text = instance.inspect(SelectedText())
+            self.assertEqual(text, obj.inst_list[0].name)
+
+            # actually select the first item
+            instance.locate(Index(0)).perform(MouseClick())
+            self.assertIs(obj.inst, obj.inst_list[0])
+
+            # test that the displayed text is still correct after change
+            name_txt = instance.find_by_name("name")
+            for _ in range(3):
+                name_txt.perform(KeyClick("Backspace"))
+            name_txt.perform(KeySequence("Something New"))
+            text = instance.inspect(SelectedText())
+            self.assertEqual(text, "Something New")
+            self.assertEqual("Something New", obj.inst_list[0].name)
 
     def test_custom_editor_resynch_editor(self):
         edited_inst = EditedInstance(value='hello')

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -177,7 +177,8 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             text = instance.inspect(SelectedText())
             self.assertEqual(text, obj.inst.name)
 
-    def test_custom_editor_with_selection_change_option_name(self):
+    # A regression test for issue enthought/traitsui#1725
+    def test_custom_editor_with_selection_change_option_name(self):     
         obj = ObjectWithList()
         tester = UITester()
         with tester.create_ui(obj, {'view': selection_view}) as ui:

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -178,7 +178,7 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(text, obj.inst.name)
 
     # A regression test for issue enthought/traitsui#1725
-    def test_custom_editor_with_selection_change_option_name(self):     
+    def test_custom_editor_with_selection_change_option_name(self):
         obj = ObjectWithList()
         tester = UITester()
         with tester.create_ui(obj, {'view': selection_view}) as ui:


### PR DESCRIPTION
closes #1641 
For full saga see comment https://github.com/enthought/traitsui/issues/1641#issuecomment-877321165

This solution works but I am not sure when one could unhook these observers (perhaps it isn't needed?)

~I will work on adding a regression test, although this _may_ require currently not existent UI Tester support for combobox of Instance Editor, I am not sure yet~

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)