### PR TITLE
Replace some relative imports in tests

### DIFF
--- a/traitsui/tests/test_key_bindings.py
+++ b/traitsui/tests/test_key_bindings.py
@@ -14,7 +14,7 @@ from unittest.mock import Mock
 from traits.testing.api import UnittestTools
 
 
-from ..key_bindings import KeyBinding, KeyBindings, KeyBindingsHandler
+from traitsui.key_bindings import KeyBinding, KeyBindings, KeyBindingsHandler
 
 
 class Controller1:

--- a/traitsui/tests/test_view_application.py
+++ b/traitsui/tests/test_view_application.py
@@ -14,7 +14,7 @@ from pyface.timer.api import CallbackTimer
 from traits.api import HasTraits, Instance, Int
 from traitsui.api import Handler, Item, UIInfo, View, toolkit
 
-from ._tools import (
+from traitsui.tests._tools import (
     BaseTestMixin,
     GuiTestAssistant,
     is_qt,


### PR DESCRIPTION
I was getting some errors in the tests about relative imports.