### PR TITLE
Use two-phase HeadingText creation from Pyface 7.4.0.

### DIFF
--- a/traitsui/qt4/title_editor.py
+++ b/traitsui/qt4/title_editor.py
@@ -21,19 +21,23 @@
 # ------------------------------------------------------------------------------
 
 
-from pyface.qt import QtCore
+from pyface.qt import QtCore, QtGui
 
 from .editor import Editor
 
-from pyface.heading_text import HeadingText
+from pyface.api import HeadingText
 
 
 class SimpleEditor(Editor):
+
     def init(self, parent):
         """Finishes initializing the editor by creating the underlying toolkit
         widget.
         """
-        self._control = HeadingText(None)
+        if isinstance(parent, QtGui.QLayout):
+            parent = parent.parentWidget()
+        self._control = HeadingText(parent=parent, create=False)
+        self._control.create()
         self.control = self._control.control
         if self.factory.allow_selection:
             flags = (
@@ -48,6 +52,15 @@ class SimpleEditor(Editor):
         editor.
         """
         self._control.text = self.str_value
+
+    def dispose(self):
+        """Cleanly dispose of the editor.
+
+        This ensures that the wrapped Pyface Widget is cleaned-up.
+        """
+        if self._control is not None:
+            self._control.destroy()
+        super().dispose()
 
 
 CustomEditor = SimpleEditor

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1349,7 +1349,7 @@ class HTMLHelpWindow(QtGui.QDialog):
 HeadingText = None
 
 
-def heading_text(*args, create=False,  **kw):
+def heading_text(*args, create=False, **kw):
     """Create a Pyface HeadingText control."""
     global HeadingText
 

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -168,7 +168,7 @@ class _Panel(BasePanel):
 
             # Handle any view title.
             if title != "":
-                layout.addWidget(heading_text(None, text=view.title).control)
+                layout.addWidget(heading_text(parent=w, text=view.title).control)
 
             if isinstance(self.control, QtGui.QWidget):
                 layout.addWidget(self.control)
@@ -1349,11 +1349,13 @@ class HTMLHelpWindow(QtGui.QDialog):
 HeadingText = None
 
 
-def heading_text(*args, **kw):
+def heading_text(*args, create=False,  **kw):
     """Create a Pyface HeadingText control."""
     global HeadingText
 
     if HeadingText is None:
         from pyface.api import HeadingText
 
-    return HeadingText(*args, **kw)
+    widget = HeadingText(*args, **kw)
+    widget.create()
+    return widget

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1356,6 +1356,6 @@ def heading_text(*args, create=False, **kw):
     if HeadingText is None:
         from pyface.api import HeadingText
 
-    widget = HeadingText(create=create, *args, **kw)
+    widget = HeadingText(*args, create=create, **kw)
     widget.create()
     return widget

--- a/traitsui/qt4/ui_panel.py
+++ b/traitsui/qt4/ui_panel.py
@@ -1356,6 +1356,6 @@ def heading_text(*args, create=False, **kw):
     if HeadingText is None:
         from pyface.api import HeadingText
 
-    widget = HeadingText(*args, **kw)
+    widget = HeadingText(create=create, *args, **kw)
     widget.create()
     return widget

--- a/traitsui/wx/title_editor.py
+++ b/traitsui/wx/title_editor.py
@@ -14,7 +14,7 @@
 
 from .editor import Editor
 
-from pyface.heading_text import HeadingText
+from pyface.api import HeadingText
 
 # FIXME: TitleEditor (the editor factory for title editors) is a proxy class
 # defined here just for backward compatibility. The class has been moved to
@@ -29,28 +29,29 @@ from traitsui.editors.title_editor import TitleEditor
 
 class _TitleEditor(Editor):
 
-    # -------------------------------------------------------------------------
-    #  Finishes initializing the editor by creating the underlying toolkit
-    #  widget:
-    # -------------------------------------------------------------------------
-
     def init(self, parent):
         """Finishes initializing the editor by creating the underlying toolkit
         widget.
         """
-        self._control = HeadingText(parent)
+        self._control = HeadingText(parent=parent, create=False)
+        self._control.create()
         self.control = self._control.control
         self.set_tooltip()
-
-    # -------------------------------------------------------------------------
-    #  Updates the editor when the object trait changes external to the editor:
-    # -------------------------------------------------------------------------
 
     def update_editor(self):
         """Updates the editor when the object trait changes external to the
         editor.
         """
         self._control.text = self.str_value
+
+    def dispose(self):
+        """Cleanly dispose of the editor.
+
+        This ensures that the wrapped Pyface Widget is cleaned-up.
+        """
+        if self._control is not None:
+            self._control.destroy()
+        super().dispose()
 
 
 SimpleEditor = _TitleEditor

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -1219,7 +1219,7 @@ class HTMLHelpWindow(wx.Frame):
 HeadingText = None
 
 
-def heading_text(*args, create=False,  **kw):
+def heading_text(*args, create=False, **kw):
     """Create a Pyface HeadingText control."""
     global HeadingText
 

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -1219,11 +1219,13 @@ class HTMLHelpWindow(wx.Frame):
 HeadingText = None
 
 
-def heading_text(*args, **kw):
-    """Creates a Pyface HeadingText control."""
+def heading_text(*args, create=False,  **kw):
+    """Create a Pyface HeadingText control."""
     global HeadingText
 
     if HeadingText is None:
-        from pyface.heading_text import HeadingText
+        from pyface.api import HeadingText
 
-    return HeadingText(*args, **kw)
+    widget = HeadingText(*args, **kw)
+    widget.create()
+    return widget

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -1226,6 +1226,6 @@ def heading_text(*args, create=False, **kw):
     if HeadingText is None:
         from pyface.api import HeadingText
 
-    widget = HeadingText(*args, **kw)
+    widget = HeadingText(create=create, *args, **kw)
     widget.create()
     return widget

--- a/traitsui/wx/ui_panel.py
+++ b/traitsui/wx/ui_panel.py
@@ -1226,6 +1226,6 @@ def heading_text(*args, create=False, **kw):
     if HeadingText is None:
         from pyface.api import HeadingText
 
-    widget = HeadingText(create=create, *args, **kw)
+    widget = HeadingText(*args, create=create, **kw)
     widget.create()
     return widget


### PR DESCRIPTION
This removes a deprecation warning coming from a change in Pyface behaviour. Additionally it adds proper disposal of the HeadingText Widget to the TitleEditor.  It would be nice to do the same for the ui_panel code, but there is no available hook and deeper architectural issues with the code.


**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~ (Not needed - small internal change).