### PR TITLE
Add CI for EDM Python 3.8

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -22,9 +22,13 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
         toolkit: ['pyqt5', 'pyside2', 'pyside6']
+        python-version: ['3.6']
         include:
           - os: ubuntu-latest
             toolkit: 'null'
+          - os: ubuntu-20.04
+            toolkit: 'pyside6'
+            python-version: '3.8'
         exclude:
           - os: windows-latest
             toolkit: pyside6
@@ -44,7 +48,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
         uses: enthought/setup-edm-action@v1
         with:
@@ -52,8 +56,8 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }}
+        run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.python-version }}
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
+          run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.python-version }}


### PR DESCRIPTION
Turn on CI for EDM Python 3.8 with PySide6.

Initially start with Linux, as that is the most urgent.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)