### PR TITLE
If `Image` is `None`, use default `paintEvent` handler only in Qt `ImageEditor`

### DIFF
--- a/docs/releases/upcoming/1907.bugfix.rst
+++ b/docs/releases/upcoming/1907.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ImageEditor paintEvent when image is None. (#1907)

--- a/traitsui/qt4/image_editor.py
+++ b/traitsui/qt4/image_editor.py
@@ -67,6 +67,7 @@ class QImageView(QFrame):
         pixmap = self._pixmap
         if pixmap is None:
             super().paintEvent(event)
+            return
 
         pm_size = pixmap.size()
         pm_width = pm_size.width()

--- a/traitsui/tests/editors/test_image_editor.py
+++ b/traitsui/tests/editors/test_image_editor.py
@@ -136,7 +136,7 @@ class TestImageEditor(BaseTestMixin, unittest.TestCase):
 
     def test_image_editor_none(self):
 
-        obj1 = ImageDisplay()
+        obj1 = ImageDisplay(image=None)
         view = View(
             Item(
                 'image',


### PR DESCRIPTION
Fixes #1882.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)