### PR TITLE
Fix SimpleSpinEditor "enter set" on qt

### DIFF
--- a/docs/releases/upcoming/1804.bugfix.rst
+++ b/docs/releases/upcoming/1804.bugfix.rst
@@ -1,0 +1,1 @@
+Fix SimpleSpinEditor "enter set" on qt (#1804)

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -620,6 +620,8 @@ class SimpleSpinEditor(BaseRangeEditor):
         self.control.setMaximum(high)
         self.control.setValue(self.value)
         self.control.valueChanged.connect(self.update_object)
+        if not factory.auto_set:
+            self.control.setKeyboardTracking(False)
         self.set_tooltip()
 
     def update_object(self, value):

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -174,7 +174,7 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
 
     # the tester support code is not yet implemented for Wx SimpleSpinEditor
     @requires_toolkit([ToolkitName.qt])
-    def test_simple_spin_editor_enter_set(self):
+    def test_simple_spin_editor_auto_set_false(self):
         model = RangeModel()
         view = View(
             Item(
@@ -184,7 +184,6 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
                     high=12,
                     mode="spinner",
                     auto_set=False,
-                    enter_set=True
                 )
             )
         )

--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -12,6 +12,7 @@ import platform
 import unittest
 
 from traits.api import HasTraits, Float, Int
+from traits.testing.api import UnittestTools
 from traitsui.api import Item, RangeEditor, UItem, View
 from traitsui.testing.api import (
     DisplayedText,
@@ -65,7 +66,7 @@ class RangeModel(HasTraits):
 
 
 @requires_toolkit([ToolkitName.qt, ToolkitName.wx])
-class TestRangeEditor(BaseTestMixin, unittest.TestCase):
+class TestRangeEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
     def setUp(self):
         BaseTestMixin.setUp(self)
 
@@ -167,10 +168,42 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase):
             # For whatever reason, "End" was not working here
             number_field.perform(KeyClick("Right"))
             number_field.perform(KeyClick("0"))
-            number_field.perform(KeyClick("Enter"))
             displayed = number_field.inspect(DisplayedText())
             self.assertEqual(model.value, 10)
             self.assertEqual(displayed, str(model.value))
+
+    # the tester support code is not yet implemented for Wx SimpleSpinEditor
+    @requires_toolkit([ToolkitName.qt])
+    def test_simple_spin_editor_enter_set(self):
+        model = RangeModel()
+        view = View(
+            Item(
+                "value",
+                editor=RangeEditor(
+                    low=1,
+                    high=12,
+                    mode="spinner",
+                    auto_set=False,
+                    enter_set=True
+                )
+            )
+        )
+        LOCAL_REGISTRY = TargetRegistry()
+        _register_simple_spin(LOCAL_REGISTRY)
+        tester = UITester(registries=[LOCAL_REGISTRY])
+        with tester.create_ui(model, dict(view=view)) as ui:
+            # sanity check
+            self.assertEqual(model.value, 1)
+            number_field = tester.find_by_name(ui, "value")
+            # For whatever reason, "End" was not working here
+            number_field.perform(KeyClick("Right"))
+            with self.assertTraitDoesNotChange(model, "value"):
+                number_field.perform(KeyClick("0"))
+            displayed = number_field.inspect(DisplayedText())
+            self.assertEqual(displayed, "10")
+            with self.assertTraitChanges(model, "value"):
+                number_field.perform(KeyClick("Enter"))
+            self.assertEqual(model.value, 10)
 
     def check_slider_set_with_text_after_empty(self, mode):
         model = RangeModel()


### PR DESCRIPTION
This PR adds a simple fix for providing enter set behavior for the simple spin editor.  As with some other editors, this behavior is enabled by setting `auto_set` to False (the value of `enter_set` doesn't actually matter).

ref: https://doc.qt.io/archives/qt-4.8/qabstractspinbox.html#keyboardTracking-prop

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)