### PR TITLE
TableEditor: initialise events with is_event=True

### DIFF
--- a/traitsui/qt/table_editor.py
+++ b/traitsui/qt/table_editor.py
@@ -282,8 +282,8 @@ class TableEditor(Editor, BaseTableEditor):
 
         # Set up the required externally synchronized traits
         is_list = mode in ("rows", "columns", "cells")
-        self.sync_value(factory.click, "click", "to")
-        self.sync_value(factory.dclick, "dclick", "to")
+        self.sync_value(factory.click, "click", "to", is_event=True)
+        self.sync_value(factory.dclick, "dclick", "to", is_event=True)
         self.sync_value(factory.columns_name, "columns", is_list=True)
         self.sync_value(factory.selected, "selected", is_list=is_list)
         self.sync_value(
@@ -291,7 +291,7 @@ class TableEditor(Editor, BaseTableEditor):
         )
         self.sync_value(factory.filter_name, "filter", "from")
         self.sync_value(factory.filtered_indices, "filtered_indices", "to")
-        self.sync_value(factory.update_filter_name, "update_filter", "from")
+        self.sync_value(factory.update_filter_name, "update_filter", "from", is_event=True)
 
         self.auto_size = self.factory.auto_size
 


### PR DESCRIPTION
**Checklist**
- Initialise Events in TableEditor with is_event=True in order to avoid the error below in "sync_value"

```Traceback (most recent call last):
  File "/Users/nino/Repos/traitsui/traitsui/editor.py", line 513, in raise_to_debug
    yield
  File "/Users/nino/Repos/traitsui/traitsui/editor.py", line 398, in sync_value
    editor_value = xgetattr(self, editor_name)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nino/micromamba/envs/more_pyside/lib/python3.11/site-packages/traits/trait_base.py", line 319, in xgetattr
    return getattr(object, names[-1])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: The dclick trait of a TableEditor instance is an 'event', which is write only.
```