### PR TITLE
Remove `merge_undo` from undo code.

### DIFF
--- a/traitsui/tests/test_undo.py
+++ b/traitsui/tests/test_undo.py
@@ -61,20 +61,6 @@ class LegacyUndoItem(AbstractUndoItem):
         pass
 
 
-class TestAbstractUndoItem(UnittestTools, unittest.TestCase):
-    def test_merge_undo_deprecated(self):
-        undo_item = LegacyUndoItem()
-        other_item = LegacyUndoItem()
-
-        with catch_warnings(record=True) as w:
-            result = undo_item.merge(other_item)
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-            self.assertIn("merge_undo", str(w[0].message))
-
-        self.assertFalse(result)
-
-
 class TestUndoItem(UnittestTools, unittest.TestCase):
     def test_undo(self):
         example = SimpleExample(value=11)

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -72,20 +72,6 @@ class AbstractUndoItem(AbstractCommand):
 
     def merge(self, other):
         """Merges two undo items if possible."""
-        import warnings
-
-        warnings.warn(
-            "'merge_undo' is deprecated and will be removed in TraitsUI 8, "
-            "use 'merge' instead",
-            DeprecationWarning,
-        )
-        return self.merge_undo(other)
-
-    def merge_undo(self, undo_item):
-        """Merges two undo items if possible.
-
-        This method is deprecated.
-        """
         return False
 
 
@@ -209,13 +195,6 @@ class UndoItem(AbstractUndoItem):
                     return True
         return False
 
-    def merge_undo(self, undo_item):
-        """Merges two undo items if possible.
-
-        This is deprecated.
-        """
-        return self.merge(undo_item)
-
     def __repr__(self):
         """Returns a "pretty print" form of the object."""
         n = self.name
@@ -298,13 +277,6 @@ class ListUndoItem(AbstractUndoItem):
                     else:
                         return True
         return False
-
-    def merge_undo(self, undo_item):
-        """Merges two undo items if possible.
-
-        This is deprecated.
-        """
-        return self.merge(undo_item)
 
     def __repr__(self):
         """Returns a 'pretty print' form of the object."""

--- a/traitsui/undo.py
+++ b/traitsui/undo.py
@@ -336,12 +336,6 @@ class UndoHistory(HasStrictTraits):
     #: The command stack for the history.
     stack = Instance(ICommandStack, allow_none=False)
 
-    #: List of accumulated undo changes.  Each item is a list of
-    #: AbstractUndoItems that should be done or undone as a group.
-    #: This trait should be considered private.
-    #: This trait is no longer used.
-    history = List()
-
     #: The current position in the list
     now = Property(Int, observe='stack._index')
 


### PR DESCRIPTION
Fixes #1515.  Also removes a no-longer used `history` trait.

This completes the transition of TraitsUI undo/redo to share the same basis as the Pyface/Apptools undo/redo.

There is still an issue in #1060 that is unresolved which is about refactoring TraitsUI to be more command-stack based, rather than building the command stack reactively.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)