### PR TITLE
Remove usage of `property_depends_on`

### DIFF
--- a/docs/releases/upcoming/1832.feature.rst
+++ b/docs/releases/upcoming/1832.feature.rst
@@ -1,0 +1,1 @@
+Remove uses of the archaic `property_depends_on` decorator.

--- a/traitsui/examples/demo/Advanced/Adapted_tree_editor_demo.py
+++ b/traitsui/examples/demo/Advanced/Adapted_tree_editor_demo.py
@@ -41,8 +41,8 @@ from traits.api import (
     HasTraits,
     Property,
     Directory,
-    property_depends_on,
     register_factory,
+    cached_property
 )
 
 from traitsui.api import (
@@ -111,7 +111,7 @@ class FileTreeDemo(HasTraits):
     root_path = Directory(entries=10)
 
     # The root of the file tree:
-    root = Property()
+    root = Property(observe='root_path')
 
     # The traits view to display:
     view = View(
@@ -132,7 +132,7 @@ class FileTreeDemo(HasTraits):
 
     # -- Property Implementations ---------------------------------------------
 
-    @property_depends_on('root_path')
+    @cached_property
     def _get_root(self):
         return File(path=self.root_path)
 

--- a/traitsui/examples/demo/Advanced/Auto_editable_readonly_table_cells.py
+++ b/traitsui/examples/demo/Advanced/Auto_editable_readonly_table_cells.py
@@ -43,7 +43,7 @@ from traits.api import (
     List,
     Range,
     Property,
-    property_depends_on,
+    cached_property,
 )
 
 from traitsui.api import View, VGroup, Item, TableEditor
@@ -68,9 +68,9 @@ class Factor(HasTraits):
     n = Int()
 
     # The list of factors of 'n':
-    factors = Property(List)
+    factors = Property(List, observe='n')
 
-    @property_depends_on('n')
+    @cached_property
     def _get_factors(self):
         n = self.n
         i = 1
@@ -146,7 +146,7 @@ class Factors(HasTraits):
     max_n = Range(1, 1000, 20, mode='slider')
 
     # The list of Factor objects:
-    factors = Property(List)
+    factors = Property(List, observe='max_n')
 
     # The view of the list of Factor objects:
     view = View(
@@ -167,7 +167,7 @@ class Factors(HasTraits):
         resizable=True,
     )
 
-    @property_depends_on('max_n')
+    @cached_property
     def _get_factors(self):
         return [Factor(n=i + 1) for i in range(self.max_n)]
 

--- a/traitsui/examples/demo/Advanced/Invalid_state_handling.py
+++ b/traitsui/examples/demo/Advanced/Invalid_state_handling.py
@@ -73,7 +73,6 @@ from traits.api import (
     Bool,
     Str,
     Property,
-    property_depends_on,
 )
 
 from traitsui.api import View, VGroup, Item
@@ -90,15 +89,17 @@ class System(HasTraits):
     velocity = Range(0.0, 100.0)
 
     # The kinetic energy of the system:
-    kinetic_energy = Property(Float)
+    kinetic_energy = Property(Float, observe='mass, velocity')
 
     # The current error status of the system:
     error = Property(
-        Bool, sync_to_view='mass.invalid, velocity.invalid, status.invalid'
+        Bool,
+        sync_to_view='mass.invalid, velocity.invalid, status.invalid',
+        observe='kinetic_energy',
     )
 
     # The current status of the system:
-    status = Property(Str)
+    status = Property(Str, observe='error')
 
     view = View(
         VGroup(
@@ -117,15 +118,12 @@ class System(HasTraits):
         )
     )
 
-    @property_depends_on('mass, velocity')
     def _get_kinetic_energy(self):
         return (self.mass * self.velocity * self.velocity) / 2.0
 
-    @property_depends_on('kinetic_energy')
     def _get_error(self):
         return self.kinetic_energy > 50000.0
 
-    @property_depends_on('error')
     def _get_status(self):
         if self.error:
             return 'The kinetic energy of the system is too high.'

--- a/traitsui/examples/demo/Advanced/Settable_cached_property.py
+++ b/traitsui/examples/demo/Advanced/Settable_cached_property.py
@@ -32,10 +32,10 @@ However, it is possible to define a 'settable cached' property which in addition
 to the capabilities of a normal 'cached' property, also allows the property's
 value to be explicitly set.
 
-To accomplish this, simply set the 'settable' argument to the
-'property_depends_on' decorator to True (see the '_get_c' method in the
-example code). When set this way, an appropriate 'setter' method is
-automatically generated for the associated property.
+To accomplish this, simply add a '_set_*' method as usual for a settable property
+(see the '_set_c' method in the example code) which takes the value provided
+and changes the values the property depends on appropriately based on the new
+value.
 
 This allows code to set the value of the property directly if desired, subject
 to any constraints specified in the property declaration. For example, in the

--- a/traitsui/ui.py
+++ b/traitsui/ui.py
@@ -31,7 +31,6 @@ from traits.api import (
     Str,
     TraitError,
     observe,
-    property_depends_on,
 )
 
 from traits.trait_base import traits_home, is_str


### PR DESCRIPTION
Mostly this is just replacing with appropriate `observe` metadata, but in one example the text description needed significant updating.

Fixes #1730

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)