### PR TITLE
Fix a typo in a warning message

### DIFF
--- a/traitsui/__init__.py
+++ b/traitsui/__init__.py
@@ -19,7 +19,7 @@ def __getattr__(name):
 
         warn(
             f"traitsui.{name} is deprecated, "
-            f"use impportlib.metadata.version('traitsui') ",
+            f"use importlib.metadata.version('traitsui') ",
             DeprecationWarning,
         )
         return version('traitsui')


### PR DESCRIPTION
Replaces `impportlib` with `importlib` in the warning message for `traitsui.__version__`.


**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)