### PR TITLE
Fix ArrayEditor support for Bool value

### DIFF
--- a/traitsui/editors/array_editor.py
+++ b/traitsui/editors/array_editor.py
@@ -72,6 +72,9 @@ class ArrayStructure(HasTraits):
         if object.dtype.kind == "i":
             trait = Int()
 
+        if object.dtype.kind == "b":
+            trait = Bool()
+
         if len(object.shape) == 1:
             self.view = self._one_dim_view(object, style, width, trait)
         elif len(object.shape) == 2:


### PR DESCRIPTION
**Checklist**
- [ ] For numpy arrays of type bool, ui is displayed as float value. With this PR, ui is shown as bool value.