### PR TITLE
Avoid broken PySide6 versions on Python 3.6 and 3.7

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -19,8 +19,14 @@ __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt5", "pygments"],
-    "pyside2": ["pyside2", "shiboken2", "pygments"],
-    "pyside6": ["pyside6", "shiboken6", "pygments"],
+    "pyside2": ["pyside2", "pygments"],
+    "pyside6": [
+        # Avoid https://bugreports.qt.io/browse/PYSIDE-1797, which causes
+        # some versions of PySide6 to be unimportable on Python 3.6 and 3.7.
+        "pyside6!=6.2.2,!=6.2.2.1,!=6.2.3,!=6.2.4,!=6.3.0; python_version<'3.8'",
+        "pyside6; python_version>='3.8'",
+        "pygments",
+    ],
     "docs": ["enthought-sphinx-theme", "sphinx"],
     "demo": [
         # to be deprecated, see enthought/traitsui#950


### PR DESCRIPTION
This PR updates the behaviour of `pip install .[pyside6]` to avoid known-bad PySide6 versions on Python 3.6 and Python 3.7. It should have no effect on Python >= 3.8.

With a bit of luck, this should get our install-from-PyPI cron job back to working.

Note: I also removed the explicit "shiboken6" and "shiboken2" requirements: we don't depend directly on shiboken at all, and for a PyPI install it should always be installed automatically as a dependency of the appropriate version of PySide.