### PR TITLE
Replace 'fast_ui' dispatch with 'ui' dispatch

### DIFF
--- a/traitsui/tree_node.py
+++ b/traitsui/tree_node.py
@@ -250,7 +250,7 @@ class TreeNode(HasPrivateTraits):
         specified object.
         """
         object.on_trait_change(
-            listener, self.children, remove=remove, dispatch="fast_ui"
+            listener, self.children, remove=remove, dispatch="ui"
         )
 
     def when_children_changed(self, object, listener, remove):
@@ -261,7 +261,7 @@ class TreeNode(HasPrivateTraits):
             listener,
             self.children + "_items",
             remove=remove,
-            dispatch="fast_ui",
+            dispatch="ui",
         )
 
     def get_label(self, object):
@@ -1356,7 +1356,7 @@ class TreeNodeObject(HasPrivateTraits):
         specified object.
         """
         self.on_trait_change(
-            listener, node.children, remove=remove, dispatch="fast_ui"
+            listener, node.children, remove=remove, dispatch="ui"
         )
 
     def tno_when_children_changed(self, node, listener, remove):
@@ -1367,7 +1367,7 @@ class TreeNodeObject(HasPrivateTraits):
             listener,
             node.children + "_items",
             remove=remove,
-            dispatch="fast_ui",
+            dispatch="ui",
         )
 
     def tno_get_label(self, node):


### PR DESCRIPTION
The `'fast_ui'` dispatch mechanism is identical to the `'ui'` dispatch mechanism. It's not used by the `fast_ui` name anywhere in ETS outside the the TraitsUI `TreeNode` implementation.

This PR replaces use of `fast_ui` with `ui`; this should allow us to deprecated and remove the `fast_ui` dispatch method in Traits at some point in the future.