### PR TITLE
Upgrade edm to use the latest version on CI - 3.3.0

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       # Enforce selection of toolkit
       ETS_TOOLKIT: qt
+      QT_MAC_WANTS_LAYER: 1
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/test-etsdemo.yml
+++ b/.github/workflows/test-etsdemo.yml
@@ -8,7 +8,7 @@ on:
     - 'ets-demo/**'
 
 env:
-  INSTALL_EDM_VERSION: 3.3.0
+  INSTALL_EDM_VERSION: 3.3.1
 
 jobs:
 

--- a/.github/workflows/test-etsdemo.yml
+++ b/.github/workflows/test-etsdemo.yml
@@ -8,7 +8,7 @@ on:
     - 'ets-demo/**'
 
 env:
-  INSTALL_EDM_VERSION: 3.2.3
+  INSTALL_EDM_VERSION: 3.3.0
 
 jobs:
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -11,7 +11,7 @@ name: Test with EDM
 on: pull_request
 
 env:
-  INSTALL_EDM_VERSION: 3.2.3
+  INSTALL_EDM_VERSION: 3.3.0
 
 jobs:
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -11,7 +11,7 @@ name: Test with EDM
 on: pull_request
 
 env:
-  INSTALL_EDM_VERSION: 3.3.0
+  INSTALL_EDM_VERSION: 3.3.1
 
 jobs:
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -12,6 +12,7 @@ on: pull_request
 
 env:
   INSTALL_EDM_VERSION: 3.3.1
+  QT_MAC_WANTS_LAYER: 1
 
 jobs:
 

--- a/.github/workflows/test-with-pip.yml
+++ b/.github/workflows/test-with-pip.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       # Enforce selection of toolkit
       ETS_TOOLKIT: qt
+      QT_MAC_WANTS_LAYER: 1
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
This PR upgrades EDM to the latest available version - 3.3.0 - on the CI.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ Not news-worthy.