### PR TITLE
Improvements for Font traits

### DIFF
--- a/docs/releases/upcoming/1819.feature.rst
+++ b/docs/releases/upcoming/1819.feature.rst
@@ -1,0 +1,1 @@
+Pyface Fonts can be used with TraitsUI Font traits.

--- a/traitsui/qt4/font_trait.py
+++ b/traitsui/qt4/font_trait.py
@@ -25,8 +25,9 @@
 
 
 from pyface.qt import QtGui
-
+from pyface.font import Font as PyfaceFont
 from traits.api import Trait, TraitHandler, TraitError
+
 
 
 # -------------------------------------------------------------------------
@@ -36,16 +37,17 @@ from traits.api import Trait, TraitHandler, TraitError
 # Mapping of strings to valid QFont style hints.
 font_families = {
     "default": QtGui.QFont.StyleHint.AnyStyle,
-    "decorative": QtGui.QFont.Decorative,
-    "roman": QtGui.QFont.Serif,
-    "script": QtGui.QFont.SansSerif,
-    "swiss": QtGui.QFont.SansSerif,
-    "modern": QtGui.QFont.TypeWriter,
+    "decorative": QtGui.QFont.StyleHint.Decorative,
+    "roman": QtGui.QFont.StyleHint.Serif,
+    "script": QtGui.QFont.StyleHint.Cursive,
+    "swiss": QtGui.QFont.StyleHint.SansSerif,
+    "modern": QtGui.QFont.StyleHint.TypeWriter,
 }
 
 # Mapping of strings to QFont styles.
 font_styles = {
     "slant": QtGui.QFont.Style.StyleOblique,
+    "oblique": QtGui.QFont.Style.StyleOblique,
     "italic": QtGui.QFont.Style.StyleItalic,
 }
 
@@ -58,11 +60,18 @@ font_noise = ["pt", "point", "family"]
 
 def font_to_str(font):
     """Converts a QFont into a string description of itself."""
+    style_hint = {
+        QtGui.QFont.StyleHint.Decorative: "decorative",
+        QtGui.QFont.StyleHint.Serif: "roman",
+        QtGui.QFont.StyleHint.Cursive: "script",
+        QtGui.QFont.StyleHint.SansSerif: "swiss",
+        QtGui.QFont.StyleHint.TypeWriter: "modern",
+    }.get(font.styleHint(), "")
     weight = {QtGui.QFont.Weight.Light: " Light", QtGui.QFont.Weight.Bold: " Bold"}.get(
         font.weight(), ""
     )
     style = {
-        QtGui.QFont.Style.StyleOblique: " Slant",
+        QtGui.QFont.Style.StyleOblique: " Oblique",
         QtGui.QFont.Style.StyleItalic: " Italic",
     }.get(font.style(), "")
     underline = ""
@@ -79,11 +88,14 @@ def font_to_str(font):
 
 def create_traitsfont(value):
     """Create a TraitFont object from a string description."""
+    if isinstance(value, PyfaceFont):
+        value = value.to_toolkit()
     if isinstance(value, QtGui.QFont):
         return TraitsFont(value)
 
     point_size = None
     family = ""
+    style_hint = QtGui.QFont.StyleHint.AnyStyle
     style = QtGui.QFont.Style.StyleNormal
     weight = QtGui.QFont.Weight.Normal
     underline = False
@@ -92,9 +104,7 @@ def create_traitsfont(value):
     for word in value.split():
         lword = word.lower()
         if lword in font_families:
-            f = QtGui.QFont()
-            f.setStyleHint(font_families[lword])
-            family = f.defaultFamily()
+            style_hint = font_families[lword]
         elif lword in font_styles:
             style = font_styles[lword]
         elif lword in font_weights:
@@ -118,6 +128,7 @@ def create_traitsfont(value):
     else:
         fnt = TraitsFont()
 
+    fnt.setStyleHint(style_hint)
     fnt.setStyle(style)
     fnt.setWeight(weight)
     fnt.setUnderline(underline)

--- a/traitsui/qt4/font_trait.py
+++ b/traitsui/qt4/font_trait.py
@@ -86,9 +86,12 @@ def font_to_str(font):
 
 
 def create_traitsfont(value):
-    """Create a TraitFont object from a string description."""
+    """Create a TraitFont object.
+
+    This can take either a string description, a QFont, or a Pyface Font.
+    """
     if isinstance(value, PyfaceFont):
-        value = value.to_toolkit()
+        return TraitsFont(value.to_toolkit())
     if isinstance(value, QtGui.QFont):
         return TraitsFont(value)
 
@@ -115,7 +118,7 @@ def create_traitsfont(value):
                 try:
                     point_size = int(lword)
                     continue
-                except:
+                except ValueError:
                     pass
             facename.append(word)
 

--- a/traitsui/qt4/font_trait.py
+++ b/traitsui/qt4/font_trait.py
@@ -29,7 +29,6 @@ from pyface.font import Font as PyfaceFont
 from traits.api import Trait, TraitHandler, TraitError
 
 
-
 # -------------------------------------------------------------------------
 #  Convert a string into a valid QFont object (if possible):
 # -------------------------------------------------------------------------

--- a/traitsui/qt4/font_trait.py
+++ b/traitsui/qt4/font_trait.py
@@ -86,7 +86,7 @@ def font_to_str(font):
 
 
 def create_traitsfont(value):
-    """Create a TraitFont object.
+    """Create a TraitsFont object.
 
     This can take either a string description, a QFont, or a Pyface Font.
     """

--- a/traitsui/qt4/tests/test_font_trait.py
+++ b/traitsui/qt4/tests/test_font_trait.py
@@ -84,7 +84,7 @@ class TestPyQtFont(unittest.TestCase):
         self.assert_qfont_equal(traits_font, font)
 
     def test_create_traitsfont_pyface_font(self):
-        args = simple_parser("18 pt Bold Oblique Underline Comic Sans script")
+        args = simple_parser("18 pt Bold Oblique Underline Courier typewriter")
         font = PyfaceFont(**args)
         traits_font = create_traitsfont(font)
 

--- a/traitsui/qt4/tests/test_font_trait.py
+++ b/traitsui/qt4/tests/test_font_trait.py
@@ -84,16 +84,12 @@ class TestPyQtFont(unittest.TestCase):
         self.assert_qfont_equal(traits_font, font)
 
     def test_create_traitsfont_pyface_font(self):
-        args = simple_parser("18 pt Bold Oblique Underline Courier typewriter")
+        args = simple_parser("18 pt Bold Oblique Underline Courier")
         font = PyfaceFont(**args)
         traits_font = create_traitsfont(font)
 
         self.assertIsInstance(traits_font, TraitsFont)
         self.assert_qfont_equal(traits_font, font.to_toolkit())
-        self.assertEqual(
-            font_to_str(traits_font),
-            "18 point courier Oblique Bold underline"
-        )
 
     def test_font_trait_default(self):
         obj = FontExample()

--- a/traitsui/qt4/tests/test_font_trait.py
+++ b/traitsui/qt4/tests/test_font_trait.py
@@ -1,0 +1,178 @@
+# (C) Copyright 2008-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+from pyface.font import Font as PyfaceFont
+from pyface.util.font_parser import simple_parser
+from pyface.qt.QtGui import QFont, QFontInfo, QApplication
+from traits.api import HasTraits
+
+from ..font_trait import (
+    PyQtFont, TraitsFont, create_traitsfont, font_families, font_styles,
+    font_to_str, font_weights
+)
+
+
+class FontExample(HasTraits):
+
+    font = PyQtFont()
+
+
+class TestPyQtFont(unittest.TestCase):
+
+    def test_create_traitsfont(self):
+        expected_outcomes = {}
+        expected_outcomes[""] = TraitsFont()
+
+        for weight, qt_weight in font_weights.items():
+            expected_outcomes[weight] = TraitsFont()
+            expected_outcomes[weight].setWeight(qt_weight)
+
+        for style, qt_style in font_styles.items():
+            expected_outcomes[style] = TraitsFont()
+            expected_outcomes[style].setStyle(qt_style)
+
+        expected_outcomes["underline"] = TraitsFont()
+        expected_outcomes["underline"].setUnderline(True)
+
+        expected_outcomes["18"] = TraitsFont()
+        expected_outcomes["18"].setPointSize(18)
+        expected_outcomes["18 pt"] = TraitsFont()
+        expected_outcomes["18 pt"].setPointSize(18)
+        expected_outcomes["18 point"] = TraitsFont()
+        expected_outcomes["18 point"].setPointSize(18)
+
+        for family, qt_style_hint in font_families.items():
+            expected_outcomes[family] = TraitsFont()
+            expected_outcomes[family].setStyleHint(qt_style_hint)
+
+        default_size = QApplication.font().pointSize()
+        expected_outcomes["Courier"] = TraitsFont("Courier", default_size)
+        expected_outcomes["Comic Sans"] = TraitsFont("Comic Sans", default_size)
+        expected_outcomes["18 pt Bold Oblique Underline Comic Sans script"] = TraitsFont(
+            "Comic Sans", 18, QFont.Weight.Bold, False
+        )
+        expected_outcomes["18 pt Bold Oblique Underline Comic Sans script"].setStyleHint(QFont.StyleHint.Cursive)
+        expected_outcomes["18 pt Bold Oblique Underline Comic Sans script"].setStyle(QFont.Style.StyleOblique)
+        expected_outcomes["18 pt Bold Oblique Underline Comic Sans script"].setUnderline(True)
+
+        for name, expected in expected_outcomes.items():
+            with self.subTest(name=name):
+                result = create_traitsfont(name)
+
+                # test we get expected font
+                self.assertIsInstance(result, TraitsFont)
+                self.assert_qfont_equal(result, expected)
+
+                # round-trip trhough font_to_str
+                result_2 = create_traitsfont(font_to_str(result))
+                self.assert_qfont_equal(result, result_2)
+
+    def test_create_traitsfont_qfont(self):
+        font = QFont("Comic Sans", 18, QFont.Weight.Bold, False)
+        traits_font = create_traitsfont(font)
+
+        self.assertIsInstance(traits_font, TraitsFont)
+        self.assert_qfont_equal(traits_font, font)
+
+    def test_create_traitsfont_pyface_font(self):
+        args = simple_parser("18 pt Bold Oblique Underline Comic Sans script")
+        font = PyfaceFont(**args)
+        traits_font = create_traitsfont(font)
+
+        self.assertIsInstance(traits_font, TraitsFont)
+        self.assert_qfont_equal(traits_font, font.to_toolkit())
+        self.assertEqual(
+            font_to_str(traits_font),
+            "18 point comic sans Oblique Bold underline"
+        )
+
+    def test_font_trait_default(self):
+        obj = FontExample()
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, TraitsFont())
+
+    def test_font_trait_str(self):
+        obj = FontExample(font="18 pt Bold Oblique Underline Comic Sans script")
+        qfont = TraitsFont(
+            "Comic Sans", 18, QFont.Weight.Bold, False
+        )
+        qfont.setStyleHint(QFont.StyleHint.Cursive)
+        qfont.setStyle(QFont.Style.StyleOblique)
+        qfont.setUnderline(True)
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, qfont)
+
+    def test_font_trait_qfont(self):
+        qfont = TraitsFont(
+            "Comic Sans", 18, QFont.Weight.Bold, False
+        )
+        qfont.setStyleHint(QFont.StyleHint.Cursive)
+        qfont.setStyle(QFont.Style.StyleOblique)
+        qfont.setUnderline(True)
+        obj = FontExample(font=qfont)
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, qfont)
+
+    def test_font_trait_pyface_font(self):
+        args = simple_parser("18 pt Bold Oblique Underline Comic Sans script")
+        font = PyfaceFont(**args)
+        obj = FontExample(font=font)
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, font.to_toolkit())
+
+    def test_traits_font_reduce(self):
+        traits_font = TraitsFont(
+            "Comic Sans", 18, QFont.Weight.Bold, False
+        )
+        traits_font.setStyleHint(QFont.StyleHint.Cursive)
+        traits_font.setStyle(QFont.Style.StyleOblique)
+        traits_font.setUnderline(True)
+
+        result = traits_font.__reduce_ex__(None)
+
+        self.assertEqual(
+            result,
+            (
+                create_traitsfont,
+                ("18 point Comic Sans Oblique Bold underline",),
+            ),
+        )
+
+    def test_traits_font_str(self):
+        traits_font = TraitsFont(
+            "Comic Sans", 18, QFont.Weight.Bold, False
+        )
+        traits_font.setStyleHint(QFont.StyleHint.Cursive)
+        traits_font.setStyle(QFont.Style.StyleOblique)
+        traits_font.setUnderline(True)
+
+        result = str(traits_font)
+
+        self.assertEqual(
+            result,
+            "18 point Comic Sans Oblique Bold underline",
+        )
+
+    def assert_qfont_equal(self, font, other):
+        self.assertIsInstance(font, QFont)
+        self.assertIsInstance(other, QFont)
+
+        self.assertEqual(font.family(), other.family())
+        self.assertEqual(font.styleHint(), font.styleHint())
+        self.assertEqual(font.pointSize(), other.pointSize())
+        self.assertEqual(font.style(), other.style())
+        self.assertEqual(font.weight(), other.weight())
+        self.assertEqual(font.underline(), other.underline())

--- a/traitsui/qt4/tests/test_font_trait.py
+++ b/traitsui/qt4/tests/test_font_trait.py
@@ -13,7 +13,7 @@ import unittest
 from pyface.font import Font as PyfaceFont
 from pyface.util.font_parser import simple_parser
 from pyface.qt.QtGui import QFont, QFontInfo, QApplication
-from traits.api import HasTraits
+from traits.api import HasTraits, TraitError
 
 from ..font_trait import (
     PyQtFont, TraitsFont, create_traitsfont, font_families, font_styles,
@@ -128,6 +128,15 @@ class TestPyQtFont(unittest.TestCase):
 
         self.assertIsInstance(obj.font, TraitsFont)
         self.assert_qfont_equal(obj.font, font.to_toolkit())
+
+    def test_font_trait_none(self):
+        obj = FontExample(font=None)
+
+        self.assertIsNone(obj.font)
+
+    def test_font_trait_bad(self):
+        with self.assertRaises(TraitError):
+            obj = FontExample(font=1)
 
     def test_traits_font_reduce(self):
         traits_font = TraitsFont(

--- a/traitsui/qt4/tests/test_font_trait.py
+++ b/traitsui/qt4/tests/test_font_trait.py
@@ -72,7 +72,7 @@ class TestPyQtFont(unittest.TestCase):
                 self.assertIsInstance(result, TraitsFont)
                 self.assert_qfont_equal(result, expected)
 
-                # round-trip trhough font_to_str
+                # round-trip through font_to_str
                 result_2 = create_traitsfont(font_to_str(result))
                 self.assert_qfont_equal(result, result_2)
 

--- a/traitsui/qt4/tests/test_font_trait.py
+++ b/traitsui/qt4/tests/test_font_trait.py
@@ -126,7 +126,7 @@ class TestPyQtFont(unittest.TestCase):
         self.assert_qfont_equal(obj.font, qfont)
 
     def test_font_trait_pyface_font(self):
-        args = simple_parser("18 pt Bold Oblique Underline Comic Sans script")
+        args = simple_parser("18 pt Bold Oblique Underline Courier typewriter")
         font = PyfaceFont(**args)
         obj = FontExample(font=font)
 

--- a/traitsui/qt4/tests/test_font_trait.py
+++ b/traitsui/qt4/tests/test_font_trait.py
@@ -92,7 +92,7 @@ class TestPyQtFont(unittest.TestCase):
         self.assert_qfont_equal(traits_font, font.to_toolkit())
         self.assertEqual(
             font_to_str(traits_font),
-            "18 point comic sans Oblique Bold underline"
+            "18 point courier Oblique Bold underline"
         )
 
     def test_font_trait_default(self):

--- a/traitsui/wx/font_trait.py
+++ b/traitsui/wx/font_trait.py
@@ -76,7 +76,7 @@ def font_to_str(font):
 
 
 def create_traitsfont(value):
-    """Create a TraitFont object from a string description."""
+    """Create a TraitsFont object from a string description."""
     if isinstance(value, PyfaceFont):
         return TraitsFont(value.to_toolkit())
     if isinstance(value, wx.Font):

--- a/traitsui/wx/tests/test_font_trait.py
+++ b/traitsui/wx/tests/test_font_trait.py
@@ -1,0 +1,185 @@
+# (C) Copyright 2008-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+
+import wx
+
+from pyface.font import Font as PyfaceFont
+from pyface.util.font_parser import simple_parser
+from traits.api import HasTraits, TraitError
+
+from ..font_trait import (
+    WxFont, TraitsFont, create_traitsfont, font_families, font_styles,
+    font_to_str, font_weights
+)
+
+
+class FontExample(HasTraits):
+
+    font = WxFont()
+
+
+class TestPyQtFont(unittest.TestCase):
+
+    def test_create_traitsfont(self):
+        expected_outcomes = {}
+        expected_outcomes[""] = TraitsFont(
+            10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL
+        )
+
+        for weight, wx_weight in font_weights.items():
+            expected_outcomes[weight] = TraitsFont(
+                10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx_weight
+            )
+
+        for style, wx_style in font_styles.items():
+            expected_outcomes[style] = TraitsFont(
+                10, wx.FONTFAMILY_DEFAULT, wx_style, wx.FONTWEIGHT_NORMAL
+            )
+
+        expected_outcomes["underline"] = TraitsFont(
+            10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, True
+        )
+
+        for size in ["18", "18 pt", "18 point"]:
+            expected_outcomes[size] = TraitsFont(
+                18, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL
+            )
+
+        for family, wx_family in font_families.items():
+            expected_outcomes[family] = TraitsFont(
+                10, wx_family, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL
+            )
+
+        expected_outcomes["Courier"] = TraitsFont(
+            10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Courier",
+        )
+        expected_outcomes["Comic Sans"] = TraitsFont(
+            10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Comic Sans",
+        )
+        expected_outcomes["18 pt Bold Oblique Underline Comic Sans script"] = TraitsFont(
+            18, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_SLANT, wx.FONTWEIGHT_BOLD, True, "Comic Sans",
+        )
+
+        for name, expected in expected_outcomes.items():
+            with self.subTest(name=name):
+                result = create_traitsfont(name)
+
+                # test we get expected font
+                self.assertIsInstance(result, TraitsFont)
+                self.assert_qfont_equal(result, expected)
+
+                # round-trip trhough font_to_str
+                result_2 = create_traitsfont(font_to_str(result))
+                self.assert_qfont_equal(result, result_2)
+
+    def test_create_traitsfont_wx_font(self):
+        font = wx.Font(
+            18, wx.FONTFAMILY_SCRIPT, wx.FONTSTYLE_SLANT, wx.FONTWEIGHT_BOLD, True, "Comic Sans",
+        )
+        traits_font = create_traitsfont(font)
+
+        self.assertIsInstance(traits_font, TraitsFont)
+        self.assert_qfont_equal(traits_font, font)
+
+    def test_create_traitsfont_system_default(self):
+        font = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
+        traits_font = create_traitsfont(font)
+
+        self.assertIsInstance(traits_font, TraitsFont)
+        self.assert_qfont_equal(traits_font, font)
+
+    def test_create_traitsfont_pyface_font(self):
+        args = simple_parser("18 pt Bold Oblique Underline Courier")
+        font = PyfaceFont(**args)
+        traits_font = create_traitsfont(font)
+
+        self.assertIsInstance(traits_font, TraitsFont)
+        self.assert_qfont_equal(traits_font, font.to_toolkit())
+
+    def test_font_trait_default(self):
+        obj = FontExample()
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT))
+
+    def test_font_trait_str(self):
+        obj = FontExample(font="18 pt Bold Oblique Underline Comic Sans script")
+        wx_font = TraitsFont(
+            18, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_SLANT, wx.FONTWEIGHT_BOLD, True, "Comic Sans",
+        )
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, wx_font)
+
+    def test_font_trait_wx_font(self):
+        wx_font = TraitsFont(
+            18, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_SLANT, wx.FONTWEIGHT_BOLD, True, "Comic Sans",
+        )
+        obj = FontExample(font=wx_font)
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, wx_font)
+
+    def test_font_trait_pyface_font(self):
+        args = simple_parser("18 pt Bold Oblique Underline Courier typewriter")
+        font = PyfaceFont(**args)
+        obj = FontExample(font=font)
+
+        self.assertIsInstance(obj.font, TraitsFont)
+        self.assert_qfont_equal(obj.font, font.to_toolkit())
+
+    def test_font_trait_none(self):
+        obj = FontExample(font=None)
+
+        self.assertIsNone(obj.font)
+
+    def test_font_trait_bad(self):
+        with self.assertRaises(TraitError):
+            obj = FontExample(font=1)
+
+    def test_traits_font_reduce(self):
+        traits_font = TraitsFont(
+            18, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_SLANT, wx.FONTWEIGHT_BOLD, True, "Comic Sans",
+        )
+
+        result = traits_font.__reduce_ex__(None)
+
+        self.assertEqual(
+            result,
+            (
+                create_traitsfont,
+                ("18 point Comic Sans Oblique Bold underline",),
+            ),
+        )
+
+    def test_traits_font_str(self):
+        traits_font = TraitsFont(
+            18, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_SLANT, wx.FONTWEIGHT_BOLD, True, "Comic Sans",
+        )
+
+        result = str(traits_font)
+
+        self.assertEqual(
+            result,
+            "18 point Comic Sans Oblique Bold underline",
+        )
+
+    def assert_qfont_equal(self, font, other):
+        self.assertIsInstance(font, wx.Font)
+        self.assertIsInstance(other, wx.Font)
+
+        self.assertEqual(font.FaceName, font.FaceName)
+        self.assertEqual(font.Family, other.Family)
+        self.assertEqual(font.PointSize, other.PointSize)
+        self.assertEqual(font.Style, other.Style)
+        self.assertEqual(font.Weight, other.Weight)
+        self.assertEqual(font.GetUnderlined(), other.GetUnderlined())

--- a/traitsui/wx/tests/test_font_trait.py
+++ b/traitsui/wx/tests/test_font_trait.py
@@ -173,7 +173,7 @@ class TestPyQtFont(unittest.TestCase):
             "18 point Comic Sans Oblique Bold underline",
         )
 
-    def assert_qfont_equal(self, font, other):
+    def assert_wxfont_equal(self, font, other):
         self.assertIsInstance(font, wx.Font)
         self.assertIsInstance(other, wx.Font)
 


### PR DESCRIPTION
This adds support for Pyface Font traits, as well as tests.

This does some fussing around with the way font families are handled - they seem to have little effect on qt4 and OS X, while on wx they are very powerful and may override the user's preferred font.  I've adjusted the way things work slightly such that I hope it makes a little better sense, in particular to make sure that the font family gets included in the string version of the code (since that is used for pickling, it seemed important!) - the tests show the behaviour.

This code is likely to be deprecated/replaced in the next release, so the tests are probably the most important piece as they document current behaviours.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)