### PR TITLE
Small fix for segfault when non-int values given to `QColor`

### DIFF
--- a/traitsui/qt4/color_trait.py
+++ b/traitsui/qt4/color_trait.py
@@ -49,10 +49,10 @@ def convert_to_color(object, name, value):
             tup = channels_to_ints(color_table[value])
 
     if isinstance(tup, tuple):
-        if 3 <= len(tup) <= 4:
+        if 3 <= len(tup) <= 4 and all(isinstance(x, int) for x in tup):
             try:
                 color = QtGui.QColor(*tup)
-            except TypeError:
+            except Exception:
                 raise TraitError
         else:
             raise TraitError


### PR DESCRIPTION
When testing on Python 3.8 with certain versions of PySide6 we were getting a segfault when a tuple with a string value was passed as a color.  This should raise a `TraitError`, not segfault.

**Checklist**
- ~[ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~