### PR TITLE
Prevent RangeTextEditor from allowing values outside range

### DIFF
--- a/docs/releases/upcoming/1731.bugfix.rst
+++ b/docs/releases/upcoming/1731.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent RangeTextEditor from allowing values outside range (#1731)

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -693,6 +693,12 @@ class RangeTextEditor(TextEditor):
     #  Trait definitions:
     # -------------------------------------------------------------------------
 
+    #: Low value for the slider range
+    low = Any()
+
+    #: High value for the slider range
+    high = Any()
+
     #: Function to evaluate floats/ints
     evaluate = Any()
 
@@ -701,8 +707,19 @@ class RangeTextEditor(TextEditor):
             widget.
         """
         TextEditor.init(self, parent)
-        self.evaluate = self.factory.evaluate
-        self.sync_value(self.factory.evaluate_name, "evaluate", "from")
+
+        factory = self.factory
+        if not factory.low_name:
+            self.low = factory.low
+
+        if not factory.high_name:
+            self.high = factory.high
+
+        self.evaluate = factory.evaluate
+        self.sync_value(factory.evaluate_name, "evaluate", "from")
+
+        self.sync_value(factory.low_name, "low", "from")
+        self.sync_value(factory.high_name, "high", "from")
 
     def update_object(self):
         """ Handles the user entering input data in the edit control.
@@ -711,8 +728,14 @@ class RangeTextEditor(TextEditor):
             value = eval(str(self.control.text()))
             if self.evaluate is not None:
                 value = self.evaluate(value)
-            self.value = value
-            col = OKColor
+
+            if not (self.low <= value <= self.high):
+                value = self.low
+                col = ErrorColor
+            else:
+                col = OKColor
+
+            self.value = value  
         except Exception:
             col = ErrorColor
 

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -721,6 +721,10 @@ class RangeTextEditor(TextEditor):
         self.sync_value(factory.low_name, "low", "from")
         self.sync_value(factory.high_name, "high", "from")
 
+        # force value to start in range
+        if not (self.low <= self.value <= self.high):
+            self.value = self.low
+
     def update_object(self):
         """ Handles the user entering input data in the edit control.
         """

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -409,7 +409,7 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             float_value_field = tester.find_by_name(ui, "float_value")
             for _ in range(3):
                 float_value_field.perform(KeyClick("Backspace"))
-            
+
             # set a value out of the range [0.0, 1]
             float_value_field.perform(KeySequence("2.0"))
             float_value_field.perform(KeyClick("Enter"))

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -394,3 +394,24 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             self.assertEqual(
                 float_value_text.inspect(DisplayedText()), "0.2 ..."
             )
+
+    # regression test for enthought/traitsui#737
+    def test_set_text_out_of_range(self):
+        model = RangeModel()
+        view = View(
+            Item(
+                'float_value',
+                editor=RangeEditor(mode='text', low=0.0, high=1)
+            ),
+        )
+        tester = UITester()
+        with tester.create_ui(model, dict(view=view)) as ui:
+            float_value_field = tester.find_by_name(ui, "float_value")
+            for _ in range(3):
+                float_value_field.perform(KeyClick("Backspace"))
+            
+            # set a value out of the range [0.0, 1]
+            float_value_field.perform(KeySequence("2.0"))
+            float_value_field.perform(KeyClick("Enter"))
+
+            self.assertTrue(0.0 <= model.float_value <= 1)


### PR DESCRIPTION
closes #737

This PR simply forces the value to be `self.low` if a value outside of the range is given.  This is similar to what the `SimpleSliderEditor` / other range editors do. 

I've tested manually with the example in the issue and added a comparable regression test.

~I still need to investigate wx - hence the WIP title for now~ EDIT: looks like wx was already doing the right thing

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)