### PR TITLE
add an expand_all method to TreeEditor

### DIFF
--- a/docs/releases/upcoming/1726.feature.rst
+++ b/docs/releases/upcoming/1726.feature.rst
@@ -1,0 +1,1 @@
+Add an expand_all method to TreeEditor (#1726)

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -272,6 +272,21 @@ class SimpleEditor(Editor):
                 for cnid in self._nodes_for(nid):
                     self.expand_levels(cnid, levels - 1)
 
+    def expand_all(self):
+        """ Expands all expandable nodes in the tree.
+
+        Warning: If the Tree contains a large number of items, this function
+        will be very slow.
+        """
+        iterator = QtGui.QTreeWidgetItemIterator(self._tree)
+        while iterator.value():
+            item = iterator.value()
+            expanded, node, object = self._get_node_data(item)
+            if self._has_children(node, object):
+                self._expand_node(item)
+                item.setExpanded(True)
+            iterator += 1
+
     def update_editor(self):
         """ Updates the editor when the object trait changes externally to the
             editor.

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -278,6 +278,8 @@ class SimpleEditor(Editor):
         Warning: If the Tree contains a large number of items, this function
         will be very slow.
         """
+        # For more info on the QtGui.QTreeWidgetItemIterator object,
+        # see https://doc.qt.io/qt-5/qtreewidgetitemiterator.html
         iterator = QtGui.QTreeWidgetItemIterator(self._tree)
         while iterator.value():
             item = iterator.value()


### PR DESCRIPTION
closes #673 
This PR took inspiration from the `expand_levels` method here:
https://github.com/enthought/traitsui/blob/fc3b8ac92eea79efba923ec2387f292c281eddf3/traitsui/qt4/tree_editor.py#L263-L273
and the second response here https://stackoverflow.com/questions/28829192/how-to-get-the-number-of-items-of-a-qtreewidget suggesting to make use of https://doc.qt.io/qt-5/qtreewidgetitemiterator.html#details for easy traversal of a `QTreeWidget`.

I found a lot of the TreeEditor internals hard to follow.  TraitsUI does its own thing setting `node_data` which takes the form `(expanded, node, object)`.  I am unclear on why expanded is included here as it could be directly accessed on the nid object via `nid.isExpanded()`.  However, this is very prevalent throughout the code so I left things as is for now rather than attempting a large refactor.  In the implementation in this PR I follow the lead of `expand_levels` to try to make use of the traitsUI way to expand nodes.  ie. calling the editors `_expand_node` method _and_ calling `setExpanded(True)` on the `nid` (which is a `QTreeWidgetItem`.  

To test this code, I used the code provided on the issue, with a very slight modification - I changed the line `editor._tree.expandAll()` to `editor.expand_all()`.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)