### PR TITLE
Set default colors for Qt toolkit to work better in dark mode

### DIFF
--- a/docs/releases/upcoming/1821.bugfix.rst
+++ b/docs/releases/upcoming/1821.bugfix.rst
@@ -1,0 +1,1 @@
+Improve error colors for dark mode on Qt.

--- a/traitsui/qt4/constants.py
+++ b/traitsui/qt4/constants.py
@@ -31,25 +31,33 @@ from pyface.api import SystemMetrics
 
 _palette = QtGui.QApplication.palette()
 
-# Default dialog title
+_base = _palette.color(QtGui.QPalette.ColorRole.Base)
+
+#: We are in dark mode if field background colour HSV value is dark.
+is_dark = (_base.value() < 0x80)
+
+#: Default dialog title
 DefaultTitle = "Edit properties"
 
-# Color of valid input
-OKColor = _palette.color(QtGui.QPalette.ColorRole.Base)
+#: Color of valid input
+OKColor = _base
 
-# Color to highlight input errors
-ErrorColor = QtGui.QColor(255, 192, 192)
+#: Color to highlight input errors
+if is_dark:
+    ErrorColor = QtGui.QColor(0xcf, 0x66, 0x79)
+else:
+    ErrorColor = QtGui.QColor(255, 192, 192)
 
-# Color for background of read-only fields
-ReadonlyColor = QtGui.QColor(244, 243, 238)
+#: Color for background of read-only fields
+ReadonlyColor = _palette.color(QtGui.QPalette.ColorRole.Window)
 
-# Color for background of fields where objects can be dropped
-DropColor = QtGui.QColor(215, 242, 255)
+#: Color for background of fields where objects can be dropped
+DropColor = _palette.color(QtGui.QPalette.ColorRole.Base)
 
-# Color for an editable field
-EditableColor = _palette.color(QtGui.QPalette.ColorRole.Base)
+#: Color for an editable field
+EditableColor = _base
 
-# Color for background of windows (like dialog background color)
+#: Color for background of windows (like dialog background color)
 WindowColor = _palette.color(QtGui.QPalette.ColorRole.Window)
 
 del _palette


### PR DESCRIPTION
This also adds a dark mode flag in the constants module.

Mac light mode error:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/600761/154456361-0af7e07c-dc27-4ba7-a088-6cd412a83a7f.png">

Mac dark mode error:
<img width="342" alt="image" src="https://user-images.githubusercontent.com/600761/154456057-52fb8d2a-56d4-479d-986a-d308374532e4.png">

This is not dynamic, however - if dark mode changes while app is running, may get odd effects.

See #1796 and #1810 

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)