### PR TITLE
Fix test suite hang on wx

### DIFF
--- a/traitsui/tests/editors/test_range_editor.py
+++ b/traitsui/tests/editors/test_range_editor.py
@@ -404,7 +404,9 @@ class TestRangeEditor(BaseTestMixin, unittest.TestCase, UnittestTools):
                 float_value_text.inspect(DisplayedText()), "0.2 ..."
             )
 
-    # regression test for enthought/traitsui#737
+    # regression test for enthought/traitsui#737. Hangs with a popup
+    # dialog on wx. (xref: enthought/traitsui#1901)
+    @requires_toolkit([ToolkitName.qt])
     def test_set_text_out_of_range(self):
         model = RangeModel()
         view = View(


### PR DESCRIPTION
This PR adds a skip for a test that hangs on wxPython. On my machine, the wxPython test run now executes to completion on my machine. (It has many failures and an occasional segfault, but that seems like a slightly better state than a hang - we at least get to find out how many tests failed.)

Closes #1901.