### PR TITLE
Support Pyface `Color` in TraitsUI toolkit Color traits.

### DIFF
--- a/docs/releases/upcoming/1812.feature.rst
+++ b/docs/releases/upcoming/1812.feature.rst
@@ -1,0 +1,1 @@
+Add support for Pyface Color and standaize color names.

--- a/traitsui/qt4/color_trait.py
+++ b/traitsui/qt4/color_trait.py
@@ -27,6 +27,7 @@ from ast import literal_eval
 
 from pyface.qt import QtGui
 from pyface.color import Color as PyfaceColor
+from pyface.util.color_helpers import channels_to_ints
 from pyface.util.color_parser import color_table
 from traits.api import Trait, TraitError
 
@@ -45,7 +46,7 @@ def convert_to_color(object, name, value):
 
         # is it in the color table?
         if value in color_table:
-            tup = tuple(int(x * 255) for x in color_table[value])
+            tup = channels_to_ints(color_table[value])
 
     if isinstance(tup, tuple):
         if 3 <= len(tup) <= 4:
@@ -84,7 +85,7 @@ convert_to_color.info = (
 
 standard_colors = {}
 for name, rgba in color_table.items():
-    rgba_bytes = tuple(int(x * 255) for x in rgba)
+    rgba_bytes = channels_to_ints(rgba)
     standard_colors[str(name)] = QtGui.QColor(*rgba_bytes)
 
 # -------------------------------------------------------------------------

--- a/traitsui/qt4/color_trait.py
+++ b/traitsui/qt4/color_trait.py
@@ -23,8 +23,10 @@
 """ Trait definition for a PyQt-based color.
 """
 
+from ast import literal_eval
 
 from pyface.qt import QtGui
+from pyface.color import Color as PyfaceColor
 
 from traits.api import Trait, TraitError
 
@@ -33,8 +35,8 @@ def convert_to_color(object, name, value):
     """Converts a number into a QColor object."""
     # Try the toolkit agnostic format.
     try:
-        tup = eval(value)
-    except:
+        tup = literal_eval(value)
+    except Exception:
         tup = value
 
     if isinstance(tup, tuple):
@@ -45,6 +47,8 @@ def convert_to_color(object, name, value):
                 raise TraitError
         else:
             raise TraitError
+    elif isinstance(value, PyfaceColor):
+        return value.to_toolkit()
     else:
         if isinstance(value, str):
             # Allow for spaces in the string value.

--- a/traitsui/qt4/color_trait.py
+++ b/traitsui/qt4/color_trait.py
@@ -27,7 +27,7 @@ from ast import literal_eval
 
 from pyface.qt import QtGui
 from pyface.color import Color as PyfaceColor
-
+from pyface.util.color_parser import color_table
 from traits.api import Trait, TraitError
 
 
@@ -39,6 +39,14 @@ def convert_to_color(object, name, value):
     except Exception:
         tup = value
 
+    if isinstance(value, str):
+        # Allow for spaces in the string value.
+        value = value.replace(" ", "")
+
+        # is it in the color table?
+        if value in color_table:
+            tup = tuple(int(x * 255) for x in color_table[value])
+
     if isinstance(tup, tuple):
         if 3 <= len(tup) <= 4:
             try:
@@ -48,12 +56,8 @@ def convert_to_color(object, name, value):
         else:
             raise TraitError
     elif isinstance(value, PyfaceColor):
-        return value.to_toolkit()
+        color = value.to_toolkit()
     else:
-        if isinstance(value, str):
-            # Allow for spaces in the string value.
-            value = value.replace(" ", "")
-
         # Let the standard ctors handle the value.
         try:
             color = QtGui.QColor(value)
@@ -78,12 +82,10 @@ convert_to_color.info = (
 #  Standard colors:
 # -------------------------------------------------------------------------
 
-# Note that this is slightly different from the wx implementation in that the
-# names do not include spaces and the full set of SVG color keywords is
-# supported.
 standard_colors = {}
-for name in QtGui.QColor.colorNames():
-    standard_colors[str(name)] = QtGui.QColor(name)
+for name, rgba in color_table.items():
+    rgba_bytes = tuple(int(x * 255) for x in rgba)
+    standard_colors[str(name)] = QtGui.QColor(*rgba_bytes)
 
 # -------------------------------------------------------------------------
 #  Callable that returns an instance of the PyQtToolkitEditorFactory for color

--- a/traitsui/qt4/tests/test_color_trait.py
+++ b/traitsui/qt4/tests/test_color_trait.py
@@ -1,0 +1,117 @@
+# (C) Copyright 2008-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+from pyface.qt import QtGui
+from pyface.color import Color as PyfaceColor
+from traits.api import HasStrictTraits, TraitError
+
+from traitsui.qt4.color_trait import PyQtColor
+
+
+class ObjectWithColor(HasStrictTraits):
+
+    color = PyQtColor()
+
+
+class ObjectWithColorAllowsNone(HasStrictTraits):
+
+    color = PyQtColor(allow_none=True)
+
+
+class TestPyQtColor(unittest.TestCase):
+
+    def test_default(self):
+        obj = ObjectWithColor()
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (255, 255, 255, 255))
+
+    def test_tuple_rgb(self):
+        obj = ObjectWithColor(color=(0, 128, 255))
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0, 128, 255, 255))
+
+    def test_tuple_rgba(self):
+        obj = ObjectWithColor(color=(0, 128, 255, 64))
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
+
+    def test_name_string(self):
+        obj = ObjectWithColor(color="maroon")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (128, 0, 0, 255))
+
+    def test_rgb_string(self):
+        obj = ObjectWithColor(color="(0, 128, 255)")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0, 128, 255, 255))
+
+    def test_rgba_string(self):
+        obj = ObjectWithColor(color="(0, 128, 255, 64)")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
+
+    def test_rgb_int_string(self):
+        obj = ObjectWithColor(color="0x0088ff")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+
+    def test_rgb_int_string_3(self):
+        obj = ObjectWithColor(color="#08f")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+
+    def test_rgb_int_string_6(self):
+        obj = ObjectWithColor(color="#0088ff")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+
+    def test_rgb_int_string_12(self):
+        obj = ObjectWithColor(color="#00008888ffff")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+
+    def test_rgb_int(self):
+        obj = ObjectWithColor(color=0x0088ff)
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+
+    def test_qcolor(self):
+        obj = ObjectWithColor(color=QtGui.QColor(0, 128, 255, 64))
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
+
+    def test_pyface_color(self):
+        obj = ObjectWithColor(color=PyfaceColor(rgba=(0.0, 0.5, 1.0, 0.25)))
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
+
+    def test_default_none(self):
+        obj = ObjectWithColorAllowsNone(color=None)
+
+        self.assertIsNone(obj.color)
+
+    def test_bad_color(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color="not a color")

--- a/traitsui/qt4/tests/test_color_trait.py
+++ b/traitsui/qt4/tests/test_color_trait.py
@@ -34,83 +34,110 @@ class TestPyQtColor(unittest.TestCase):
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (255, 255, 255, 255))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (255, 255, 255, 255))
 
     def test_tuple_rgb(self):
         obj = ObjectWithColor(color=(0, 128, 255))
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0, 128, 255, 255))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0, 128, 255, 255))
 
     def test_tuple_rgba(self):
         obj = ObjectWithColor(color=(0, 128, 255, 64))
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0, 128, 255, 64))
 
     def test_name_string(self):
-        obj = ObjectWithColor(color="maroon")
+        obj = ObjectWithColor(color="rebeccapurple")
 
         self.assertIsInstance(obj.color, QtGui.QColor)
-        self.assertEqual(obj.color.getRgb(), (128, 0, 0, 255))
+        self.assertEqual(obj.color.getRgb(), (0x66, 0x33, 0x99, 0xff))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0x66, 0x33, 0x99, 0xff))
+
+    def test_name_string_with_space(self):
+        obj = ObjectWithColor(color="rebecca purple")
+
+        self.assertIsInstance(obj.color, QtGui.QColor)
+        self.assertEqual(obj.color.getRgb(), (0x66, 0x33, 0x99, 0xff))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0x66, 0x33, 0x99, 0xff))
 
     def test_rgb_string(self):
         obj = ObjectWithColor(color="(0, 128, 255)")
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0, 128, 255, 255))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0, 128, 255, 255))
 
     def test_rgba_string(self):
         obj = ObjectWithColor(color="(0, 128, 255, 64)")
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
-
-    def test_rgb_int_string(self):
-        obj = ObjectWithColor(color="0x0088ff")
-
-        self.assertIsInstance(obj.color, QtGui.QColor)
-        self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0, 128, 255, 64))
 
     def test_rgb_int_string_3(self):
         obj = ObjectWithColor(color="#08f")
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0x00, 0x88, 0xff, 0xff))
 
     def test_rgb_int_string_6(self):
         obj = ObjectWithColor(color="#0088ff")
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0x00, 0x88, 0xff, 0xff))
 
     def test_rgb_int_string_12(self):
         obj = ObjectWithColor(color="#00008888ffff")
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0x00, 0x88, 0xff, 0xff))
 
     def test_rgb_int(self):
         obj = ObjectWithColor(color=0x0088ff)
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0x00, 0x88, 0xff, 0xff))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0x00, 0x88, 0xff, 0xff))
 
     def test_qcolor(self):
         obj = ObjectWithColor(color=QtGui.QColor(0, 128, 255, 64))
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0, 128, 255, 64))
 
     def test_pyface_color(self):
         obj = ObjectWithColor(color=PyfaceColor(rgba=(0.0, 0.5, 1.0, 0.25)))
 
         self.assertIsInstance(obj.color, QtGui.QColor)
         self.assertEqual(obj.color.getRgb(), (0, 128, 255, 64))
+        self.assertIsInstance(obj.color_, QtGui.QColor)
+        self.assertEqual(obj.color_.getRgb(), (0, 128, 255, 64))
 
     def test_default_none(self):
         obj = ObjectWithColorAllowsNone(color=None)
 
         self.assertIsNone(obj.color)
+        self.assertIsNone(obj.color_)
 
     def test_bad_color(self):
         with self.assertRaises(TraitError):

--- a/traitsui/qt4/tests/test_color_trait.py
+++ b/traitsui/qt4/tests/test_color_trait.py
@@ -142,3 +142,15 @@ class TestPyQtColor(unittest.TestCase):
     def test_bad_color(self):
         with self.assertRaises(TraitError):
             ObjectWithColor(color="not a color")
+
+    def test_bad_tuple(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color=(0xff, 0xff))
+
+    def test_bad_tuple_not_int(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color=("not an int", 0xff, 0xff))
+
+    def test_bad_tuple_string(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color="(0xff, 0xff)")

--- a/traitsui/wx/color_trait.py
+++ b/traitsui/wx/color_trait.py
@@ -11,20 +11,12 @@
 """ Trait definition for a wxPython-based color.
 """
 
+from ast import literal_eval
 
 import wx
 
 from pyface.color import Color as PyfaceColor
-
 from traits.api import Trait, TraitError
-
-# Version dependent imports (ColourPtr not defined in wxPython 2.5):
-try:
-    ColourPtr = wx.ColourPtr
-except:
-
-    class ColourPtr(object):
-        pass
 
 
 # -------------------------------------------------------------------------
@@ -117,9 +109,6 @@ def convert_to_color(object, name, value):
 
     elif isinstance(value, PyfaceColor):
         return value.to_toolkit()
-
-    elif isinstance(value, ColourPtr):
-        return wx.Colour(value.Red(), value.Green(), value.Blue())
 
     elif isinstance(value, wx.Colour):
         return value

--- a/traitsui/wx/color_trait.py
+++ b/traitsui/wx/color_trait.py
@@ -16,6 +16,7 @@ from ast import literal_eval
 import wx
 
 from pyface.color import Color as PyfaceColor
+from pyface.util.color_parser import color_table
 from traits.api import Trait, TraitError
 
 
@@ -38,6 +39,7 @@ class W3CColourDatabase(object):
     _database = wx.ColourDatabase()
 
     def __init__(self):
+        # correct for differences in definitions
         self._color_names = [
             "aqua",
             "black",
@@ -67,6 +69,11 @@ class W3CColourDatabase(object):
         self.AddColour("purple", wx.Colour(0x80, 0x00, 0x80, 255))
         self.AddColour("silver", wx.Colour(0xC0, 0xC0, 0xC0, 255))
         self.AddColour("teal", wx.Colour(0, 0x80, 0x80, 255))
+
+        # add all the standard colours
+        for name, rgba in color_table.items():
+            rgba_bytes = tuple(int(x * 255) for x in rgba)
+            self.AddColour(name, wx.Colour(*rgba_bytes))
 
     def AddColour(self, name, color):
         if name not in self._color_names:
@@ -151,76 +158,7 @@ convert_to_color.info = (
 # -------------------------------------------------------------------------
 
 standard_colors = {}
-for name in [
-    "aquamarine",
-    "black",
-    "blue",
-    "blue violet",
-    "brown",
-    "cadet blue",
-    "coral",
-    "cornflower blue",
-    "cyan",
-    "dark grey",
-    "dark green",
-    "dark olive green",
-    "dark orchid",
-    "dark slate blue",
-    "dark slate grey",
-    "dark turquoise",
-    "dim grey",
-    "firebrick",
-    "forest green",
-    "gold",
-    "goldenrod",
-    "grey",
-    "green",
-    "green yellow",
-    "indian red",
-    "khaki",
-    "light blue",
-    "light grey",
-    "light steel blue",
-    "lime green",
-    "magenta",
-    "maroon",
-    "medium aquamarine",
-    "medium blue",
-    "medium forest green",
-    "medium goldenrod",
-    "medium orchid",
-    "medium sea green",
-    "medium slate blue",
-    "medium spring green",
-    "medium turquoise",
-    "medium violet red",
-    "midnight blue",
-    "navy",
-    "orange",
-    "orange red",
-    "orchid",
-    "pale green",
-    "pink",
-    "plum",
-    "purple",
-    "red",
-    "salmon",
-    "sea green",
-    "sienna",
-    "sky blue",
-    "slate blue",
-    "spring green",
-    "steel blue",
-    "tan",
-    "thistle",
-    "turquoise",
-    "violet",
-    "violet red",
-    "wheat",
-    "white",
-    "yellow",
-    "yellow green",
-]:
+for name in color_table:
     try:
         wx_color = w3c_color_database.Find(name)
         standard_colors[name] = convert_to_color(None, None, wx_color)

--- a/traitsui/wx/color_trait.py
+++ b/traitsui/wx/color_trait.py
@@ -14,6 +14,8 @@
 
 import wx
 
+from pyface.color import Color as PyfaceColor
+
 from traits.api import Trait, TraitError
 
 # Version dependent imports (ColourPtr not defined in wxPython 2.5):
@@ -112,6 +114,9 @@ def convert_to_color(object, name, value):
     """Converts a number into a wxColour object."""
     if isinstance(value, tuple):
         return tuple_to_wxcolor(value)
+
+    elif isinstance(value, PyfaceColor):
+        return value.to_toolkit()
 
     elif isinstance(value, ColourPtr):
         return wx.Colour(value.Red(), value.Green(), value.Blue())

--- a/traitsui/wx/color_trait.py
+++ b/traitsui/wx/color_trait.py
@@ -16,6 +16,7 @@ from ast import literal_eval
 import wx
 
 from pyface.color import Color as PyfaceColor
+from pyface.util.color_helpers import channels_to_ints
 from pyface.util.color_parser import color_table
 from traits.api import Trait, TraitError
 
@@ -72,7 +73,7 @@ class W3CColourDatabase(object):
 
         # add all the standard colours
         for name, rgba in color_table.items():
-            rgba_bytes = tuple(int(x * 255) for x in rgba)
+            rgba_bytes = channels_to_ints(rgba)
             self.AddColour(name, wx.Colour(*rgba_bytes))
 
     def AddColour(self, name, color):

--- a/traitsui/wx/color_trait.py
+++ b/traitsui/wx/color_trait.py
@@ -122,19 +122,18 @@ def convert_to_color(object, name, value):
         return value
 
     elif isinstance(value, str):
+        # Allow for spaces in the string value.
+        value = value.replace(" ", "")
 
         if value in standard_colors:
             return standard_colors[value]
 
-        # Check for tuple-ness
-        tmp = value.strip()
-        if (
-            tmp.startswith("(")
-            and tmp.endswith(")")
-            and tmp.count(",") in (2, 3)
-        ):
-            tup = eval(tmp)
-            return tuple_to_wxcolor(tup)
+        # Check for tuple string
+        try:
+            tup = literal_eval(value)
+        except Exception:
+            raise TraitError
+        return tuple_to_wxcolor(tup)
 
     else:
         try:

--- a/traitsui/wx/tests/test_color_trait.py
+++ b/traitsui/wx/tests/test_color_trait.py
@@ -1,0 +1,95 @@
+# (C) Copyright 2008-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+import wx
+
+from pyface.color import Color as PyfaceColor
+from traits.api import HasStrictTraits, TraitError
+
+from traitsui.wx.color_trait import WxColor
+
+
+class ObjectWithColor(HasStrictTraits):
+
+    color = WxColor()
+
+
+class ObjectWithColorAllowsNone(HasStrictTraits):
+
+    color = WxColor(allow_none=True)
+
+
+class TestWxColor(unittest.TestCase):
+
+    def test_default(self):
+        obj = ObjectWithColor()
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (255, 255, 255, 255))
+
+    def test_tuple_rgb(self):
+        obj = ObjectWithColor(color=(0, 128, 255))
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0, 128, 255, 255))
+
+    def test_tuple_rgba(self):
+        obj = ObjectWithColor(color=(0, 128, 255, 64))
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0, 128, 255, 64))
+
+    def test_name_string(self):
+        obj = ObjectWithColor(color="maroon")
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (128, 0, 0, 255))
+
+    def test_rgb_string(self):
+        obj = ObjectWithColor(color="(0, 128, 255)")
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0, 128, 255, 255))
+
+    def test_rgba_string(self):
+        obj = ObjectWithColor(color="(0, 128, 255, 64)")
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0, 128, 255, 64))
+
+    def test_rgb_int_string(self):
+        obj = ObjectWithColor(color="0x0088ff")
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0x00, 0x88, 0xff, 0xff))
+
+    def test_rgb_int(self):
+        obj = ObjectWithColor(color=0x0088ff)
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0x00, 0x88, 0xff, 0xff))
+
+    def test_pyface_color(self):
+        obj = ObjectWithColor(color=PyfaceColor(rgba=(0.0, 0.5, 1.0, 0.25)))
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0, 128, 255, 64))
+
+    def test_default_none(self):
+        obj = ObjectWithColorAllowsNone()
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (255, 255, 255, 255))
+
+    def test_bad_color(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color="not a color")

--- a/traitsui/wx/tests/test_color_trait.py
+++ b/traitsui/wx/tests/test_color_trait.py
@@ -55,12 +55,20 @@ class TestWxColor(unittest.TestCase):
         self.assertEqual(obj.color_.Get(), (0, 128, 255, 64))
 
     def test_name_string(self):
-        obj = ObjectWithColor(color="maroon")
+        obj = ObjectWithColor(color="rebeccapurple")
 
         self.assertIsInstance(obj.color, wx.Colour)
-        self.assertEqual(obj.color.Get(), (128, 0, 0, 255))
+        self.assertEqual(obj.color.Get(), (0x66, 0x33, 0x99, 0xff))
         self.assertIsInstance(obj.color_, wx.Colour)
-        self.assertEqual(obj.color_.Get(), (128, 0, 0, 255))
+        self.assertEqual(obj.color_.Get(), (0x66, 0x33, 0x99, 0xff))
+
+    def test_name_string_with_space(self):
+        obj = ObjectWithColor(color="rebecca purple")
+
+        self.assertIsInstance(obj.color, wx.Colour)
+        self.assertEqual(obj.color.Get(), (0x66, 0x33, 0x99, 0xff))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (0x66, 0x33, 0x99, 0xff))
 
     def test_rgb_string(self):
         obj = ObjectWithColor(color="(0, 128, 255)")
@@ -103,3 +111,15 @@ class TestWxColor(unittest.TestCase):
     def test_bad_color(self):
         with self.assertRaises(TraitError):
             ObjectWithColor(color="not a color")
+
+    def test_bad_tuple(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color=(0xff, 0xff))
+
+    def test_bad_tuple_not_int(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color=("not an int", 0xff, 0xff))
+
+    def test_bad_tuple_string(self):
+        with self.assertRaises(TraitError):
+            ObjectWithColor(color="(0xff, 0xff)")

--- a/traitsui/wx/tests/test_color_trait.py
+++ b/traitsui/wx/tests/test_color_trait.py
@@ -35,60 +35,70 @@ class TestWxColor(unittest.TestCase):
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (255, 255, 255, 255))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (255, 255, 255, 255))
 
     def test_tuple_rgb(self):
         obj = ObjectWithColor(color=(0, 128, 255))
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (0, 128, 255, 255))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (0, 128, 255, 255))
 
     def test_tuple_rgba(self):
         obj = ObjectWithColor(color=(0, 128, 255, 64))
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (0, 128, 255, 64))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (0, 128, 255, 64))
 
     def test_name_string(self):
         obj = ObjectWithColor(color="maroon")
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (128, 0, 0, 255))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (128, 0, 0, 255))
 
     def test_rgb_string(self):
         obj = ObjectWithColor(color="(0, 128, 255)")
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (0, 128, 255, 255))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (0, 128, 255, 255))
 
     def test_rgba_string(self):
         obj = ObjectWithColor(color="(0, 128, 255, 64)")
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (0, 128, 255, 64))
-
-    def test_rgb_int_string(self):
-        obj = ObjectWithColor(color="0x0088ff")
-
-        self.assertIsInstance(obj.color, wx.Colour)
-        self.assertEqual(obj.color.Get(), (0x00, 0x88, 0xff, 0xff))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (0, 128, 255, 64))
 
     def test_rgb_int(self):
         obj = ObjectWithColor(color=0x0088ff)
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (0x00, 0x88, 0xff, 0xff))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (0x00, 0x88, 0xff, 0xff))
 
     def test_pyface_color(self):
         obj = ObjectWithColor(color=PyfaceColor(rgba=(0.0, 0.5, 1.0, 0.25)))
 
         self.assertIsInstance(obj.color, wx.Colour)
         self.assertEqual(obj.color.Get(), (0, 128, 255, 64))
+        self.assertIsInstance(obj.color_, wx.Colour)
+        self.assertEqual(obj.color_.Get(), (0, 128, 255, 64))
 
     def test_default_none(self):
-        obj = ObjectWithColorAllowsNone()
+        obj = ObjectWithColorAllowsNone(color=None)
 
-        self.assertIsInstance(obj.color, wx.Colour)
-        self.assertEqual(obj.color.Get(), (255, 255, 255, 255))
+        self.assertIsNone(obj.color)
+        self.assertIsNone(obj.color_)
 
     def test_bad_color(self):
         with self.assertRaises(TraitError):


### PR DESCRIPTION
In addition this PR standardizes the set of recognized color names to those that Pyface `Color` understands (basically all web colors, which aligns with Enable/Chaco).  Previously these were just whatever the backend understood.

This includes tests for the `PyQtColor` and `WxColor` traits (which correspond to the traits.api `Color` trait) and which were previously absent.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)