### PR TITLE
Replace all use of magic named _fired methods with observe

### DIFF
--- a/docs/source/traitsui_user_manual/examples/key_bindings.py
+++ b/docs/source/traitsui_user_manual/examples/key_bindings.py
@@ -10,7 +10,7 @@
 
 # key_bindings.py -- Example of a code editor with a key bindings editor
 
-from traits.api import Button, Code, HasPrivateTraits, Str
+from traits.api import Button, Code, HasPrivateTraits, observe, Str
 from traitsui.api import Group, Handler, Item, View
 from traitsui.key_bindings import KeyBinding, KeyBindings
 
@@ -68,7 +68,8 @@ class KBCodeExample(HasPrivateTraits):
         handler=CodeHandler(),
     )
 
-    def _kb_fired(self, event):
+    @observe('kb')
+    def _edit_key_bindings(self, event):
         key_bindings.edit_traits()
 
 

--- a/docs/source/tutorials/code_snippets/interactive.py
+++ b/docs/source/tutorials/code_snippets/interactive.py
@@ -1,13 +1,14 @@
 # interactive.py
 
-from traits.api import HasTraits, Int, Button
+from traits.api import HasTraits, Int, Button, observe
 from traitsui.api import View, Item, ButtonEditor
 
 class Counter(HasTraits):
     value =  Int()
     add_one = Button()
 
-    def _add_one_fired(self):
+    @observe('add_one')
+    def _increment_value(self, event):
         self.value +=1
 
     view = View('value', Item('add_one', show_label=False ))

--- a/docs/source/tutorials/code_snippets/traits_thread.py
+++ b/docs/source/tutorials/code_snippets/traits_thread.py
@@ -2,7 +2,7 @@
 
 from threading import Thread
 from time import sleep
-from traits.api import Button, HasTraits, Instance, Str
+from traits.api import Button, HasTraits, Instance, observe, Str
 from traitsui.api import View, Item
 
 
@@ -31,7 +31,8 @@ class Camera(HasTraits):
 
     view = View(Item('start_stop_capture', show_label=False))
 
-    def _start_stop_capture_fired(self):
+    @observe('start_stop_capture')
+    def _on_start_stop_capture(self, event):
         if self.capture_thread and self.capture_thread.isAlive():
             self.capture_thread.wants_abort = True
         else:

--- a/traitsui/editors/shell_editor.py
+++ b/traitsui/editors/shell_editor.py
@@ -11,7 +11,7 @@
 """ Editor that displays an interactive Python shell.
 """
 
-from traits.api import Bool, Str, Event, Property
+from traits.api import Bool, Str, Event, Property, observe
 from traits.observation.api import match
 
 from traitsui.basic_editor_factory import BasicEditorFactory
@@ -179,11 +179,13 @@ class _ShellEditor(Editor):
 
     # Trait change handlers --------------------------------------------------
 
-    def _command_to_execute_fired(self, command):
+    @observe("command_to_execute")
+    def _execute_command(self, event):
         """ Handles the 'command_to_execute' trait being fired.
         """
         # Show the command. A 'hidden' command should be executed directly on
         # the namespace trait!
+        command = event.new
         self._shell.execute_command(command, hidden=False)
 
 

--- a/traitsui/examples/demo/Advanced/Table_editor_with_progress_column.py
+++ b/traitsui/examples/demo/Advanced/Table_editor_with_progress_column.py
@@ -16,7 +16,7 @@ with qt backend.
 import random
 
 from pyface.api import GUI
-from traits.api import Button, HasTraits, Instance, Int, List, Str
+from traits.api import Button, HasTraits, Instance, Int, List, observe, Str
 from traitsui.api import ObjectColumn, TableEditor, UItem, View
 from traitsui.extras.progress_column import ProgressColumn
 
@@ -48,7 +48,8 @@ class JobManager(HasTraits):
         if any(job.percent_complete < 100 for job in self.jobs):
             GUI.invoke_after(100, self.process)
 
-    def _start_fired(self):
+    @observe('start')
+    def _populate_and_process(self, event):
         self.populate()
         GUI.invoke_after(1000, self.process)
 

--- a/traitsui/examples/demo/Standard_Editors/ButtonEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/ButtonEditor_demo.py
@@ -19,7 +19,7 @@ Please refer to the `ButtonEditor API docs`_ for further information.
 .. _ButtonEditor API docs: https://docs.enthought.com/traitsui/api/traitsui.editors.button_editor.html#traitsui.editors.button_editor.ButtonEditor
 """
 
-from traits.api import HasTraits, Button
+from traits.api import HasTraits, Button, observe
 from traitsui.api import Item, View, Group, message
 
 
@@ -34,7 +34,8 @@ class ButtonEditorDemo(HasTraits):
     # To demonstrate any given Trait editor, an appropriate Trait is required.
     fire_event = Button('Click Me')
 
-    def _fire_event_fired():
+    @observe('fire_event')
+    def _button_clicked_message(self, event):
         message("Button clicked!")
 
     # ButtonEditor display

--- a/traitsui/examples/demo/Standard_Editors/ButtonEditor_simple_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/ButtonEditor_simple_demo.py
@@ -21,7 +21,7 @@ Please refer to the `ButtonEditor API docs`_ for further information.
 .. _ButtonEditor API docs: https://docs.enthought.com/traitsui/api/traitsui.editors.button_editor.html#traitsui.editors.button_editor.ButtonEditor
 """
 
-from traits.api import HasTraits, Button, Int
+from traits.api import HasTraits, Button, Int, observe
 
 from traitsui.api import Item, View
 
@@ -34,9 +34,8 @@ class ButtonEditorDemo(HasTraits):
     click_counter = Int(0)
 
     # When the button is clicked, do something.
-    # The listener method is named '_TraitName_fired', where
-    # 'TraitName' is the name of the button trait.
-    def _my_button_trait_fired(self):
+    @observe("my_button_trait")
+    def _increment_counter(self, event):
         self.click_counter += 1
 
     # Demo view:

--- a/traitsui/examples/demo/Standard_Editors/CSVListEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/CSVListEditor_demo.py
@@ -21,7 +21,7 @@ Please refer to the `CSVListEditor API docs`_ for further information.
 """
 
 from traits.api import (
-    HasTraits, List, Int, Float, Enum, Range, Str, Button, Property
+    HasTraits, List, Int, Float, Enum, Range, Str, Button, Property, observe
 )
 from traitsui.api import (
     View, Item, Label, Heading, VGroup, HGroup, UItem, spring, TextEditor,
@@ -153,12 +153,14 @@ class CSVListEditorDemo(HasTraits):
     def _get_list1str(self):
         return str(self.list1)
 
-    def _pop1_fired(self):
+    @observe("pop1")
+    def _pop_from_list1(self, event):
         if len(self.list1) > 0:
             x = self.list1.pop()
             print(x)
 
-    def _sort1_fired(self):
+    @observe('sort1')
+    def _sort_list1(self, event):
         self.list1.sort()
 
 

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -1374,7 +1374,7 @@ class TableFilterEditor(HasTraits):
         ]
         self.selected_template = self.templates[0]
 
-    @observe('_add_button')
+    @observe('add_button')
     def _create_and_select_new_filter(self, event):
         """ Create a new filter based on the selected template and select it.
         """

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -1374,7 +1374,8 @@ class TableFilterEditor(HasTraits):
         ]
         self.selected_template = self.templates[0]
 
-    def _add_button_fired(self):
+    @observe('_add_button')
+    def _create_and_select_new_filter(self, event):
         """ Create a new filter based on the selected template and select it.
         """
         new_filter = self.selected_template.clone_traits()
@@ -1383,7 +1384,8 @@ class TableFilterEditor(HasTraits):
         self.filters.append(new_filter)
         self.selected_filter = new_filter
 
-    def _remove_button_fired(self):
+    @observe("remove_button")
+    def _delete_selected_filter(self, event):
         """ Delete the currently selected filter.
         """
         if self.selected_template == self.selected_filter:


### PR DESCRIPTION
This PR simply replaces all uses of the `_fired` magically named methods with their observe equivalent.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)