### PR TITLE
Fixes for Qt6 VideoEditor

### DIFF
--- a/.github/actions/apt-get-qt-deps/action.yml
+++ b/.github/actions/apt-get-qt-deps/action.yml
@@ -20,4 +20,6 @@ runs:
         sudo apt-get install libpulse-mainloop-glib0
         # Needed to work around https://bugreports.qt.io/browse/PYSIDE-1547
         sudo apt-get install libopengl0
+        # Needed for Qt6 video playback
+        sudo apt-get install libgstreamer-gl1.0-0
       shell: bash

--- a/docs/releases/upcoming/1908.bugfix.rst
+++ b/docs/releases/upcoming/1908.bugfix.rst
@@ -1,0 +1,1 @@
+Fix QVideoEditor for Qt6 (#1908)

--- a/integrationtests/test_all_examples.py
+++ b/integrationtests/test_all_examples.py
@@ -198,16 +198,6 @@ SEARCHER.skip_file_if(
     "Only support wx",
 )
 SEARCHER.skip_file_if(
-    os.path.join(DEMO, "Misc", "demo_group_size.py"),
-    is_qt6,
-    "enable tries to import a missing constant. See enthought/enable#891",
-)
-SEARCHER.skip_file_if(
-    os.path.join(DEMO, "Standard_Editors", "VideoEditor_demo.py"),
-    lambda: not is_qt5(),
-    "Only supported on Qt5",
-)
-SEARCHER.skip_file_if(
     os.path.join(TUTORIALS, "view_multi_object.py"),
     lambda: True,
     "Require wx and is blocking.",

--- a/traitsui/examples/demo/Standard_Editors/VideoEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/VideoEditor_demo.py
@@ -17,6 +17,7 @@ Please refer to the `VideoEditor API docs`_ for further information.
 """
 import numpy as np
 from PIL import Image
+from pyface.qt import is_qt5
 from pyface.qt.QtGui import QImage
 from traits.api import (
     Bool,
@@ -177,8 +178,11 @@ class VideoEditorDemo(HasTraits):
 
 url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4"  # noqa: E501
 # Create the demo:
-demo = VideoEditorDemo(image_func=test_image_func, video_url=url)
-# demo = VideoEditorDemo(video_url=url)
+if is_qt5:
+    demo = VideoEditorDemo(image_func=test_image_func, video_url=url)
+else:
+    # Qt 6 can't do on-the-fly image manipulation
+    demo = VideoEditorDemo(video_url=url)
 
 # Run the demo (if invoked from the command line):
 if __name__ == '__main__':

--- a/traitsui/qt4/video_editor.py
+++ b/traitsui/qt4/video_editor.py
@@ -131,7 +131,9 @@ if is_qt5:
                 cloned_frame.width(),
                 cloned_frame.height(),
                 cloned_frame.bytesPerLine(),
-                QVideoFrame.imageFormatFromPixelFormat(cloned_frame.pixelFormat()),
+                QVideoFrame.imageFormatFromPixelFormat(
+                    cloned_frame.pixelFormat()
+                ),
             )
             self.frameAvailable.emit(image)
             return True
@@ -389,7 +391,7 @@ class VideoEditor(Editor):
         if is_qt5:
             self.buffer = self.media_player.bufferStatus()
         else:
-            self.buffer = self.media_player.bufferProgress()
+            self.buffer = int(self.media_player.bufferProgress() * 100)
 
     def _notify_interval_changed_emitted(self, interval):
         self.notify_interval = interval / 1000.0
@@ -414,7 +416,10 @@ class VideoEditor(Editor):
     def _media_content_observer(self, event):
         self.video_error = ''
         if self.media_player is not None:
-            self.media_player.setMedia(self.media_content)
+            if is_qt5:
+                self.media_player.setMedia(self.media_content)
+            else:
+                self.media_player.setSource(self.media_content)
 
     @observe('muted')
     def _muted_observer(self, event):

--- a/traitsui/qt4/video_editor.py
+++ b/traitsui/qt4/video_editor.py
@@ -308,7 +308,7 @@ class VideoEditor(Editor):
                 self.media_player.playbackStateChanged.connect(
                     self._state_changed_emitted
                 )
-                self.media_player.errorChanged.connect(self._error_emitted)
+                self.media_player.errorOccurred.connect(self._error_emitted)
                 self.media_player.bufferProgressChanged.connect(
                     self._buffer_status_changed_emitted
                 )
@@ -339,7 +339,7 @@ class VideoEditor(Editor):
                 self.media_player.playbackStateChanged.disconnect(
                     self._state_changed_emitted
                 )
-                self.media_player.errorChanged.disconnect(self._error_emitted)
+                self.media_player.errorOccurred.disconnect(self._error_emitted)
                 self.media_player.bufferProgressChanged.disconnect(
                     self._buffer_status_changed_emitted
                 )

--- a/traitsui/tests/editors/test_video_editor.py
+++ b/traitsui/tests/editors/test_video_editor.py
@@ -18,7 +18,7 @@ import pkg_resources
 from traits.api import Bool, Callable, File, Float, HasTraits, Range, Str
 from traitsui.api import ContextValue, Item, View
 from traitsui.editors.video_editor import MediaStatus, PlayerState, VideoEditor
-from traitsui.tests._tools import BaseTestMixin, create_ui
+from traitsui.tests._tools import BaseTestMixin, create_ui, is_qt5, is_qt6
 
 filename = pkg_resources.resource_filename('traitsui.testing', 'data/test.mp4')
 
@@ -38,6 +38,7 @@ class MovieTheater(HasTraits):
     image_func = Callable()
 
 
+@unittest.skipIf(not is_qt5() and not is_qt6(), 'Requires Qt5 or 6')
 class TestVideoEditor(BaseTestMixin, unittest.TestCase):
     def setUp(self):
         BaseTestMixin.setUp(self)

--- a/traitsui/tests/editors/test_video_editor.py
+++ b/traitsui/tests/editors/test_video_editor.py
@@ -18,7 +18,7 @@ import pkg_resources
 from traits.api import Bool, Callable, File, Float, HasTraits, Range, Str
 from traitsui.api import ContextValue, Item, View
 from traitsui.editors.video_editor import MediaStatus, PlayerState, VideoEditor
-from traitsui.tests._tools import BaseTestMixin, create_ui, is_qt5
+from traitsui.tests._tools import BaseTestMixin, create_ui
 
 filename = pkg_resources.resource_filename('traitsui.testing', 'data/test.mp4')
 
@@ -38,7 +38,6 @@ class MovieTheater(HasTraits):
     image_func = Callable()
 
 
-@unittest.skipIf(not is_qt5(), 'Requires Qt5')
 class TestVideoEditor(BaseTestMixin, unittest.TestCase):
     def setUp(self):
         BaseTestMixin.setUp(self)


### PR DESCRIPTION
Get basic `VideoEditor` functionality up and working for Qt6.  There have been considerable changes to the way that QtMultimedia works.

Can't (yet) handle editing the video frames along the way, but it is technically feasible: the problem is that the mechanism is completely different in Qt6 and still needs some investigation.

Fixes #1905.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)