### PR TITLE
Add explicit `allow_none` in Datetime traits.

### DIFF
--- a/docs/releases/upcoming/1964.bugfix.rst
+++ b/docs/releases/upcoming/1964.bugfix.rst
@@ -1,0 +1,1 @@
+Add explicit allow_none in Datetime traits (#1964)

--- a/traitsui/editors/datetime_editor.py
+++ b/traitsui/editors/datetime_editor.py
@@ -26,10 +26,10 @@ class DatetimeEditor(EditorFactory):
     # -------------------------------------------------------------------------
 
     #: The earliest datetime allowed by the editor
-    minimum_datetime = Datetime(datetime.datetime(100, 1, 1))
+    minimum_datetime = Datetime(datetime.datetime(100, 1, 1), allow_none=True)
 
     #: The latest datetime allowed by the editor
-    maximum_datetime = Datetime(datetime.datetime.max)
+    maximum_datetime = Datetime(datetime.datetime.max, allow_none=True)
 
     # -- ReadonlyEditor traits ------------------------------------------------
 

--- a/traitsui/examples/demo/Standard_Editors/DatetimeEditor_demo.py
+++ b/traitsui/examples/demo/Standard_Editors/DatetimeEditor_demo.py
@@ -34,7 +34,7 @@ from traitsui.api import View, Item, Group
 class DateEditorDemo(HasTraits):
     """Demo class to show Datetime editors."""
 
-    datetime = Datetime()
+    datetime = Datetime(allow_none=True)
     info_string = Str('The editors for Traits Datetime objects.')
 
     traits_view = View(

--- a/traitsui/qt4/datetime_editor.py
+++ b/traitsui/qt4/datetime_editor.py
@@ -24,10 +24,10 @@ class SimpleEditor(Editor):
     """Simple Traits UI time editor that wraps QDateTimeEdit."""
 
     #: the earliest datetime allowed by the editor
-    minimum_datetime = Datetime
+    minimum_datetime = Datetime(allow_none=True)
 
     #: the latest datetime allowed by the editor
-    maximum_datetime = Datetime
+    maximum_datetime = Datetime(allow_none=True)
 
     def init(self, parent):
         """Finishes initializing the editor by creating the underlying toolkit

--- a/traitsui/tests/editors/test_datetime_editor.py
+++ b/traitsui/tests/editors/test_datetime_editor.py
@@ -29,7 +29,7 @@ from traitsui.tests._tools import (
 class InstanceWithDatetime(HasTraits):
     """Demo class to show Datetime editors."""
 
-    date_time = Datetime()
+    date_time = Datetime(allow_none=True)
 
 
 def to_datetime(q_datetime):

--- a/traitsui/tests/test_datetime.py
+++ b/traitsui/tests/test_datetime.py
@@ -37,7 +37,7 @@ DATE = MAX_DATE - timedelta(days=5)
 
 class DatetimeInitDailog(HasTraits):
 
-    date = Datetime()
+    date = Datetime(allow_none=True)
 
     def _date_default(self):
         return DATE


### PR DESCRIPTION
Add `allow_none` to `Datetime` bounds in `DatetimeEditor` and to other uses of `Datetime` in tests and examples.

This fixes a deprecation warning with recent traits.

Fixes #1963.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)