### PR TITLE
Update to GitHub Actions CI configurations

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -8,6 +8,9 @@ on:
   # Make it possible to manually trigger the workflow
   workflow_dispatch:
 
+env:
+  PYTHONUNBUFFERED: 1
+
 jobs:
   test:
     env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron:  '0 0 * * 4'
 
+env:
+  PYTHONUNBUFFERED: 1
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/minimal-deps.yml
+++ b/.github/workflows/minimal-deps.yml
@@ -6,6 +6,15 @@ name: Minimal setup
 
 on: pull_request
 
+env:
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/style-checks.yml
+++ b/.github/workflows/style-checks.yml
@@ -4,6 +4,15 @@ name: Style check
 
 on: pull_request
 
+env:
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   style:
     strategy:

--- a/.github/workflows/test-etsdemo.yml
+++ b/.github/workflows/test-etsdemo.yml
@@ -9,6 +9,13 @@ on:
 
 env:
   INSTALL_EDM_VERSION: 3.2.3
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -12,6 +12,13 @@ on: pull_request
 
 env:
   INSTALL_EDM_VERSION: 3.2.3
+  PYTHONUNBUFFERED: 1
+
+concurrency:
+  # This should have the effect of cancelling CI runs for
+  # existing commits when a new commit is pushed to the PR.
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -9,6 +9,9 @@ on:
   # Make it possible to manually trigger the workflow
   workflow_dispatch:
 
+env:
+  PYTHONUNBUFFERED: 1
+
 jobs:
   # Tests against Qt/Python packages from PyPI
   pip-qt:


### PR DESCRIPTION
This PR does two things

- sets `PYTHONUNBUFFERED` environment variable to `True` on all jobs except for the PyPI upload job.
- sets up `concurrency` so that existing CI runs are cancelled when a new commit is pushed to a PR branch. This is done only for the jobs that are run on PRs.

One more step towards enthought/ets#71

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~