### PR TITLE
BUG: Cast to int to avoid deprecation warning

### DIFF
--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -143,12 +143,13 @@ class _StickyDialog(QtGui.QDialog):
         # the former (Window).
         flags = QtCore.Qt.Window
         if not ui.view.resizable:
-            flags = flags | QtCore.Qt.WindowSystemMenuHint
+            flags |= QtCore.Qt.WindowSystemMenuHint
             layout.setSizeConstraint(QtGui.QLayout.SetFixedSize)
         try:
-            flags = flags | QtCore.Qt.WindowCloseButtonHint
+            flags |= QtCore.Qt.WindowCloseButtonHint
             if ui.view.resizable:
-                flags = flags | (
+                # Cast to int to deal with strange bug on PyQt5 5.12.3
+                flags |= int(
                     QtCore.Qt.WindowMinimizeButtonHint
                     | QtCore.Qt.WindowMaximizeButtonHint
                 )

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -148,7 +148,8 @@ class _StickyDialog(QtGui.QDialog):
         try:
             flags |= QtCore.Qt.WindowCloseButtonHint
             if ui.view.resizable:
-                # Cast to int to deal with strange bug on PyQt5 5.12.3
+                # Cast to int to deal with cast-to-int deprecation warning on
+                # PyQt5 5.12.3
                 flags |= int(
                     QtCore.Qt.WindowMinimizeButtonHint
                     | QtCore.Qt.WindowMaximizeButtonHint

--- a/traitsui/qt4/ui_base.py
+++ b/traitsui/qt4/ui_base.py
@@ -143,12 +143,12 @@ class _StickyDialog(QtGui.QDialog):
         # the former (Window).
         flags = QtCore.Qt.Window
         if not ui.view.resizable:
-            flags |= QtCore.Qt.WindowSystemMenuHint
+            flags = flags | QtCore.Qt.WindowSystemMenuHint
             layout.setSizeConstraint(QtGui.QLayout.SetFixedSize)
         try:
-            flags |= QtCore.Qt.WindowCloseButtonHint
+            flags = flags | QtCore.Qt.WindowCloseButtonHint
             if ui.view.resizable:
-                flags |= (
+                flags = flags | (
                     QtCore.Qt.WindowMinimizeButtonHint
                     | QtCore.Qt.WindowMaximizeButtonHint
                 )


### PR DESCRIPTION
On a conda-forge env, I got this error when setting up a window in a test where I have warnings turn into errors:

<details>

```
mne_kit_gui/tests/test_kit2fiff_gui.py:122: in test_kit2fiff_gui
    ui, frame = mne.gui.kit2fiff()
../../anaconda3/envs/mne-kit-gui/lib/python3.9/site-packages/mne/gui/__init__.py:241: in kit2fiff
    return _initialize_gui(frame)
../../anaconda3/envs/mne-kit-gui/lib/python3.9/site-packages/mne/gui/__init__.py:16: in _initialize_gui
    return frame.edit_traits(view=view), frame
../../anaconda3/envs/mne-kit-gui/lib/python3.9/site-packages/traits/has_traits.py:1825: in edit_traits
    return view.ui(
../traitsui/traitsui/view.py:450: in ui
    ui.ui(parent, kind)
../traitsui/traitsui/ui.py:235: in ui
    self.rebuild(self, parent)
../traitsui/traitsui/qt4/toolkit.py:168: in ui_live
    ui_live.ui_live(ui, parent)
../traitsui/traitsui/qt4/ui_live.py:52: in ui_live
    _ui_dialog(ui, parent, BaseDialog.NONMODAL)
../traitsui/traitsui/qt4/ui_live.py:72: in _ui_dialog
    BaseDialog.display_ui(ui, parent, style)
../traitsui/traitsui/qt4/ui_base.py:290: in display_ui
    ui.owner.init(ui, parent, style)
../traitsui/traitsui/qt4/ui_live.py:103: in init
    self.create_dialog(parent, style)
../traitsui/traitsui/qt4/ui_base.py:248: in create_dialog
    self.control = control = _StickyDialog(self.ui, parent)
../traitsui/traitsui/qt4/ui_base.py:151: in __init__
    flags = flags | (
E   TypeError: unsupported operand type(s) for |: 'WindowFlags' and 'WindowFlags'
```

</details>

But I could recreate the problem much more simply:
```
>>> from pyface.qt import QtCore
>>> (QtCore.Qt.Window | QtCore.Qt.WindowSystemMenuHint) | (QtCore.Qt.WindowMinimizeButtonHint | QtCore.Qt.WindowMaximizeButtonHint)
<stdin>:1: DeprecationWarning: an integer is required (got type WindowFlags).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
```
In other words, the deprecation warning about an integer being required turned into an error. This seemed like one reasonable way to work around the issue.