### PR TITLE
Update copyright notice in 2023 for non-python files.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 This software is OSI Certified Open Source Software.
 OSI Certified is a certification mark of the Open Source Initiative.
 
-Copyright (c) 2004-2022, Enthought, Inc.
+Copyright (c) 2004-2023, Enthought, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/source/traitsui_user_manual/index.rst
+++ b/docs/source/traitsui_user_manual/index.rst
@@ -8,7 +8,7 @@ TraitsUI |version| User Manual
 
 :Authors: Lyn Pierce, Janet Swisher, and Enthought Developers
 :Version: Document Version 4
-:Copyright: 2005-2022 Enthought, Inc. All Rights Reserved.
+:Copyright: 2005-2023 Enthought, Inc. All Rights Reserved.
 
 Contents
 ========

--- a/ets-demo/LICENSE.txt
+++ b/ets-demo/LICENSE.txt
@@ -1,7 +1,7 @@
 This software is OSI Certified Open Source Software.
 OSI Certified is a certification mark of the Open Source Initiative.
 
-(C) Copyright 2004-2022 Enthought, Inc., Austin, TX
+(C) Copyright 2004-2023 Enthought, Inc., Austin, TX
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Missed a few copyright updates because I was filtering for Python files only.