### PR TITLE
Fix WX directory editor

### DIFF
--- a/traitsui/wx/directory_editor.py
+++ b/traitsui/wx/directory_editor.py
@@ -37,7 +37,7 @@ class SimpleEditor(SimpleFileEditor):
         """Creates the correct type of file dialog."""
         dlg = DirectoryDialog(
             parent=self.get_control_widget(),
-            default_path=self._file_name.text(),
+            default_path=self._file_name.GetValue(),
         )
         return dlg
 


### PR DESCRIPTION
Small fix for the WX directory editor: Replace `self._file_name.text()` by `self._file_name.GetValue()`.

The previous code caused an exception
```
Traceback (most recent call last):
  File "<...>\traitsui\traitsui\wx\file_editor.py", line 147, in show_file_dialog
    dlg = self._create_file_dialog()
  File "<...>\traitsui\traitsui\wx\directory_editor.py", line 40, in _create_file_dialog
    default_path=self._file_name.text(),
AttributeError: 'TextCtrl' object has no attribute 'text'
```

Reproducing code:
```python
from traits.etsconfig.api import ETSConfig
ETSConfig.toolkit = 'wx'

from traits.api import Directory, HasTraits
from traitsui.api import View, Item


class Test(HasTraits):
    directory = Directory()

test_view = View(
    Item('directory')
)

test = Test()
test.configure_traits(view=test_view)
```