### PR TITLE
Add missing dependency for examples

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -33,6 +33,7 @@ __extras_require__ = {
         "h5py",
         "numpy",
         "pandas",
+        "pillow",
         "tables",
     ],
     "editors": [


### PR DESCRIPTION
The `pillow` package is used by the `VideoEditor_demo.py`, but is not mentioned in the `examples` list under `__extras_require__`.

With luck, this PR should get the integration tests workflow passing again.