### PR TITLE
Call Bool before evaluating {enabled/visible}_when condition for labels

### DIFF
--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -726,7 +726,7 @@ class _GroupPanel(object):
             method_to_call = getattr(label, method_dict[kind])
             try:
                 cond_value = eval(when, globals(), context)
-                method_to_call(cond_value)
+                method_to_call(bool(cond_value))
             except Exception:
                 # catch errors in the validate_when expression
                 from traitsui.api import raise_to_debug

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -732,7 +732,7 @@ class FillPanel(object):
             method_to_call = getattr(label, method_dict[kind])
             try:
                 cond_value = eval(when, globals(), context)
-                method_to_call(cond_value)
+                method_to_call(bool(cond_value))
             except Exception:
                 # catch errors in the validate_when expression
                 from traitsui.api import raise_to_debug


### PR DESCRIPTION
closes #1768 

WIP label because the still needs a test.  support was introduced in #1544, but that needs a test as well.  Not sure if I will have the time to write a test on this, but wanted to open a PR with the simple fix now so it isn't forgetten. (previous comment about difficulty I had writing tests for Labels {enabled/visible}_when https://github.com/enthought/traitsui/pull/1544#issuecomment-823551479)

Note that for "normal" enabled/visible when we have `cond_value` come up in an `if` statement: https://github.com/enthought/traitsui/blob/87dceb219b8b7b547907f031aaca70e1a66b7945/traitsui/ui.py#L793

In the code here we really do want to always pass a bool to `setVisible` or `setEnabled`.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)