### PR TITLE
Support changing images in ImageEditor for all IImage subclasses

### DIFF
--- a/docs/releases/upcoming/1810.bugfix.rst
+++ b/docs/releases/upcoming/1810.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue with ImageEditor not updating for all IImage implementations.

--- a/etstool.py
+++ b/etstool.py
@@ -128,7 +128,6 @@ source_dependencies = {
 # The following should match extras_require in setup.py but with package
 # names compatible with EDM
 extra_dependencies = {
-    # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': {
         'pygments',
     },
@@ -160,6 +159,7 @@ extra_dependencies = {
     'editors': {
         'numpy',
         'pandas',
+        'pillow',
     },
     # Test dependencies also applied to installation from PYPI
     'test': {

--- a/traitsui/qt4/image_editor.py
+++ b/traitsui/qt4/image_editor.py
@@ -276,8 +276,7 @@ class _ImageEditor(Editor):
         """
         if self.factory.image is None:
             value = self.value
-            if isinstance(value, ImageResource):
-                self.control.setPixmap(convert_bitmap(value))
+            self.control.setPixmap(convert_bitmap(value))
         self.control.setScaledContents(self.factory.scale)
         self.control.setAllowUpscaling(self.factory.allow_upscaling)
         self.control.setPreserveAspectRatio(self.factory.preserve_aspect_ratio)

--- a/traitsui/qt4/image_editor.py
+++ b/traitsui/qt4/image_editor.py
@@ -262,7 +262,10 @@ class _ImageEditor(Editor):
             image = self.value
 
         self.control = QImageView()
-        self.control.setPixmap(convert_bitmap(image))
+        if image is not None:
+            self.control.setPixmap(convert_bitmap(image))
+        else:
+            self.control.setPixmap(None)
         self.control.setScaledContents(self.factory.scale)
         self.control.setAllowUpscaling(self.factory.allow_upscaling)
         self.control.setPreserveAspectRatio(self.factory.preserve_aspect_ratio)
@@ -276,7 +279,10 @@ class _ImageEditor(Editor):
         """
         if self.factory.image is None:
             value = self.value
-            self.control.setPixmap(convert_bitmap(value))
+            if value is not None:
+                self.control.setPixmap(convert_bitmap(value))
+            else:
+                self.control.setPixmap(None)
         self.control.setScaledContents(self.factory.scale)
         self.control.setAllowUpscaling(self.factory.allow_upscaling)
         self.control.setPreserveAspectRatio(self.factory.preserve_aspect_ratio)

--- a/traitsui/tests/editors/test_image_editor.py
+++ b/traitsui/tests/editors/test_image_editor.py
@@ -39,6 +39,7 @@ class ImageDisplay(HasTraits):
     image = Image()
 
 
+@requires_toolkit([ToolkitName.wx, ToolkitName.qt])
 class TestImageEditor(BaseTestMixin, unittest.TestCase):
 
     def test_image_editor_static(self):

--- a/traitsui/tests/editors/test_image_editor.py
+++ b/traitsui/tests/editors/test_image_editor.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Tests pertaining to the AnimatedGIFEditor
+""" Tests pertaining to the ImageEditor
 """
 
 import unittest
@@ -40,7 +40,7 @@ class ImageDisplay(HasTraits):
 
 
 @requires_toolkit([ToolkitName.wx])
-class TestAnimatedGIFEditor(BaseTestMixin, unittest.TestCase):
+class TestImageEditor(BaseTestMixin, unittest.TestCase):
 
     def test_image_editor_static(self):
         obj1 = ImageDisplay()

--- a/traitsui/tests/editors/test_image_editor.py
+++ b/traitsui/tests/editors/test_image_editor.py
@@ -39,7 +39,6 @@ class ImageDisplay(HasTraits):
     image = Image()
 
 
-@requires_toolkit([ToolkitName.wx])
 class TestImageEditor(BaseTestMixin, unittest.TestCase):
 
     def test_image_editor_static(self):
@@ -48,7 +47,7 @@ class TestImageEditor(BaseTestMixin, unittest.TestCase):
             Item(
                 'image',
                 editor=ImageEditor(
-                    image=ImageResource(absolute_path=filename1),
+                    image=ImageResource(filename1),
                 ),
             )
         )
@@ -59,7 +58,7 @@ class TestImageEditor(BaseTestMixin, unittest.TestCase):
 
     def test_image_editor_resource(self):
         obj1 = ImageDisplay(
-            image=ImageResource(absolute_path=filename1)
+            image=ImageResource(filename1)
         )
         view = View(
             Item(
@@ -70,7 +69,7 @@ class TestImageEditor(BaseTestMixin, unittest.TestCase):
 
         # This should not fail.
         with create_ui(obj1, dict(view=view)) as ui:
-            obj1.image = ImageResource(absolute_path=filename2)
+            obj1.image = ImageResource(filename2)
 
     def test_image_editor_array(self):
         try:

--- a/traitsui/tests/editors/test_image_editor.py
+++ b/traitsui/tests/editors/test_image_editor.py
@@ -1,0 +1,142 @@
+# (C) Copyright 2004-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Tests pertaining to the AnimatedGIFEditor
+"""
+
+import unittest
+
+import pkg_resources
+
+from pyface.api import Image, ImageResource
+from traits.api import File, HasTraits
+from traitsui.api import ImageEditor, Item, View
+from traitsui.tests._tools import (
+    BaseTestMixin,
+    create_ui,
+    requires_toolkit,
+    ToolkitName,
+)
+
+
+filename1 = pkg_resources.resource_filename(
+    "traitsui", "examples/demo/Extras/images/e-logo-rev.png"
+)
+filename2 = pkg_resources.resource_filename(
+    "traitsui", "examples/demo/Extras/images/info.png"
+)
+
+
+class ImageDisplay(HasTraits):
+
+    image = Image()
+
+
+@requires_toolkit([ToolkitName.wx])
+class TestAnimatedGIFEditor(BaseTestMixin, unittest.TestCase):
+
+    def test_image_editor_static(self):
+        obj1 = ImageDisplay()
+        view = View(
+            Item(
+                'image',
+                editor=ImageEditor(
+                    image=ImageResource(absolute_path=filename1),
+                ),
+            )
+        )
+
+        # This should not fail.
+        with create_ui(obj1, dict(view=view)) as ui:
+            pass
+
+    def test_image_editor_resource(self):
+        obj1 = ImageDisplay(
+            image=ImageResource(absolute_path=filename1)
+        )
+        view = View(
+            Item(
+                'image',
+                editor=ImageEditor()
+            )
+        )
+
+        # This should not fail.
+        with create_ui(obj1, dict(view=view)) as ui:
+            obj1.image = ImageResource(absolute_path=filename2)
+
+    def test_image_editor_array(self):
+        try:
+            import numpy as np
+            from pyface.api import ArrayImage
+        except ImportError:
+            self.skipTest("NumPy is not available")
+
+        gradient1 = np.empty(shape=(256, 256, 3), dtype='uint8')
+        gradient1[:, :, 0] = np.arange(256).reshape(256, 1)
+        gradient1[:, :, 1] = np.arange(256).reshape(1, 256)
+        gradient1[:, :, 2] = np.arange(255, -1, -1).reshape(1, 256)
+
+        gradient2 = np.empty(shape=(256, 256, 3), dtype='uint8')
+        gradient2[:, :, 0] = np.arange(255, -1, -1).reshape(256, 1)
+        gradient2[:, :, 1] = np.arange(256).reshape(1, 256)
+        gradient2[:, :, 2] = np.arange(255, -1, -1).reshape(1, 256)
+
+        obj1 = ImageDisplay(
+            image=ArrayImage(data=gradient1)
+        )
+        view = View(
+            Item(
+                'image',
+                editor=ImageEditor()
+            )
+        )
+
+        # This should not fail.
+        with create_ui(obj1, dict(view=view)) as ui:
+            obj1.image = ArrayImage(data=gradient2)
+
+    def test_image_editor_pillow(self):
+        try:
+            import PIL.Image
+            from pyface.api import PILImage
+        except ImportError:
+            self.skipTest("Pillow is not available")
+
+        pil_image_1 = PIL.Image.open(filename1)
+        pil_image_2 = PIL.Image.open(filename2)
+
+        obj1 = ImageDisplay(
+            image=PILImage(image=pil_image_1)
+        )
+        view = View(
+            Item(
+                'image',
+                editor=ImageEditor()
+            )
+        )
+
+        # This should not fail.
+        with create_ui(obj1, dict(view=view)) as ui:
+            obj1.image = PILImage(image=pil_image_2)
+
+    def test_image_editor_none(self):
+
+        obj1 = ImageDisplay()
+        view = View(
+            Item(
+                'image',
+                editor=ImageEditor()
+            )
+        )
+
+        # This should not fail.
+        with create_ui(obj1, dict(view=view)) as ui:
+            pass

--- a/traitsui/tests/editors/test_image_editor.py
+++ b/traitsui/tests/editors/test_image_editor.py
@@ -21,6 +21,7 @@ from traitsui.api import ImageEditor, Item, View
 from traitsui.tests._tools import (
     BaseTestMixin,
     create_ui,
+    is_qt,
     requires_toolkit,
     ToolkitName,
 )
@@ -109,6 +110,12 @@ class TestImageEditor(BaseTestMixin, unittest.TestCase):
             from pyface.api import PILImage
         except ImportError:
             self.skipTest("Pillow is not available")
+        if is_qt:
+            try:
+                # is ImageQt available as well
+                from PIL.ImageQt import ImageQt
+            except ImportError:
+                self.skipTest("ImageQt is not available")
 
         pil_image_1 = PIL.Image.open(filename1)
         pil_image_2 = PIL.Image.open(filename2)

--- a/traitsui/wx/image_control.py
+++ b/traitsui/wx/image_control.py
@@ -34,14 +34,14 @@ class ImageControl(wx.Window):
         self, parent, bitmap, selected=None, handler=None, padding=10
     ):
         """Initializes the object."""
-        wx.Window.__init__(
-            self,
-            parent,
-            -1,
-            size=wx.Size(
+        if bitmap is not None:
+            size = wx.Size(
                 bitmap.GetWidth() + padding, bitmap.GetHeight() + padding
-            ),
-        )
+            )
+        else:
+            size = wx.Size(32 + padding, 32 + padding)
+
+        wx.Window.__init__(self, parent, -1, size=size,)
         self._bitmap = bitmap
         self._selected = selected
         self._handler = handler
@@ -82,6 +82,8 @@ class ImageControl(wx.Window):
             if bitmap != self._bitmap:
                 self._bitmap = bitmap
                 self.Refresh()
+        else:
+            self._bitmap = None
 
         return self._bitmap
 
@@ -141,6 +143,8 @@ class ImageControl(wx.Window):
         wdc = wx.PaintDC(self)
         wdx, wdy = self.GetClientSize()
         bitmap = self._bitmap
+        if bitmap is None:
+            return
         bdx = bitmap.GetWidth()
         bdy = bitmap.GetHeight()
         wdc.DrawBitmap(bitmap, (wdx - bdx) // 2, (wdy - bdy) // 2, True)

--- a/traitsui/wx/image_editor.py
+++ b/traitsui/wx/image_editor.py
@@ -40,8 +40,12 @@ class _ImageEditor(Editor):
         image = self.factory.image
         if image is None:
             image = self.value
+        if image is not None:
+            bitmap = convert_bitmap(image)
+        else:
+            bitmap = None
 
-        self.control = ImageControl(parent, convert_bitmap(image), padding=0)
+        self.control = ImageControl(parent, bitmap, padding=0)
 
         self.set_tooltip()
 
@@ -51,4 +55,8 @@ class _ImageEditor(Editor):
         """
         if self.factory.image is None:
             value = self.value
-            self.control.Bitmap(convert_bitmap(value))
+            if value is not None:
+                bitmap = convert_bitmap(value)
+            else:
+                bitmap = None
+            self.control.Bitmap(bitmap)

--- a/traitsui/wx/image_editor.py
+++ b/traitsui/wx/image_editor.py
@@ -51,5 +51,4 @@ class _ImageEditor(Editor):
         """
         if self.factory.image is None:
             value = self.value
-            if isinstance(value, ImageResource):
-                self.control.Bitmap(convert_bitmap(value))
+            self.control.Bitmap(convert_bitmap(value))


### PR DESCRIPTION
Currently code is doing a check for `ImageResource`.  Includes smoke tests for expected functionality.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)