### PR TITLE
Use Pyface file dialogs instead of creating custom ones

### DIFF
--- a/traitsui/qt4/directory_editor.py
+++ b/traitsui/qt4/directory_editor.py
@@ -20,7 +20,7 @@
 """ Defines various directory editor for the PyQt user interface toolkit.
 """
 
-from pyface.qt import QtGui
+from pyface.api import DirectoryDialog
 
 from .file_editor import (
     SimpleEditor as SimpleFileEditor,
@@ -35,11 +35,11 @@ class SimpleEditor(SimpleFileEditor):
 
     def _create_file_dialog(self):
         """Creates the correct type of file dialog."""
-        dlg = QtGui.QFileDialog(self.control)
-        dlg.selectFile(self._file_name.text())
-        dlg.setFileMode(QtGui.QFileDialog.FileMode.Directory)
-        dlg.setOptions(QtGui.QFileDialog.Option.ShowDirsOnly)
 
+        dlg = DirectoryDialog(
+            parent=self.get_control_widget(),
+            default_path=self._file_name.text(),
+        )
         return dlg
 
 

--- a/traitsui/qt4/file_editor.py
+++ b/traitsui/qt4/file_editor.py
@@ -114,7 +114,10 @@ class SimpleEditor(SimpleTextEditor):
         dlg.open()
 
         if dlg.return_code == OK:
-            self.value = dlg.path
+            if self.factory.truncate:
+                self.value = splitext(dlg.path)
+            else:
+                self.value = dlg.path
             self.update_editor()
 
     def get_error_control(self):

--- a/traitsui/wx/directory_editor.py
+++ b/traitsui/wx/directory_editor.py
@@ -11,10 +11,11 @@
 """ Defines various directory editors for the wxPython user interface toolkit.
 """
 
+from os.path import isdir
 
 import wx
 
-from os.path import isdir
+from pyface.api import DirectoryDialog
 
 from .file_editor import (
     SimpleEditor as SimpleFileEditor,
@@ -34,8 +35,10 @@ class SimpleEditor(SimpleFileEditor):
 
     def _create_file_dialog(self):
         """Creates the correct type of file dialog."""
-        dlg = wx.DirDialog(self.control, message="Select a Directory")
-        dlg.SetPath(self._file_name.GetValue())
+        dlg = DirectoryDialog(
+            parent=self.get_control_widget(),
+            default_path=self._file_name.text(),
+        )
         return dlg
 
     def _create_file_popup(self):

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -142,7 +142,10 @@ class SimpleEditor(SimpleTextEditor):
             dlg.open()
 
             if dlg.return_code == OK:
-                self.value = dlg.path
+                if self.factory.truncate:
+                    self.value = splitext(dlg.path)
+                else:
+                    self.value = dlg.path
                 self.update_editor()
 
     def get_error_control(self):

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -198,7 +198,7 @@ class SimpleEditor(SimpleTextEditor):
         dlg = FileDialog(
             parent=self.get_control_widget(),
             default_path=self._file_name.text(),
-            action=self.factory.dialog_style,
+            action="save" if self.factory.dialog_style == "save as" else "open",
             wildcard=wildcard,
         )
         return dlg

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -11,11 +11,11 @@
 """ Defines file editors for the wxPython user interface toolkit.
 """
 
+from os.path import abspath, split, splitext, isfile, exists
 
 import wx
 
-from os.path import abspath, split, splitext, isfile, exists
-
+from pyface.api import FileDialog, OK
 from traits.api import List, Str, Event, Any, observe, TraitError
 
 from .text_editor import SimpleEditor as SimpleTextEditor
@@ -139,14 +139,10 @@ class SimpleEditor(SimpleTextEditor):
             self.popup = self._create_file_popup()
         else:
             dlg = self._create_file_dialog()
-            rc = dlg.ShowModal() == wx.ID_OK
-            file_name = abspath(dlg.GetPath())
-            dlg.Destroy()
-            if rc:
-                if self.factory.truncate_ext:
-                    file_name = splitext(file_name)[0]
+            dlg.open()
 
-                self.value = file_name
+            if dlg.return_code == OK:
+                self.value = dlg.path
                 self.update_editor()
 
     def get_error_control(self):
@@ -195,28 +191,16 @@ class SimpleEditor(SimpleTextEditor):
     def _create_file_dialog(self):
         """Creates the correct type of file dialog."""
         if len(self.factory.filter) > 0:
-            wildcard = "|".join(self.factory.filter[:])
+            wildcard = "|".join(self.factory.filter)
         else:
             wildcard = "All Files (*.*)|*.*"
 
-        if self.factory.dialog_style == "save":
-            style = wx.FD_SAVE
-        elif self.factory.dialog_style == "open":
-            style = wx.FD_OPEN
-        else:
-            style = wx.FD_DEFAULT_STYLE
-
-        directory, filename = split(self._get_value())
-
-        dlg = wx.FileDialog(
-            self.control,
-            defaultDir=directory,
-            defaultFile=filename,
-            message="Select a File",
+        dlg = FileDialog(
+            parent=self.get_control_widget(),
+            default_path=self._file_name.text(),
+            action=self.factory.dialog_style,
             wildcard=wildcard,
-            style=style,
         )
-
         return dlg
 
     def _create_file_popup(self):


### PR DESCRIPTION
This has the potential to allow more common code between the two editors, but not in this PR.

No new tests, unfortunately, as we don't have a way to drive the file dialogs once they are open.

**Checklist**
- ~[ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~