### PR TITLE
Fixes for NewAction in the TreeEditor to remove shared state

### DIFF
--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -948,7 +948,7 @@ class SimpleEditor(Editor):
             editor.setUpdatesEnabled(True)
 
     def _on_context_menu(self, pos):
-        """Handles the user requesting a context menuright clicking on a tree node."""
+        """Handles the user requesting a context menu on a tree node."""
         nid = self._tree.itemAt(pos)
 
         if nid is None:
@@ -986,8 +986,9 @@ class SimpleEditor(Editor):
             # Use the menu specified by the node:
             group = menu.find_group(NewAction)
             if group is not None:
-                # Only set it the first time:
-                group.id = ""
+                # Reset the group for the current usage in case it is shared
+                # - the call to `node.get_add()` is potentially dynamic
+                group.clear()
                 actions = self._new_actions(node, object)
                 if len(actions) > 0:
                     group.insert(0, Menu(name="New", *actions))

--- a/traitsui/wx/tree_editor.py
+++ b/traitsui/wx/tree_editor.py
@@ -1138,8 +1138,11 @@ class SimpleEditor(Editor):
                 # Use the menu specified by the node:
                 group = menu.find_group(NewAction)
                 if group is not None:
-                    # Only set it the first time:
-                    group.id = ""
+                    # Reset the group for the current usage in case it is
+                    # shared - the call to `node.get_add()` is potentially
+                    # dynamic and the callback `_menu_new_node()` captures
+                    # state about this particular TreeEditor instance
+                    group.clear()
                     actions = self._new_actions(node, object)
                     if len(actions) > 0:
                         group.insert(0, Menu(name="New", *actions))


### PR DESCRIPTION
Fixes #1948 

Unfortunately I'm unsure how to create a regression test for this right now; the underlying code is not factored particularly well, so I'll open a ticket for that.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)