### PR TITLE
Allow separators to be added in EnumEditor's dropdown menu

### DIFF
--- a/traitsui/editors/enum_editor.py
+++ b/traitsui/editors/enum_editor.py
@@ -15,7 +15,7 @@ traits user interface toolkits.
 import os
 import sys
 
-from traits.api import Any, Range, Enum, Bool
+from traits.api import Any, Range, Enum, Bool, Str
 
 from traitsui.editor_factory import EditorWithListFactory
 from traitsui.toolkit import toolkit_object
@@ -52,6 +52,12 @@ class EnumEditor(EditorWithListFactory):
 
     #: Completion mode for editors with text-entry (Qt only):
     completion_mode = CompletionMode
+
+    #: Whether values trait contains separators (Qt only)
+    use_separator = Bool(False)
+
+    #: The separator string used in values trait (Qt only)
+    separator = Str("")
 
     # -------------------------------------------------------------------------
     #  'Editor' factory methods:

--- a/traitsui/qt4/enum_editor.py
+++ b/traitsui/qt4/enum_editor.py
@@ -162,7 +162,7 @@ class SimpleEditor(BaseEditor):
         super().init(parent)
 
         self.control = control = self.create_combo_box()
-        control.addItems(self.names)
+        self._add_items_to_combo_box()
 
         control.currentIndexChanged.connect(self.update_object)
 
@@ -212,7 +212,7 @@ class SimpleEditor(BaseEditor):
         self.control.blockSignals(True)
         try:
             self.control.clear()
-            self.control.addItems(self.names)
+            self._add_items_to_combo_box()
         finally:
             self.control.blockSignals(False)
 
@@ -240,6 +240,13 @@ class SimpleEditor(BaseEditor):
             QtGui.QSizePolicy.Policy.Maximum, QtGui.QSizePolicy.Policy.Fixed
         )
         return control
+
+    def _add_items_to_combo_box(self):
+        for name in self.names:
+            if self.factory.use_separator and name == self.factory.separator:
+                self.control.insertSeparator(self.control.count())
+            else:
+                self.control.addItem(name)
 
     def _set_background(self, col):
         le = self.control.lineEdit()


### PR DESCRIPTION
This allows user to add special separator strings (default to empty string) in `values` that is passed to EnumEditor and EnumEditor will translate them to separators if dropdown menu style is used. For Qt backend only.


**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)