### PR TITLE
fix NameError and add test for warnings

### DIFF
--- a/traitsui/tests/ui_editors/test_data_frame_editor.py
+++ b/traitsui/tests/ui_editors/test_data_frame_editor.py
@@ -504,3 +504,10 @@ class TestDataFrameEditor(BaseTestMixin, unittest.TestCase):
         assert_array_equal(item_0_df.values, [[0, 1, 2]])
         assert_array_equal(item_0_df.columns, ['X', 'Y', 'Z'])
         self.assertEqual(item_0_df.index[0], 1)
+
+    def test_scroll_to_row_hint_warnings(self):
+        with self.assertWarns(DeprecationWarning):
+            dfe = DataFrameEditor(scroll_to_row_hint="center")
+
+        with self.assertWarns(DeprecationWarning):
+            dfe.scroll_to_row_hint

--- a/traitsui/ui_editors/data_frame_editor.py
+++ b/traitsui/ui_editors/data_frame_editor.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import logging
+import warnings
 
 from traits.api import (
     Bool,


### PR DESCRIPTION
part of #1751 

This PR fixes the `NameError` by importing `warnings` and adds a simple test that accessing or assigning `scroll_to_row_hint` causes a `DeprecationWarning`

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)