### PR TITLE
[WIP] MAINT: add ui popup solution for qt

### DIFF
--- a/traitsui/qt/toolkit.py
+++ b/traitsui/qt/toolkit.py
@@ -167,6 +167,14 @@ class GUIToolkit(Toolkit):
 
         ui_live.ui_live(ui, parent)
 
+    def ui_popup(self, ui, parent):
+        """Creates a GUI-toolkit-specific temporary "live update" popup dialog
+        user interface using information from the specified UI object.
+        """
+        from . import ui_live
+
+        ui_live.ui_popup(ui, parent)
+
     def ui_modal(self, ui, parent):
         """Creates a PyQt modal dialog user interface using information
         from the specified UI object.

--- a/traitsui/qt/ui_live.py
+++ b/traitsui/qt/ui_live.py
@@ -236,6 +236,10 @@ class _LiveWindow(BaseDialog):
 
         self.undo = self.redo = self.revert = None
 
+    def close_popup(self, rc=True):
+        """Close the popup window and set the given return code."""
+        super().close(rc)
+
     def _on_finished(self, result):
         """Handles the user finishing with the dialog."""
         accept = bool(result)


### PR DESCRIPTION
Previously, traitsui/examples/demo/Advanced/Popup_Dialog_demo.py can only function with the wx toolkit. When a qt toolkit is used, button popup window can show successfully:

<img width="184" alt="Screen Shot 2023-04-26 at 2 59 03 PM" src="https://user-images.githubusercontent.com/102019577/234482768-506a4fd3-3a7e-4eb6-8d81-a94ce72cc860.png">

However, if we change Gender from "Male" to "Female", the ui will crash as mentioned in issue #2013 
Thus we come up a potential solution. Currently, the qt users can change the Gender and close the popup window by clicking the "x" on top of the window

<img width="216" alt="Screen Shot 2023-04-26 at 3 26 01 PM" src="https://user-images.githubusercontent.com/102019577/234487775-afcb86c4-48f8-4b5b-918e-c5756e19020a.png">

However, the cancel button in the pop up window is still not functioning properly (it will generate another popup other than closing the current popup). Closes #2013 

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)