### PR TITLE
Setup slack notification for cron jobs

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -42,3 +42,31 @@ jobs:
         with:
           run: python -m unittest discover -v traitsui
           working-directory: ${{ runner.temp }}
+
+  notify-on-failure:
+    needs: test
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-success:
+    needs: test
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,3 +43,31 @@ jobs:
         with:
           run: python -m unittest discover -v ${{ github.workspace }}/integrationtests
           working-directory: ${{ runner.temp }}
+
+  notify-on-failure:
+    needs: test
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-success:
+    needs: test
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -41,34 +41,6 @@ jobs:
           run: python -m unittest discover -v traitsui
           working-directory: ${{ runner.temp }}
 
-  notify-on-qt-failure:
-    needs: pip-qt
-    if: failure()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on failure
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: FAILED
-          color: danger
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
-  notify-on-qt-success:
-    needs: pip-qt
-    if: success()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify Slack channel on success
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
-          status: SUCCESS
-          color: good
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
-
   # Tests against wxPython from PyPI
   # On OSX:
   #   - wxPython complains about 'This program needs access to the screen'.
@@ -105,8 +77,8 @@ jobs:
           run: python -m unittest discover -v traitsui
           working-directory: ${{ runner.temp }}
 
-  notify-on-wx-failure:
-    needs: pip-wx
+  notify-on-failure:
+    needs: [pip-qt, pip-wx]
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -119,8 +91,8 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
-  notify-on-wx-success:
-    needs: pip-wx
+  notify-on-success:
+    needs: [pip-qt, pip-wx]
     if: success()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -76,3 +76,31 @@ jobs:
         with:
           run: python -m unittest discover -v traitsui
           working-directory: ${{ runner.temp }}
+
+  notify-on-failure:
+    needs: pip-qt
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+
+  notify-on-success:
+    needs: pip-qt
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -41,6 +41,34 @@ jobs:
           run: python -m unittest discover -v traitsui
           working-directory: ${{ runner.temp }}
 
+  notify-on-failure:
+    needs: pip-qt
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+
+  notify-on-success:
+    needs: pip-qt
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+
   # Tests against wxPython from PyPI
   # On OSX:
   #   - wxPython complains about 'This program needs access to the screen'.
@@ -78,21 +106,21 @@ jobs:
           working-directory: ${{ runner.temp }}
 
   notify-on-failure:
-    needs: pip-qt
+    needs: pip-wx
     if: failure()
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack channel on failure
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel_id: ${{ env.SLACK_CHANNEL_ID }}
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
           status: FAILED
           color: danger
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
 
   notify-on-success:
-    needs: pip-qt
+    needs: pip-wx
     if: success()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -41,7 +41,7 @@ jobs:
           run: python -m unittest discover -v traitsui
           working-directory: ${{ runner.temp }}
 
-  notify-on-failure:
+  notify-on-qt-failure:
     needs: pip-qt
     if: failure()
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
 
-  notify-on-success:
+  notify-on-qt-success:
     needs: pip-qt
     if: success()
     runs-on: ubuntu-latest
@@ -105,7 +105,7 @@ jobs:
           run: python -m unittest discover -v traitsui
           working-directory: ${{ runner.temp }}
 
-  notify-on-failure:
+  notify-on-wx-failure:
     needs: pip-wx
     if: failure()
     runs-on: ubuntu-latest
@@ -119,7 +119,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
 
-  notify-on-success:
+  notify-on-wx-success:
     needs: pip-wx
     if: success()
     runs-on: ubuntu-latest

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -53,7 +53,7 @@ jobs:
           status: FAILED
           color: danger
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
   notify-on-qt-success:
     needs: pip-qt
@@ -67,7 +67,7 @@ jobs:
           status: SUCCESS
           color: good
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
   # Tests against wxPython from PyPI
   # On OSX:
@@ -117,7 +117,7 @@ jobs:
           status: FAILED
           color: danger
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
 
   notify-on-wx-success:
     needs: pip-wx
@@ -131,4 +131,4 @@ jobs:
           status: SUCCESS
           color: good
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}


### PR DESCRIPTION
One step towards https://github.com/enthought/ets/issues/65

This PR sets up slack notifications for the 3 cron jobs in this repository. Note that I manually triggerred the cron jobs to check that the slack notifications actually show up - and they do.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~