### PR TITLE
Dark mode colors for wx

### DIFF
--- a/traitsui/wx/constants.py
+++ b/traitsui/wx/constants.py
@@ -20,37 +20,60 @@ from pyface.api import SystemMetrics
 
 #: Define platform and wx version constants:
 is_mac = sys.platform == "darwin"
+is_dark = wx.SystemSettings.GetAppearance().IsDark()
 
 #: Default dialog title
 DefaultTitle = "Edit properties"
 
 #: Color of valid input
-OKColor = wx.WHITE
+# Alternative: OKColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_INFOBK)
+if is_dark:
+    OKColor = wx.BLACK
+else:
+    OKColor = wx.WHITE
 
 #: Color to highlight input errors
-ErrorColor = wx.Colour(255, 192, 192)
+if is_dark:
+    ErrorColor = wx.Colour(0xcf, 0x66, 0x79)
+else:
+    ErrorColor = wx.Colour(255, 192, 192)
+
 
 #: Color for background of read-only fields
-ReadonlyColor = wx.Colour(244, 243, 238)
+if is_dark:
+    ReadonlyColor = wx.Colour(22, 22, 24)
+else:
+    ReadonlyColor = wx.Colour(244, 243, 238)
 
 #: Color for background of fields where objects can be dropped
-DropColor = wx.Colour(215, 242, 255)
+if is_dark:
+    DropColor = wx.Colour(94, 131, 167)
+else:
+    DropColor = wx.Colour(215, 242, 255)
 
 #: Color for an editable field
-EditableColor = wx.WHITE
+EditableColor = OKColor
 
 #: Color for background of windows (like dialog background color)
 if is_mac:
-    WindowColor = wx.Colour(232, 232, 232)
-    BorderedGroupColor = wx.Colour(224, 224, 224)
+    # Alternative: WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BACKGROUND)
+    if is_dark:
+        WindowColor = wx.Colour(72, 72, 72)
+        BorderedGroupColor = wx.Colour(64, 64, 64)
+    else:
+        WindowColor = wx.Colour(232, 232, 232)
+        BorderedGroupColor = wx.Colour(224, 224, 224)
 else:
     WindowColor = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR)
 
 #: Default colour for table foreground
-TableCellColor = wx.BLACK
+if is_dark:
+    TableCellColor = wx.WHITE
+else:
+    TableCellColor = wx.BLACK
 
 #: Default colour for table background
-TableCellBackgroundColor = wx.WHITE
+TableCellBackgroundColor = OKColor
 
 #: Default colour for table background
 TableReadOnlyBackgroundColor = ReadonlyColor
@@ -65,7 +88,11 @@ TableLabelBackgroundColor = WindowColor
 TableSelectionTextColor = TableCellColor
 
 #: Default background colour for table selection (light blue)
-TableSelectionBackgroundColor = wx.Colour(173, 216, 230)
+# Alternative: wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT)
+if is_dark:
+    TableSelectionBackgroundColor = wx.Colour(48, 78, 117)
+else:
+    TableSelectionBackgroundColor = wx.Colour(173, 216, 230)
 
 #: Standard width of an image bitmap
 standard_bitmap_width = 120


### PR DESCRIPTION
This adds dark mode colors for wx. Created in response to visibility issues described at https://github.com/python-microscopy/python-microscopy/issues/1331.

**Checklist**
- [ ] Add a news fragment if this PR is news-worthy for end users. (see docs/releases/README.rst)