### PR TITLE
Fix resetting of the error state for FileEditor

### DIFF
--- a/traitsui/wx/file_editor.py
+++ b/traitsui/wx/file_editor.py
@@ -138,6 +138,7 @@ class SimpleEditor(SimpleTextEditor):
             self._no_update = False
         else:
             self._file_name.SetValue(self.str_value)
+        self._reset_error()
 
     def show_file_dialog(self, event=None):
         """Displays the pop-up file dialog."""
@@ -157,6 +158,13 @@ class SimpleEditor(SimpleTextEditor):
     def get_error_control(self):
         """Returns the editor's control for indicating error status."""
         return self._file_name
+
+    def _reset_error(self):
+        """Resets the error state of the editor."""
+        if self._error is not None:
+            self._error = None
+            self.ui.errors -= 1
+            self.set_error_state(False)
 
     # -- Traits Event Handlers ------------------------------------------------
 
@@ -228,6 +236,7 @@ class SimpleEditor(SimpleTextEditor):
                 file_name = splitext(file_name)[0]
 
             self.value = file_name
+            self._reset_error()
         except TraitError as excp:
             pass
 


### PR DESCRIPTION
Reset the 'error' state of the file editor when its value changes. Previously, the state would remain
as error, which means the value cannot be set.

Created as draft because this only implements it for `wx`, whereas `qt` has the same issue.

The code block of the `_reset_error` function
```python
if self._error is not None:
    self._error = None
    self.ui.errors -= 1 
    self.set_error_state(False)
```
is then present in four places: `text_editor` and `file_editor` for both `qt` and `wx`. Since I'm not really familiar with the overall architecture of the code: What's the best place to put this? Or should I keep it separate?
