### PR TITLE
Fix Qt InstanceEditor appearance when None selected

### DIFF
--- a/docs/releases/upcoming/1728.bugfix.rst
+++ b/docs/releases/upcoming/1728.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Qt InstanceEditor appearance when None selected (#1728)

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -218,9 +218,10 @@ class CustomEditor(Editor):
         if name >= 0:
             choice.setCurrentIndex(name)
         else:
-            # Otherwise, current value is no longer valid, try to discard it:
+            # Otherwise, current value is no longer valid, set combobox empty
             try:
                 self.value = None
+                choice.setCurrentIndex(name)
             except:
                 pass
 
@@ -275,17 +276,21 @@ class CustomEditor(Editor):
         # Update the selector (if any):
         choice = self._choice
         item = self.item_for(self.value)
-        if (choice is not None) and (item is not None):
-            name = item.get_name(self.value)
-            if self._object_cache is not None:
-                idx = choice.findText(name)
-                if idx < 0:
-                    idx = choice.count()
-                    choice.addItem(name)
+        if choice is not None:
+            if item is not None:
+                name = item.get_name(self.value)
+                if self._object_cache is not None:
+                    idx = choice.findText(name)
+                    if idx < 0:
+                        idx = choice.count()
+                        choice.addItem(name)
 
-                choice.setCurrentIndex(idx)
+                    choice.setCurrentIndex(idx)
+                else:
+                    choice.setText(name)
             else:
-                choice.setText(name)
+                choice.setCurrentIndex(-1)
+
 
     def resynch_editor(self):
         """ Resynchronizes the contents of the editor when the object trait

--- a/traitsui/qt4/instance_editor.py
+++ b/traitsui/qt4/instance_editor.py
@@ -221,7 +221,7 @@ class CustomEditor(Editor):
             # Otherwise, current value is no longer valid, set combobox empty
             try:
                 self.value = None
-                choice.setCurrentIndex(name)
+                choice.setCurrentIndex(-1)
             except:
                 pass
 

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -369,7 +369,7 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             text = instance.inspect(SelectedText())
             self.assertEqual(text, obj.inst_list[1].name)
 
-            # test resetting selection to None 
+            # test resetting selection to None
             reset_to_none_button = tester.find_by_name(ui, "reset_to_none")
             reset_to_none_button.perform(MouseClick())
             self.assertIsNone(obj.inst)

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -146,10 +146,10 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             # test that the current object is None
             self.assertIsNone(obj.inst)
 
-            # test that the displayed text is correct
+            # test that the displayed text is empty
             instance = tester.find_by_name(ui, "inst")
             text = instance.inspect(SelectedText())
-            self.assertEqual(text, obj.inst_list[0].name)
+            self.assertEqual(text, '')
 
             # test that changing selection works
             instance.locate(Index(1)).perform(MouseClick())
@@ -185,16 +185,12 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             # test that the current object is None
             self.assertIsNone(obj.inst)
 
-            # test that the displayed text is correct
-            instance = tester.find_by_name(ui, "inst")
-            text = instance.inspect(SelectedText())
-            self.assertEqual(text, obj.inst_list[0].name)
-
             # actually select the first item
+            instance = tester.find_by_name(ui, "inst")
             instance.locate(Index(0)).perform(MouseClick())
             self.assertIs(obj.inst, obj.inst_list[0])
 
-            # test that the displayed text is still correct after change
+            # test that the displayed text is correct after change
             name_txt = instance.find_by_name("name")
             for _ in range(3):
                 name_txt.perform(KeyClick("Backspace"))

--- a/traitsui/tests/editors/test_instance_editor.py
+++ b/traitsui/tests/editors/test_instance_editor.py
@@ -11,7 +11,7 @@
 import unittest
 
 from pyface.toolkit import toolkit_object
-from traits.api import HasTraits, Instance, List, Str, String
+from traits.api import Button, HasTraits, Instance, List, observe, Str, String
 from traitsui.api import InstanceEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
@@ -59,12 +59,22 @@ class ObjectWithInstance(HasTraits):
 class ObjectWithList(HasTraits):
     inst_list = List(Instance(NamedInstance))
     inst = Instance(NamedInstance, args=())
+    reset_to_none = Button()
+    change_options = Button()
 
     def _inst_list_default(self):
         return [
             NamedInstance(name=value, value=value)
             for value in ['one', 'two', 'three']
         ]
+
+    @observe('reset_to_none')
+    def _reset_inst_to_none(self, event):
+        self.inst = None
+
+    @observe('change_options')
+    def _modify_inst_list(self, event):
+        self.inst_list = [NamedInstance(name='one', value='one')]
 
 
 simple_view = View(Item("inst"), buttons=["OK"])
@@ -75,6 +85,16 @@ selection_view = View(
         editor=InstanceEditor(name='inst_list'),
         style='custom',
     ),
+    buttons=["OK"],
+)
+none_view = View(
+    Item(
+        "inst",
+        editor=InstanceEditor(name='inst_list'),
+        style='custom',
+    ),
+    Item('reset_to_none'),
+    Item('change_options'),
     buttons=["OK"],
 )
 modal_view = View(
@@ -329,3 +349,43 @@ class TestInstanceEditor(BaseTestMixin, unittest.TestCase):
             something_ui.locate(Index(1)).perform(MouseClick())
 
             self.assertTrue(ok_button.inspect(IsEnabled()))
+
+    # regression test for enthought/traitsui#1134
+    def test_none_selected(self):
+        obj = ObjectWithList()
+        tester = UITester()
+        with tester.create_ui(obj, {'view': none_view}) as ui:
+            # test that the current object is None
+            self.assertIsNone(obj.inst)
+
+            # test that the displayed text is empty to start
+            instance = tester.find_by_name(ui, "inst")
+            text = instance.inspect(SelectedText())
+            self.assertEqual(text, '')
+
+            # test that changing selection works and displayed text is correct
+            instance.locate(Index(1)).perform(MouseClick())
+            self.assertIs(obj.inst, obj.inst_list[1])
+            text = instance.inspect(SelectedText())
+            self.assertEqual(text, obj.inst_list[1].name)
+
+            # test resetting selection to None 
+            reset_to_none_button = tester.find_by_name(ui, "reset_to_none")
+            reset_to_none_button.perform(MouseClick())
+            self.assertIsNone(obj.inst)
+            text = instance.inspect(SelectedText())
+            self.assertEqual(text, '')
+
+            # change selection again
+            instance.locate(Index(1)).perform(MouseClick())
+            self.assertIs(obj.inst, obj.inst_list[1])
+            text = instance.inspect(SelectedText())
+            self.assertEqual(text, obj.inst_list[1].name)
+
+            # test modifying list of selectable options returns current object
+            # to None
+            change_options_button = tester.find_by_name(ui, "change_options")
+            change_options_button.perform(MouseClick())
+            self.assertIsNone(obj.inst)
+            text = instance.inspect(SelectedText())
+            self.assertEqual(text, '')


### PR DESCRIPTION
closes #1134 

I've been testing this locally using:
```
from traits.api import Button, HasStrictTraits, Instance, List, Str, observe
from traitsui.api import EnumEditor, InstanceEditor, Item, VGroup, View


class Option(HasStrictTraits):
    name = Str()


class Model(HasStrictTraits):
    selected_option = Instance(Option)
    all_options = List(Instance(Option))
    reset_to_none = Button()
    change_options = Button()

    selected_name = Str()
    all_names = List(Str)

    view = View(
        VGroup(
            Item('selected_option', label='InstanceEditor',
                 editor=InstanceEditor(name='all_options', editable=False)),
            Item('selected_name', label='EnumEditor',
                 editor=EnumEditor(name='all_names')),
            Item('reset_to_none'),
            Item('change_options')
        ),
    )

    @observe('reset_to_none')
    def do_stuff(self, event):
        self.selected_option = None

    @observe('change_options')
    def do_other_stuff(self, event):
        self.all_options = [Option(name='Option A')]


if __name__ == "__main__":
    model = Model(
        all_options=[Option(name='Option A'), Option(name='Option B')],
        all_names=['Option A', 'Option B'],
    )
    model.configure_traits()
    print(f'Selected option: {model.selected_option}')
    print(f'Selected name: {model.selected_name}')
```
The `reset_to_none` and `change_options` buttons were to ensure both the `rebuild_items` and `update_editor` code paths could be run.  I believe the changes to both methods are necessary for this behavior to be correct.


~I will work on writing real unit tests for this~ EDIT: done. I basically just copied the above and used UITester

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)