### PR TITLE
FIX: Replace unnecessary eval() calls with literal_eval()

### DIFF
--- a/traitsui/qt4/check_list_editor.py
+++ b/traitsui/qt4/check_list_editor.py
@@ -26,6 +26,7 @@ user interface toolkit.
 
 
 import logging
+from ast import literal_eval
 
 from pyface.qt import QtCore, QtGui, is_pyside
 
@@ -266,7 +267,7 @@ class TextEditor(BaseTextEditor):
         """Handles the user changing the contents of the edit control."""
         try:
             value = str(self.control.text())
-            value = eval(value)
+            value = literal_eval(value)
         except:
             pass
         try:

--- a/traitsui/qt4/extra/bounds_editor.py
+++ b/traitsui/qt4/extra/bounds_editor.py
@@ -8,6 +8,8 @@
 #
 # Thanks for using Enthought open source!
 
+from ast import literal_eval
+
 from pyface.qt import QtGui, QtCore
 
 from traits.api import Float, Any, Str, Union
@@ -90,7 +92,7 @@ class _BoundsEditor(Editor):
     def update_low_on_enter(self):
         try:
             try:
-                low = eval(str(self._label_lo.text()).strip())
+                low = literal_eval(str(self._label_lo.text()).strip())
                 if self.evaluate is not None:
                     low = self.evaluate(low)
             except Exception as ex:
@@ -112,7 +114,7 @@ class _BoundsEditor(Editor):
     def update_high_on_enter(self):
         try:
             try:
-                high = eval(str(self._label_hi.text()).strip())
+                high = literal_eval(str(self._label_hi.text()).strip())
                 if self.evaluate is not None:
                     high = self.evaluate(high)
             except:

--- a/traitsui/qt4/range_editor.py
+++ b/traitsui/qt4/range_editor.py
@@ -25,6 +25,7 @@ PyQt user interface toolkit.
 """
 
 
+from ast import literal_eval
 from math import log10
 
 from pyface.qt import QtCore, QtGui
@@ -187,7 +188,7 @@ class SimpleSliderEditor(BaseRangeEditor):
             return
 
         try:
-            value = eval(str(self.control.text.text()).strip())
+            value = literal_eval(str(self.control.text.text()).strip())
         except Exception as ex:
             # They entered something that didn't eval as a number, (e.g.,
             # 'foo') pretend it didn't happen
@@ -460,7 +461,7 @@ class LargeRangeSliderEditor(BaseRangeEditor):
         if self.control is None:
             return
         try:
-            self.value = eval(str(self.control.text.text()).strip())
+            self.value = literal_eval(str(self.control.text.text()).strip())
         except TraitError as excp:
             pass
 
@@ -727,7 +728,7 @@ class RangeTextEditor(TextEditor):
     def update_object(self):
         """Handles the user entering input data in the edit control."""
         try:
-            value = eval(str(self.control.text()))
+            value = literal_eval(str(self.control.text()))
             if self.evaluate is not None:
                 value = self.evaluate(value)
 

--- a/traitsui/wx/check_list_editor.py
+++ b/traitsui/wx/check_list_editor.py
@@ -14,6 +14,7 @@ wxPython user interface toolkit.
 
 
 import logging
+from ast import literal_eval
 
 import wx
 
@@ -240,7 +241,7 @@ class TextEditor(BaseTextEditor):
         """Handles the user changing the contents of the edit control."""
         try:
             value = self.control.GetValue()
-            value = eval(value)
+            value = literal_eval(value)
         except:
             pass
         try:

--- a/traitsui/wx/extra/bounds_editor.py
+++ b/traitsui/wx/extra/bounds_editor.py
@@ -8,6 +8,8 @@
 #
 # Thanks for using Enthought open source!
 
+from ast import literal_eval
+
 import wx
 
 from traits.api import Float, Any, Str, Union
@@ -131,7 +133,7 @@ class _BoundsEditor(Editor):
             event.Skip()
         try:
             try:
-                low = eval(str(self._label_lo.GetValue()).strip())
+                low = literal_eval(str(self._label_lo.GetValue()).strip())
                 if self.evaluate is not None:
                     low = self.evaluate(low)
             except Exception as ex:
@@ -155,7 +157,7 @@ class _BoundsEditor(Editor):
             event.Skip()
         try:
             try:
-                high = eval(str(self._label_hi.GetValue()).strip())
+                high = literal_eval(str(self._label_hi.GetValue()).strip())
                 if self.evaluate is not None:
                     high = self.evaluate(high)
             except:


### PR DESCRIPTION
Drive-by while looking into `RangeEditor` strangeness.