### PR TITLE
Fix date range editor tests: allow `None` for test traits.

### DIFF
--- a/traitsui/tests/editors/test_date_range_editor.py
+++ b/traitsui/tests/editors/test_date_range_editor.py
@@ -30,7 +30,7 @@ from traitsui.tests._tools import (
 
 class Foo(HasTraits):
 
-    date_range = Tuple(Date, Date)
+    date_range = Tuple(Date(allow_none=True), Date(allow_none=True))
 
 
 def default_custom_view():


### PR DESCRIPTION
This adds `allow_none=True` to the traits on the model used for the test case.

Fixes #2018 