### PR TITLE
Fix incorrect items added in Tree Editor

### DIFF
--- a/docs/releases/upcoming/1745.bugfix.rst
+++ b/docs/releases/upcoming/1745.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue with incorrect items added via context menu in a TreeEditor.

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -27,6 +27,7 @@
 
 import copy
 import collections.abc
+from functools import partial
 from itertools import zip_longest
 import logging
 
@@ -1090,9 +1091,12 @@ class SimpleEditor(Editor):
                 name = class_name
             if factory is None:
                 factory = klass
-            def perform_add(object):
+            def perform_add(object, factory, prompt):
                 self._menu_new_node(factory, prompt)
-            items.append(Action(name=name, on_perform=perform_add))
+            on_perform = partial(
+                perform_add, factory=factory, prompt=prompt
+            )
+            items.append(Action(name=name, on_perform=on_perform))
         return items
 
     # -------------------------------------------------------------------------

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -1256,9 +1256,12 @@ class SimpleEditor(Editor):
                 name = class_name
             if not factory:
                 factory = klass
-            def perform_add(object):
+            def perform_add(object, factory, prompt):
                 self._menu_new_node(factory, prompt)
-            items.append(Action(name=name, on_perform=perform_add))
+            on_perform = partial(
+                perform_add, factory=factory, prompt=prompt
+            )
+            items.append(Action(name=name, on_perform=on_perform))
         return items
 
     def _is_copyable(self, object):


### PR DESCRIPTION
Fixes #1744 

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)