### PR TITLE
Use better NumPy scalar types in example

### DIFF
--- a/traitsui/examples/demo/Standard_Editors/ArrayEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/ArrayEditor_demo.py
@@ -19,10 +19,10 @@ from traitsui.menu import NoButtons
 
 class ArrayEditorTest(HasPrivateTraits):
 
-    three = Array(np.int, (3, 3))
+    three = Array(np.int64, (3, 3))
 
     four = Array(
-        np.float,
+        np.float64,
         (4, 4),
         editor=ArrayEditor(width=-50),
     )


### PR DESCRIPTION
A drive-by nitpick: replace `np.float` and `np.int` (which are just long-winded ways of spelling the builtin `int` and `float`, and are deprecated) with `np.float64` and `np.int64`.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)