### PR TITLE
Don't link to examples on the main branch in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -175,7 +175,7 @@ except ImportError as exc:
 
 # Useful aliases to avoid repeating long URLs.
 extlinks = {'github-demo': (
-    'https://github.com/enthought/traitsui/tree/main/traitsui/examples/demo/%s',
+    f'https://github.com/enthought/traitsui/tree/{version}/traitsui/examples/demo/%s',
     'github-demo')
 }
 


### PR DESCRIPTION
At the moment, the documentation links to examples on the `main`/default branch. This isn't right because the examples might change in between releases, potentially confusing users who are referring to the documentation. This PR fixes that problem by making the documentation use version-specific links i.e. for the 7.2.1 release, the `7.2.1` tag will be used instead of the `main` branch.

I tested this locally by checking the links generated in the built docs - the examples links will be broken as expected as the dev version has no corresponding tag on GitHub. I then hardcoded the version in the sphinx configuration to `7.2.1` and the links worked as expected, pointing to the `7.2.1` tree instead of `main`.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~