### PR TITLE
Fix rendering of dragged tree nodes on Qt6

### DIFF
--- a/docs/releases/upcoming/1960.bugfix.rst
+++ b/docs/releases/upcoming/1960.bugfix.rst
@@ -1,0 +1,1 @@
+Fix rendering of dragged tree nodes on Qt6 (#1960)

--- a/traitsui/qt4/tree_editor.py
+++ b/traitsui/qt4/tree_editor.py
@@ -30,7 +30,7 @@ from functools import partial
 from itertools import zip_longest
 import logging
 
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtCore, QtGui, is_qt5
 
 from pyface.api import ImageResource
 from pyface.ui_traits import convert_image
@@ -1551,7 +1551,11 @@ class _TreeWidget(QtGui.QTreeWidget):
         pm.fill(self.palette().base().color())
         painter = QtGui.QPainter(pm)
 
-        option = self.viewOptions()
+        if is_qt5:
+            option = self.viewOptions()
+        else:
+            option = QtGui.QStyleOptionViewItem()
+            self.initViewItemOption(option)
         option.state |= QtGui.QStyle.StateFlag.State_Selected
         option.rect = QtCore.QRect(
             nid_rect.topLeft() - rect.topLeft(), nid_rect.size()


### PR DESCRIPTION
This replaces `QAbstractTreeView.viewOptions()` with `initViewItemOption()`, and this seems to be a drop-in replacement.

I can't see how to test this fix in CI.

Fixes #1959

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)