### PR TITLE
Use the "sphinx-copybutton" extension in documentation

### DIFF
--- a/docs/releases/upcoming/1904.doc.rst
+++ b/docs/releases/upcoming/1904.doc.rst
@@ -1,0 +1,1 @@
+Add a copy button to code blocks in documentation (#1904)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'sphinx.ext.napoleon',
     # Link to code in sphinx generated API docs
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
     'traits.util.trait_documenter',
 ]
 
@@ -79,6 +80,12 @@ today_fmt = '%B %d, %Y'
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Options for Sphinx copybutton extension
+# ---------------------------------------
+
+# Matches prompts - "$ ", ">>>" and "..."
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
 
 # Options for HTML output
 # -----------------------

--- a/etstool.py
+++ b/etstool.py
@@ -284,6 +284,11 @@ def install(runtime, toolkit, environment, editable, source):
                 "edm run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"
             )
 
+    # Temporarily install "sphinx-copybutton" from PyPI
+    commands.append(
+        "edm run -e {environment} -- python -m pip install sphinx-copybutton"
+    )
+
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)
 

--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -27,7 +27,7 @@ __extras_require__ = {
         "pyside6; python_version>='3.8'",
         "pygments",
     ],
-    "docs": ["enthought-sphinx-theme", "sphinx"],
+    "docs": ["enthought-sphinx-theme", "sphinx", "sphinx-copybutton"],
     "demo": [
         # to be deprecated, see enthought/traitsui#950
         "configobj",


### PR DESCRIPTION
This PR does the following: 
- Use the `sphinx_copybutton` extension when building the Sphinx documentation
- Make `sphinx-copybutton` as a `docs` extra for the `traitsui` package
- Install `sphinx-copybutton` from PyPI when building docs using the `etstool.py` utility.

Ref https://sphinx-copybutton.readthedocs.io/en/latest/

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)