### PR TITLE
QtView shouldn't crash for modal kinds.

### DIFF
--- a/traitsui/qt4/extra/qt_view.py
+++ b/traitsui/qt4/extra/qt_view.py
@@ -28,7 +28,10 @@ logger = logging.getLogger(__name__)
 
 
 class QtView(View):
-    """A View that allows the specification of Qt style sheets."""
+    """A View that allows the specification of Qt style sheets.
+
+    This works with any non-modal View.
+    """
 
     #: An optional string containing a Qt style sheet.
     style_sheet = Str()
@@ -59,6 +62,9 @@ class QtView(View):
         ui = super().ui(
             context, parent, kind, view_elements, handler, id, scrollable, args
         )
+
+        if not ui.control:
+            return ui
 
         if self.style_sheet:
             ui.control.setStyleSheet(self.style_sheet)


### PR DESCRIPTION
This doesn't mean that stylesheets work, just that there is no crash.  Also update the docstring to indicate why it won't work.

See #1788 - this is only a partial fix.


**Checklist**
- ~[ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~