### PR TITLE
Properly dispose of any header view for the ListStrEditor.

### DIFF
--- a/traitsui/qt4/list_str_editor.py
+++ b/traitsui/qt4/list_str_editor.py
@@ -200,6 +200,7 @@ class _ListStrEditor(Editor):
         )
         if self._header_view is not None:
             self._header_view.setModel(None)
+            self._header_view.deleteLater()
             self._header_view = None
 
         self.list_view._dispose()


### PR DESCRIPTION
Fixes #1888.  This only manifested as incomplete clean-up in test suites on an internal Enthought project - no errors were generated even without the fix.

**Checklist**
- [ ] ~Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)~