### PR TITLE
Add `ListStrAdapter` to `traitsui.api`

### DIFF
--- a/docs/releases/upcoming/1823.feature.rst
+++ b/docs/releases/upcoming/1823.feature.rst
@@ -1,0 +1,1 @@
+Add ListStrAdapter to traitsui.api.

--- a/traitsui/api.py
+++ b/traitsui/api.py
@@ -139,9 +139,10 @@ Menus and Actions
 - :attr:`~.UndoAction`
 - :attr:`~.UndoButton`
 
-Table UI
---------
+Table and List UI
+-----------------
 
+- :class:`~.ListStrAdapter`
 - :class:`~.TabularAdapter`
 - :attr:`~.TableEditor`
 
@@ -344,6 +345,8 @@ from .item import (
     UReadonly,
     spring,
 )
+
+from .list_str_adapter import ListStrAdapter
 
 from .menu import (
     Action,


### PR DESCRIPTION
Does what it says.

Fixes #1799.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)