### PR TITLE
Delay importing toolkit when importing View.

### DIFF
--- a/traitsui/editor.py
+++ b/traitsui/editor.py
@@ -15,7 +15,6 @@
 from contextlib import contextmanager
 from functools import partial
 
-from pyface.api import information
 from traits.api import (
     Any,
     Bool,
@@ -162,6 +161,8 @@ class Editor(HasPrivateTraits):
         excp : Exception
             The exception which occurred.
         """
+        from pyface.api import information
+
         information(
             parent=self.get_control_widget(),
             title=self.description + " value error",

--- a/traitsui/tests/test_regression.py
+++ b/traitsui/tests/test_regression.py
@@ -11,6 +11,8 @@
 """ General regression tests for various fixed bugs.
 """
 
+from subprocess import check_output, STDOUT
+import sys
 import unittest
 
 from traits.api import DelegatesTo, Event, HasTraits, Instance, Undefined
@@ -55,3 +57,13 @@ class TestRegression(BaseTestMixin, unittest.TestCase):
             object=Parent(),
             name="not_a_trait",
         )
+
+    def test_importing_view_does_not_import_toolkit(self):
+        output = check_output(
+            [sys.executable, "-c",
+             "import sys; from traitsui.view import View;"
+             "print(list(sys.modules.keys()))"],
+            stderr=STDOUT
+        )
+        output = output.decode('ascii')
+        self.assertFalse('QtCore' in output)


### PR DESCRIPTION
The last traitsui release introduced a regression where doing `from traitsui.view import View` would end up importing a toolkit backend. This is tested and fixed.  I am not sure if this is an appropriate test case but here it is.  This is related to https://github.com/enthought/mayavi/pull/1139