### PR TITLE
MAINT: add note for wx only use for scrubber finder

### DIFF
--- a/traitsui/examples/demo/Advanced/Scrubber_editor_demo.py
+++ b/traitsui/examples/demo/Advanced/Scrubber_editor_demo.py
@@ -98,6 +98,10 @@ In this example, several of the variations described above are shown:
 
 For comparison purposes, the example also shows the same traits displayed using
 their default editors.
+
+Notes:
+
+- This demo only works on the wx backend.
 """
 
 # -- Imports --------------------------------------------------------------


### PR DESCRIPTION
As mentioned in issue #2010, a NotImplementedError: the qt traitsui.qt backend doesn't implement scrubber_editor:_ScrubberEditor will be raised when running this example without wx. Viewing the code (https://github.com/enthought/traitsui/blob/main/traitsui/wx/scrubber_editor.py ) suggests that ScrubberEditor is only implemented for wx version of the code  However, this is not explicitly mentioned in the demo. This PR add lines to mention this explicitly. closes #2010 

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst) (Not really...)