### PR TITLE
Use Pyface's message dialogs in errors instead of rolling our own

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -15,6 +15,7 @@
 from contextlib import contextmanager
 from functools import partial
 
+from pyface.api import information
 from traits.api import (
     Any,
     Bool,
@@ -33,7 +34,6 @@ from traits.api import (
     Undefined,
     cached_property,
 )
-
 from traits.trait_base import not_none, xgetattr, xsetattr
 
 from .editor_factory import EditorFactory
@@ -157,14 +157,17 @@ class Editor(HasPrivateTraits):
     def error(self, excp):
         """Handles an error that occurs while setting the object's trait value.
 
-        This should normally be overridden in a subclass.
-
         Parameters
         ----------
         excp : Exception
             The exception which occurred.
         """
-        pass
+        information(
+            parent=self.get_control_widget(),
+            title=self.description + " value error",
+            message=str(excp),
+            text_format='plain',
+        )
 
     def set_focus(self):
         """Assigns focus to the editor's underlying toolkit widget.
@@ -477,6 +480,15 @@ class Editor(HasPrivateTraits):
             return "Specifies " + text
 
         return None
+
+    def get_control_widget(self):
+        """Get the concrete widget for the control.
+
+        The default implementation returns the control, however some editors
+        in some backends may store a layout or sizer instead of a proper widget
+        or control, which may not be suitable for certain usages.
+        """
+        return self.control
 
     # -- Utility context managers --------------------------------------------
 

--- a/traitsui/qt4/editor.py
+++ b/traitsui/qt4/editor.py
@@ -65,24 +65,16 @@ class Editor(UIEditor):
         if self.control.text() != new_value:
             self.control.setText(new_value)
 
-    def error(self, excp):
-        """Handles an error that occurs while setting the object's trait value."""
-        # Make sure the control is a widget rather than a layout.
-        if isinstance(self.control, QtGui.QLayout):
-            control = self.control.parentWidget()
-        else:
-            control = self.control
+    def get_control_widget(self):
+        """Get the concrete widget for the control.
 
-        message_box = QtGui.QMessageBox(
-            QtGui.QMessageBox.Icon.Information,
-            self.description + " value error",
-            str(excp),
-            buttons=QtGui.QMessageBox.StandardButton.Ok,
-            parent=control,
-        )
-        message_box.setTextFormat(QtCore.Qt.TextFormat.PlainText)
-        message_box.setEscapeButton(QtGui.QMessageBox.StandardButton.Ok)
-        message_box.exec_()
+        Some editors may use a QLayout  instead of a Qwidget, which may not be
+        suitable for certain usages (eg. for parenting other widgets).
+        """
+        if isinstance(self.control, QtGui.QLayout):
+            return self.control.parentWidget()
+        else:
+            return self.control
 
     def set_tooltip_text(self, control, text):
         """Sets the tooltip for a specified control."""

--- a/traitsui/tests/test_editor.py
+++ b/traitsui/tests/test_editor.py
@@ -981,3 +981,15 @@ class TestEditor(BaseTestMixin, GuiTestAssistant, unittest.TestCase):
             mdtester = ModalDialogTester(trigger_error)
             mdtester.open_and_run(check_and_close)
             self.assertTrue(mdtester.dialog_was_opened)
+
+    def test_get_control_widget(self):
+        user_object = UserObject(user_auxiliary=UserObject())
+        context = {"object": user_object}
+        editor = create_editor(context=context)
+        editor.prepare(None)
+
+        control = editor.get_control_widget()
+        try:
+            self.assertIsNotNone(control)
+        finally:
+            editor.dispose()

--- a/traitsui/wx/editor.py
+++ b/traitsui/wx/editor.py
@@ -61,17 +61,6 @@ class Editor(UIEditor):
         if self.control.GetValue() != new_value:
             self.control.SetValue(new_value)
 
-    def error(self, excp):
-        """Handles an error that occurs while setting the object's trait value."""
-        dlg = wx.MessageDialog(
-            self.control,
-            str(excp),
-            self.description + " value error",
-            wx.OK | wx.ICON_INFORMATION,
-        )
-        dlg.ShowModal()
-        dlg.Destroy()
-
     def set_tooltip_text(self, control, text):
         """Sets the tooltip for a specified control."""
         control.SetToolTip(text)


### PR DESCRIPTION
This allows us to use the same error-handling code cross-platform, modulo a little tweaking for editors which wrap `QLayout` instead of `QWidget`.

This should be transparent to tests - the underlying widgets are the same, we just create them differently.


**Checklist**
- ~[ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~