### PR TITLE
Fix logic for selecting action in file dialog

### DIFF
--- a/traitsui/qt/file_editor.py
+++ b/traitsui/qt/file_editor.py
@@ -138,7 +138,7 @@ class SimpleEditor(SimpleTextEditor):
         dlg = FileDialog(
             parent=self.get_control_widget(),
             default_path=self._file_name.text(),
-            action="save" if self.factory.dialog_style == "save as" else "open",
+            action="save as" if self.factory.dialog_style == "save" else "open",
             wildcard=wildcard,
         )
         return dlg

--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -207,7 +207,7 @@ class SimpleEditor(SimpleTextEditor):
         dlg = FileDialog(
             parent=self.get_control_widget(),
             default_path=self._file_name.GetValue(),
-            action="save" if self.factory.dialog_style == "save as" else "open",
+            action="save as" if self.factory.dialog_style == "save" else "open",
             wildcard=wildcard,
         )
         return dlg


### PR DESCRIPTION
The `FileDialog.action` can have values `open`, `open files`, or `save as`, see https://github.com/enthought/pyface/blob/a9bf0264cb2afe9d05ce8856de650fd6efbc2684/pyface/ui/wx/file_dialog.py#L37 and https://github.com/enthought/pyface/blob/a9bf0264cb2afe9d05ce8856de650fd6efbc2684/pyface/ui/qt/file_dialog.py#L36.

The `dialog_style` on the other hand can have values `open` and `save`, see https://github.com/enthought/traitsui/blob/c08f891c19e5464e308cb9c6c14e77599e11b132/traitsui/editors/file_editor.py#L77-L78

As such, the logic for converting from `dialog_style` to `action` was the wrong way around. As a result,
the file dialog would always open in "open" mode.