### PR TITLE
Fix NotebookEditor initial selected

### DIFF
--- a/docs/releases/upcoming/1791.bugfix.rst
+++ b/docs/releases/upcoming/1791.bugfix.rst
@@ -1,0 +1,1 @@
+Fix NotebookEditor initial `selected` (#1791)

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -526,8 +526,7 @@ class NotebookEditor(Editor):
 
             # Remember the page for later deletion processing:
             self._uis.append([ui.control, ui, view_object, monitoring])
-            if len(self._uis) == 1:
-                self._tab_activated(0)
+        self._tab_activated(0)
         if self.selected:
             self._selected_changed(self.selected)
 

--- a/traitsui/qt4/list_editor.py
+++ b/traitsui/qt4/list_editor.py
@@ -526,7 +526,8 @@ class NotebookEditor(Editor):
 
             # Remember the page for later deletion processing:
             self._uis.append([ui.control, ui, view_object, monitoring])
-
+            if len(self._uis) == 1:
+                self._tab_activated(0)
         if self.selected:
             self._selected_changed(self.selected)
 

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -304,6 +304,7 @@ class TestNotebookListEditor(unittest.TestCase):
                     MouseClick()
                 )
 
+    # regression test for enthought/traitsui#1790
     def test_initial_selected(self):
         class PhoneBookWithSelected(Phonebook):
             selected = Instance(Person)

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -319,7 +319,7 @@ class TestNotebookListEditor(unittest.TestCase):
                     ),
                 )
             )
-        
+
         tester = UITester()
         phonebook = PhoneBookWithSelected(people=get_people())
         with tester.create_ui(phonebook) as ui:

--- a/traitsui/tests/editors/test_list_editor.py
+++ b/traitsui/tests/editors/test_list_editor.py
@@ -303,3 +303,25 @@ class TestNotebookListEditor(unittest.TestCase):
                 tester.find_by_name(ui, "people").locate(Index(0)).perform(
                     MouseClick()
                 )
+
+    def test_initial_selected(self):
+        class PhoneBookWithSelected(Phonebook):
+            selected = Instance(Person)
+
+            traits_view = View(
+                Item(
+                    "people",
+                    style="custom",
+                    editor=ListEditor(
+                        use_notebook=True,
+                        selected='selected',
+                    ),
+                )
+            )
+        
+        tester = UITester()
+        phonebook = PhoneBookWithSelected(people=get_people())
+        with tester.create_ui(phonebook) as ui:
+            self.assertEqual(
+                phonebook.selected, phonebook.people[0]
+            )

--- a/traitsui/wx/list_editor.py
+++ b/traitsui/wx/list_editor.py
@@ -540,6 +540,8 @@ class NotebookEditor(Editor):
             # Remember the DockControl for later deletion processing:
             uis.append([dock_control, object, view_object, monitoring])
             dock_controls.append(dock_control)
+            if len(uis) == 1:
+                dock_control.dockable.dockable_tab_activated(dock_control, True)
 
         # Add the new items to the DockWindow:
         self.add_controls(dock_controls)


### PR DESCRIPTION
closes #1790 

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)