### PR TITLE
Replace uses of Any({}) with Dict()

### DIFF
--- a/traitsui/list_str_adapter.py
+++ b/traitsui/list_str_adapter.py
@@ -14,6 +14,7 @@
 from traits.api import (
     Any,
     Bool,
+    Dict,
     Enum,
     Event,
     HasPrivateTraits,
@@ -137,7 +138,7 @@ class ListStrAdapter(HasPrivateTraits):
     # -- Private Trait Definitions --------------------------------------------
 
     #: Cache of attribute handlers.
-    cache = Any({})
+    cache = Dict()
 
     #: Event fired when the cache is flushed.
     cache_flushed = Event(update=True)

--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -19,6 +19,7 @@ from pyface.qt import QtCore, QtGui, is_qt5
 from traits.api import (
     Any,
     Bool,
+    Dict,
     Event,
     Int,
     Instance,
@@ -81,10 +82,10 @@ class _ListStrEditor(Editor):
     adapter = Instance(ListStrAdapter)
 
     #: Dictionary mapping image names to QIcons
-    images = Any({})
+    images = Dict()
 
     #: Dictionary mapping ImageResource objects to QIcons
-    image_resources = Any({})
+    image_resources = Dict()
 
     #: The current number of item currently in the list:
     item_count = Property()

--- a/traitsui/qt4/table_editor.py
+++ b/traitsui/qt4/table_editor.py
@@ -34,6 +34,7 @@ from traits.api import (
     Any,
     Bool,
     Button,
+    Dict,
     Event,
     List,
     HasTraits,
@@ -160,10 +161,10 @@ class TableEditor(Editor, BaseTableEditor):
     auto_size = Bool(False)
 
     #: Dictionary mapping image names to QIcons
-    images = Any({})
+    images = Dict()
 
     #: Dictionary mapping ImageResource objects to QIcons
-    image_resources = Any({})
+    image_resources = Dict()
 
     #: An image being converted:
     image = Image

--- a/traitsui/qt4/tabular_editor.py
+++ b/traitsui/qt4/tabular_editor.py
@@ -24,6 +24,7 @@ from traits.api import (
     Any,
     Bool,
     Callable,
+    Dict,
     Event,
     HasStrictTraits,
     Instance,
@@ -131,10 +132,10 @@ class TabularEditor(Editor):
     model = Instance(TabularModel)
 
     #: Dictionary mapping image names to QIcons
-    images = Any({})
+    images = Dict()
 
     #: Dictionary mapping ImageResource objects to QIcons
-    image_resources = Any({})
+    image_resources = Dict()
 
     #: An image being converted:
     image = Image

--- a/traitsui/table_column.py
+++ b/traitsui/table_column.py
@@ -19,6 +19,7 @@ from traits.api import (
     Bool,
     Callable,
     Constant,
+    Dict,
     Enum,
     Expression,
     Float,
@@ -458,7 +459,7 @@ class ExpressionColumn(ObjectColumn):
 
     #: The globals dictionary that should be passed to the expression
     #: evaluation:
-    globals = Any({})
+    globals = Dict()
 
     def get_raw_value(self, object):
         """ Gets the unformatted value of the column for a specified object.

--- a/traitsui/tabular_adapter.py
+++ b/traitsui/tabular_adapter.py
@@ -18,6 +18,7 @@
 from traits.api import (
     Any,
     Bool,
+    Dict,
     Enum,
     Event,
     Float,
@@ -217,7 +218,7 @@ class TabularAdapter(HasPrivateTraits):
     # -- Private Trait Definitions --------------------------------------------
 
     #: Cache of attribute handlers.
-    cache = Any({})
+    cache = Dict()
 
     #: Event fired when the cache is flushed.
     cache_flushed = Event(update=True)

--- a/traitsui/wx/list_str_editor.py
+++ b/traitsui/wx/list_str_editor.py
@@ -24,6 +24,7 @@ from traits.api import (
     Event,
     TraitListEvent,
     Property,
+    Dict,
 )
 
 # FIXME: ListStrEditor is a proxy class defined here just for backward
@@ -146,11 +147,11 @@ class _ListStrEditor(Editor):
     #: The adapter from list items to editor values:
     adapter = Instance(ListStrAdapter)
 
-    #: Dictionaly mapping image names to wx.ImageList indices:
-    images = Any({})
+    #: Dictionary mapping image names to wx.ImageList indices:
+    images = Dict()
 
     #: Dictionary mapping ImageResource objects to wx.ImageList indices:
-    image_resources = Any({})
+    image_resources = Dict()
 
     #: The current number of item currently in the list:
     item_count = Property()

--- a/traitsui/wx/tabular_editor.py
+++ b/traitsui/wx/tabular_editor.py
@@ -26,6 +26,7 @@ from traits.api import (
     Event,
     Property,
     TraitListEvent,
+    Dict,
 )
 
 # FIXME: TabularEditor (the editor factory for tabular editors) is a proxy class
@@ -249,10 +250,10 @@ class TabularEditor(Editor):
     adapter = Instance(TabularAdapter)
 
     #: Dictionary mapping image names to wx.ImageList indices:
-    images = Any({})
+    images = Dict()
 
     #: Dictionary mapping ImageResource objects to wx.ImageList indices:
-    image_resources = Any({})
+    image_resources = Dict()
 
     #: An image being converted:
     image = Image


### PR DESCRIPTION
This PR replaces several traits declared with type `Any({})`  to have type `Dict` instead.

I'm not sure why these lines were using `Any({})`, but I suspect that they long predate modern Traits and relied on the old `TraitHandler` inference mechanisms.

The main motivation for this PR was enthought/traits#1532: currently there's some special-casing in Traits that treats a `list` or `dict` default value to `Any` specially, making a copy of that default value for each relevant `HasTraits` instance. We're considering deprecating and eventually removing that special-casing. That would cause a behaviour change for the cases  changed in this PR. (Within the whole of ETS, these were the only pieces of current code found that would be affected by such a change.)

Independent of whether that change goes through in Traits or not, it seems worth using the more explicit trait type here.

Note for reviewer: many of the changed files are currently excluded by the `flake8` check; I've checked manually that all changed files import `Dict`.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)