### PR TITLE
Add workaround for test_key_click failure on Windows/PySide6

### DIFF
--- a/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_interaction_helpers.py
+++ b/traitsui/testing/tester/_ui_tester_registry/qt4/tests/test_interaction_helpers.py
@@ -205,7 +205,11 @@ class TestInteractions(unittest.TestCase):
         _interaction_helpers.key_click_qwidget(
             textbox, command.KeyClick("Enter"), 0
         )
-        self.assertEqual(change_slot.call_count, 1)
+        # The textChanged event appears to be fired twice instead of once
+        # on Windows/PySide6, for reasons as yet undetermined. But for our
+        # purposes it's good enough that it's fired at all.
+        # xref: enthought/traitsui#1895
+        change_slot.assert_called()
         self.assertEqual(textbox.toPlainText(), "\n")
 
         # for a QLabel, one can try a key click and nothing will happen


### PR DESCRIPTION
This PR weakens the `test_key_click` test to check that when the Enter key is pressed inside a QTextEdit, the `textChanged` event is fired at least once. Previously, the test checked that the event was fired _exactly_ once, but that check fails on Windows / PySide 6, for reasons that I haven't been able to track down. This may be a PySide6 or Qt bug, but I haven't found any relevant bug report.

I suspect that for our purposes it should be good enough that `textChanged` is fired at all; we shouldn't need to care too much about how many times it's fired.

Closes #1895.