### PR TITLE
Fix regression in wx version of FileEditor

### DIFF
--- a/traitsui/wx/directory_editor.py
+++ b/traitsui/wx/directory_editor.py
@@ -37,7 +37,7 @@ class SimpleEditor(SimpleFileEditor):
         """Creates the correct type of file dialog."""
         dlg = DirectoryDialog(
             parent=self.get_control_widget(),
-            default_path=self._file_name.text(),
+            default_path=self._file_name.GetValue(),
         )
         return dlg
 

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -206,7 +206,7 @@ class SimpleEditor(SimpleTextEditor):
 
         dlg = FileDialog(
             parent=self.get_control_widget(),
-            default_path=self._file_name.text(),
+            default_path=self._file_name.GetValue(),
             action="save" if self.factory.dialog_style == "save as" else "open",
             wildcard=wildcard,
         )


### PR DESCRIPTION
File (and directory editors) are broken in current head (and the last couple of releases). See traceback below.

```
Traceback (most recent call last):
  File "/Users/david/dev/traitsui/traitsui/wx/file_editor.py", line 147, in show_file_dialog
    dlg = self._create_file_dialog()
  File "/Users/david/dev/traitsui/traitsui/wx/file_editor.py", line 209, in _create_file_dialog
    default_path=self._file_name.text(),
AttributeError: 'TextCtrl' object has no attribute 'text'
```

This looks like it can be traced to #1829, which seems to have copy-pasted the `FileDialog` creation code verbatim from the QT version into the wx version. Replacing the `.text()` call with the wx equivalent `.GetValue()` seems to fix things. Thought I'd submit a PR directly seeing as I had a simple fix, but happy to create an issue instead/as well if desired.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)