### PR TITLE
Display the selected date in the DateEditor in custom style.

### DIFF
--- a/docs/releases/upcoming/1967.bugfix.rst
+++ b/docs/releases/upcoming/1967.bugfix.rst
@@ -1,0 +1,1 @@
+Display the selected date in the DateEditor in custom style (#1967)

--- a/traitsui/qt4/date_editor.py
+++ b/traitsui/qt4/date_editor.py
@@ -107,6 +107,12 @@ class CustomEditor(Editor):
 
         self.control.clicked.connect(self.update_object)
 
+        if not self.factory.multi_select:
+            self.control.showSelectedDate()
+        elif self._selected:
+            first_date = min(self._selected)
+            self.control.setCurrentPage(first_date.year, first_date.month)
+
     def dispose(self):
         """Disposes of the contents of an editor."""
         if self.control is not None:
@@ -122,6 +128,7 @@ class CustomEditor(Editor):
             if not self.factory.multi_select:
                 q_date = QtCore.QDate(value.year, value.month, value.day)
                 self.control.setSelectedDate(q_date)
+                self.control.showSelectedDate()
             else:
                 self.apply_unselected_style_to_all()
                 for date in value:


### PR DESCRIPTION
This change:

- shows the calendar page with the current value when started
- if multi-select is true, it shows the page with the earliest date
- when the date changes externally in single-select mode it also updates

This fixes #1942

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)