### PR TITLE
Hide controls after `deleteLater` is called, not before

### DIFF
--- a/traitsui/qt4/toolkit.py
+++ b/traitsui/qt4/toolkit.py
@@ -382,8 +382,8 @@ class GUIToolkit(Toolkit):
 
         # This may be called from within the finished() signal handler so we
         # need to do the delete after the handler has returned.
-        control.hide()
         control.deleteLater()
+        control.hide()
 
     def destroy_children(self, control):
         """Destroys all of the child controls of a specified GUI toolkit


### PR DESCRIPTION
This is an experiment to see if it fixes some issues observed with `ModalDialogTester` and PySide6

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)