### PR TITLE
Allow read-only TextEditor text to be selected by users by default

### DIFF
--- a/traitsui/editors/text_editor.py
+++ b/traitsui/editors/text_editor.py
@@ -78,7 +78,7 @@ class TextEditor(EditorFactory):
     view = AView
 
     #: In a read-only text editor, allow selection and copying of the text.
-    readonly_allow_selection = Bool(False)
+    readonly_allow_selection = Bool(True)
 
     #: Grayed-out placeholder text to be displayed when the editor is empty.
     placeholder = Str()


### PR DESCRIPTION

Changes the default behaviour of `TextEditor` (only for Qt backend) in read-only mode: the displayed text can now be selected in the UI by default (the `readonly_allow_selection` attribute defaults to `True`).

The content of read-only `TextEditor`s is usually some useful information so users need to be able to copy those values quite often. 