### PR TITLE
Fix `TreeEditor` extended selection bug

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -888,6 +888,7 @@ class SimpleEditor(Editor):
                 if id(nid) == id(nids[0]):
                     object = sel_object
                     not_handled = node.select(sel_object)
+                    break
         else:
             nid = None
             object = None

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -888,6 +888,7 @@ class SimpleEditor(Editor):
                 if id(nid) == id(nids[0]):
                     object = sel_object
                     not_handled = node.select(sel_object)
+                    # need to break here to preserve node value for use later
                     break
         else:
             nid = None

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -910,6 +910,8 @@ class SimpleEditor(Editor):
             if nid == nids[0]:
                 object = sel_object
                 not_handled = node.select(object)
+                # need to break here to preserve node value for use later
+                break
 
         # Set the value of the new selection:
         if self.factory.selection_mode == "single":


### PR DESCRIPTION
This should fix #1839.

The issue was a for loop that was iterating over all the nodes in a selection, but then using the `node` variable from the loop as if it were the selection, leading to a mismatch between the selected `object` and the `node`.  The `View` for the editor came from the `node` and so might not be correct for the `object`, leading to a crash and segfault.

The fix is to break once the selection has been identified.

Can't easily test other than manually, and the Wx fix is blocked by #1845.  The sample code from #1839 is fairly straightforward to run and to get a replication.

**Checklist**
- ~[ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~