### PR TITLE
Fix datetime initialization problem

### DIFF
--- a/traitsui/qt4/datetime_editor.py
+++ b/traitsui/qt4/datetime_editor.py
@@ -38,9 +38,9 @@ class SimpleEditor(Editor):
         self.maximum_datetime = self.factory.maximum_datetime
 
         self.control = QtGui.QDateTimeEdit()
-        self.control.dateTimeChanged.connect(self.update_object)
         self.update_minimum_datetime()
         self.update_maximum_datetime()
+        self.control.dateTimeChanged.connect(self.update_object)
 
     def dispose(self):
         """Disposes of the contents of an editor."""


### PR DESCRIPTION
Closes #1761. Fixes the data initialization problem by moving the code the connects the update of the widget to after when the minimum and maximum date values are initialized.