### PR TITLE
Allow main test workflow to be run manually

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -8,7 +8,7 @@
 
 name: Test with EDM
 
-on: pull_request
+on: [pull_request, workflow_dispatch]
 
 env:
   INSTALL_EDM_VERSION: 3.3.1


### PR DESCRIPTION
This PR allows the main test workflow to be run manually if desired. This is convenient when debugging CI failures - the workflow can be run directly on a test branch, without needing to first create a PR for that branch.