### PR TITLE
Default branch has been renamed from "master" to "main"

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -1,4 +1,4 @@
-# This workflow installs dependencies from master
+# This workflow installs dependencies from main branch
 
 name: ETS from source
 

--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,6 @@
 TraitsUI: Traits-capable windowing framework
 ============================================
 
-.. image:: https://travis-ci.org/enthought/traitsui.svg?branch=master
-   :target: https://travis-ci.org/enthought/traitsui
-
-.. image:: https://ci.appveyor.com/api/projects/status/n2qy8kcwh8ibi9g3/branch/master?svg=true
-   :target: https://ci.appveyor.com/project/EnthoughtOSS/traitsui/branch/master
-
 The TraitsUI project contains a toolkit-independent GUI abstraction layer,
 which is used to support the "visualization" features of the
 `Traits <http://github.com/enthought/traits>`__ package.
@@ -46,7 +40,7 @@ we can use TraitsUI to specify a and display a GUI view::
 
 which creates a GUI which looks like this:
 
-.. image:: https://raw.github.com/enthought/traitsui/master/README_example.png
+.. image:: https://raw.github.com/enthought/traitsui/main/README_example.png
 
 Important Links
 ---------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -175,7 +175,7 @@ except ImportError as exc:
 
 # Useful aliases to avoid repeating long URLs.
 extlinks = {'github-demo': (
-    'https://github.com/enthought/traitsui/tree/master/traitsui/examples/demo/%s',
+    'https://github.com/enthought/traitsui/tree/main/traitsui/examples/demo/%s',
     'github-demo')
 }
 

--- a/etstool.py
+++ b/etstool.py
@@ -277,7 +277,7 @@ def install(runtime, toolkit, environment, editable, source):
         execute(commands, parameters)
         source_pkgs = source_dependencies.values()
         # Without the --no-dependencies flag such that new dependencies on
-        # master are brought in.
+        # main branch are brought in.
         commands = [
             "python -m pip install --force-reinstall {pkg}".format(pkg=pkg)
             for pkg in source_pkgs


### PR DESCRIPTION
This PR replaces the use of `master` in the repo with `main` as the default branch name has been updated.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~