### PR TITLE
MAINT:add comment to explain the example as wx only

### DIFF
--- a/examples/tutorials/traitsui_4.0/editors/animated_gif.py
+++ b/examples/tutorials/traitsui_4.0/editors/animated_gif.py
@@ -17,6 +17,10 @@ playing
 The value associated with **AnimatedGIFEditor** should be the name of the
 animated GIF image file to be displayed. No user editing of the value is
 provided by this editor, it is display only.
+
+Notes:
+
+- This demo only works on the wx backend.
 """
 
 # --[Imports]--------------------------------------------------------------


### PR DESCRIPTION
The traitsui/examples/tutorials/traitsui_4.0/editors/animated_gif.py will generate a RuntimeError: Importing from wx backend after selecting qt backend!. The cause of this error comes from assert_toolkit_import(["wx"]) in traitsui/traitsui/toolkit.py. Althought removing this line can suppress this problem, this demo is supposed to be wx only, thus I push this PR to add the message. closes #2016 

**Checklist**
- [x] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst) (Not really, just a reminder of backend usage)