### PR TITLE
Protect against deleted nodes in Qt `TreeEditor`

### DIFF
--- a/docs/releases/upcoming/1973.bugfix.rst
+++ b/docs/releases/upcoming/1973.bugfix.rst
@@ -1,0 +1,1 @@
+Guard Qt TreeEditor against destroyed QTreeViewItems (#1973)

--- a/traitsui/qt4/helper.py
+++ b/traitsui/qt4/helper.py
@@ -27,7 +27,7 @@
 import os.path
 
 from pyface.api import SystemMetrics
-from pyface.qt import QtCore, QtGui, is_qt5, is_pyqt
+from pyface.qt import QtCore, QtGui, is_qt5, is_pyqt, qt_api
 from pyface.ui_traits import convert_image
 from traits.api import Enum, CTrait, BaseTraitHandler, TraitError
 
@@ -259,3 +259,34 @@ def wrap_text_with_elision(text, font, width, height):
         )
 
     return lines
+
+
+# ------------------------------------------------------------------------
+# Object lifetime helpers
+# ------------------------------------------------------------------------
+
+def qobject_is_valid(qobject):
+    """Return whether the wrapped Qt object is still valid.
+
+    Parameters
+    ----------
+    qobject : QObject instance
+        The wrapped Qt QObject to inspect.
+
+    Returns
+    -------
+    valid : bool
+        Whether or not the underlying C++ object still exists.
+    """
+    if is_pyqt:
+        from sip import isdeleted
+        return not isdeleted(qobject)
+    elif qt_api == 'pyside2':
+        from shiboken2 import isValid
+        return isValid(qobject)
+    elif qt_api == 'pyside6':
+        from shiboken6 import isValid
+        return isValid(qobject)
+    else:
+        # unknown wrapper
+        raise RuntimeError("Unknown Qt API {qt_api}")

--- a/traitsui/qt4/tests/test_helper.py
+++ b/traitsui/qt4/tests/test_helper.py
@@ -128,7 +128,7 @@ class TestWrapText(unittest.TestCase):
 
     @unittest.skipIf(
         is_mac_os and qt_api == "pyside6",
-        "causes next test to segfault on Mac OS/PySide6",
+        "causes next test to segfault on Mac OS/PySide6 (see #1974)",
     )
     def test_qobject_is_valid(self):
         qobject = QtCore.QObject()

--- a/traitsui/qt4/tests/test_helper.py
+++ b/traitsui/qt4/tests/test_helper.py
@@ -11,9 +11,9 @@
 import textwrap
 import unittest
 
-from pyface.qt import QtGui
+from pyface.qt import is_pyqt, qt_api, QtCore, QtGui
 from traitsui.tests._tools import requires_toolkit, ToolkitName
-from traitsui.qt4.helper import wrap_text_with_elision
+from traitsui.qt4.helper import qobject_is_valid, wrap_text_with_elision
 from traitsui.qt4.font_trait import create_traitsfont
 
 
@@ -124,3 +124,26 @@ class TestWrapText(unittest.TestCase):
 
         expected_lines = get_expected_lines(lorem_ipsum, 500)[:3]
         self.assertEqual(lines, expected_lines)
+
+    def test_qobject_is_valid(self):
+        qobject = QtCore.QObject()
+
+        if is_pyqt:
+            from sip import delete
+        elif qt_api == "pyside2":
+            from shiboken2 import delete
+        elif qt_api == "pyside6":
+            from shiboken6 import delete
+        else:
+            with self.assertRaises(RuntimeError):
+                qobject_is_valid(qobject)
+            return
+
+        result = qobject_is_valid(qobject)
+
+        self.assertTrue(result)
+
+        delete(qobject)
+        result = qobject_is_valid(qobject)
+
+        self.assertFalse(result)

--- a/traitsui/qt4/tests/test_helper.py
+++ b/traitsui/qt4/tests/test_helper.py
@@ -12,7 +12,7 @@ import textwrap
 import unittest
 
 from pyface.qt import is_pyqt, qt_api, QtCore, QtGui
-from traitsui.tests._tools import requires_toolkit, ToolkitName
+from traitsui.tests._tools import is_mac_os, requires_toolkit, ToolkitName
 from traitsui.qt4.helper import qobject_is_valid, wrap_text_with_elision
 from traitsui.qt4.font_trait import create_traitsfont
 
@@ -42,6 +42,7 @@ def get_expected_lines(text, width):
 
 @requires_toolkit([ToolkitName.qt])
 class TestWrapText(unittest.TestCase):
+
     def test_wrap_text_basic(self):
         font = create_traitsfont("Courier")
         font_metrics = QtGui.QFontMetrics(font)
@@ -125,6 +126,10 @@ class TestWrapText(unittest.TestCase):
         expected_lines = get_expected_lines(lorem_ipsum, 500)[:3]
         self.assertEqual(lines, expected_lines)
 
+    @unittest.skipIf(
+        is_mac_os and qt_api == "pyside6",
+        "causes next test to segfault on Mac OS/PySide6",
+    )
     def test_qobject_is_valid(self):
         qobject = QtCore.QObject()
 


### PR DESCRIPTION
This change makes checks that the underlying Qt `QTreeViewItem` exists before attempting to access any data stored on it.  This hopefully resolves some issues observed in PySide6 which I suspect were caused by a change in API from returning `AttrbuteError` to `RuntimeError` when accessing that data.

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)