### PR TITLE
Add an RtD config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -20,6 +20,7 @@ __extras_require__ = {
     "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt5", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
+    "docs": ["enthought-sphinx-theme", "sphinx"],
     "demo": [
         # to be deprecated, see enthought/traitsui#950
         "configobj", "docutils",


### PR DESCRIPTION
This PR adds a basic configuration file for Read the Docs. These changes are based on enthought/traits#1478. This is one more step towards enthought/ets#69.

This PR also add a `docs` `extras_require` when installing `traitsui` to make it easy to build the sphinx docs.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~